### PR TITLE
security: supply chain hardening for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/validate-secrets.yml
+++ b/.github/workflows/validate-secrets.yml
@@ -73,7 +73,7 @@ jobs:
             ;;
           *)
             # Fallback: try twine with a real sdist from our project
-            pip install twine build > /dev/null 2>&1
+            pip install "twine==6.1.0" "build==1.2.2" > /dev/null 2>&1
             mkdir -p /tmp/pypi-test && cd /tmp/pypi-test
             echo '[project]' > pyproject.toml
             echo 'name = "_validate-token-test"' >> pyproject.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Stage 1: Build and bundle the TypeScript application
 ARG DISABLE_LANGUAGES=rust
 
-FROM node:20-slim AS builder
+FROM node:20-slim@sha256:f93745c153377ee2fbbdd6e24efcd03cd2e86d6ab1d8aa9916a3790c40313a55 AS builder
 ARG DISABLE_LANGUAGES
 ENV DEBUG_MCP_DISABLE_LANGUAGES=${DISABLE_LANGUAGES}
 
 # Install pnpm (using version 10 to match local development)
-RUN npm install -g pnpm@10
+RUN npm install -g pnpm@10.33.0
 
 # Set application directory
 WORKDIR /app
@@ -90,7 +90,7 @@ RUN rm -rf /app/node_modules/@debugmcp && \
     cp /app/packages/adapter-java/package.json /app/node_modules/@debugmcp/adapter-java/
 
 # Stage 2: Create runtime image with full LLDB dependencies
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b
 # Disable Go at runtime too — Delve isn't installed in the container
 ENV DEBUG_MCP_DISABLE_LANGUAGES=rust,go,dotnet
 
@@ -120,7 +120,7 @@ RUN apt-get update && \
       openjdk-21-jdk-headless && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip3 install --break-system-packages --no-cache-dir "debugpy>=1.8.14"
+    pip3 install --break-system-packages --no-cache-dir "debugpy==1.8.14"
 
 # Copy Node runtime from builder to avoid installing system-wide Node.js
 COPY --from=builder /usr/local/bin/node /usr/local/bin/node

--- a/docker/test-ubuntu.dockerfile
+++ b/docker/test-ubuntu.dockerfile
@@ -1,16 +1,24 @@
-FROM ubuntu:22.04
+FROM node:20-slim@sha256:f93745c153377ee2fbbdd6e24efcd03cd2e86d6ab1d8aa9916a3790c40313a55 AS node-base
 
-# Install Node.js and Python
+FROM ubuntu:22.04@sha256:eb29ed27b0821dca09c2e28b39135e185fc1302036427d5f4d70a41ce8fd7659
+
+# Copy Node.js from official image (avoids curl|bash install pattern)
+COPY --from=node-base /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-base /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node-base /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node-base /usr/local/bin/npx /usr/local/bin/npx
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+# Install Python and supporting tools
 RUN apt-get update && apt-get install -y \
-    curl \
     python3 \
     python3-pip \
     git \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install debugpy
-RUN pip3 install debugpy
+# Install debugpy (pinned version)
+RUN pip3 install "debugpy==1.8.14"
 
 # Set working directory
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -182,6 +182,11 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "overrides": {
+      "vite": "7.3.2",
+      "path-to-regexp": ">=8.4.0",
+      "brace-expansion": ">=5.0.5"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: 7.3.2
+  path-to-regexp: '>=8.4.0'
+  brace-expansion: '>=5.0.5'
+
 importers:
 
   .:
@@ -65,10 +70,10 @@ importers:
         version: 25.5.0
       '@vitest/coverage-istanbul':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)))
       c8:
         specifier: ^11.0.0
         version: 11.0.0
@@ -107,7 +112,7 @@ importers:
         version: 8.57.1(eslint@10.0.3)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
     optionalDependencies:
       '@debugmcp/adapter-dotnet':
         specifier: workspace:*
@@ -154,7 +159,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
   packages/adapter-go:
     dependencies:
@@ -176,7 +181,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
   packages/adapter-java:
     dependencies:
@@ -198,7 +203,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
   packages/adapter-javascript:
     dependencies:
@@ -214,7 +219,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)))
       eslint:
         specifier: ^10.0.3
         version: 10.0.3
@@ -232,7 +237,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
   packages/adapter-mock:
     dependencies:
@@ -251,7 +256,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
   packages/adapter-python:
     dependencies:
@@ -276,7 +281,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
   packages/adapter-rust:
     dependencies:
@@ -304,7 +309,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
   packages/mcp-debugger:
     devDependencies:
@@ -344,7 +349,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-istanbul':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)))
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -353,7 +358,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
 packages:
 
@@ -997,7 +1002,7 @@ packages:
     resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: 7.3.2
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1091,8 +1096,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.1:
@@ -1804,8 +1809,8 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2172,8 +2177,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2226,7 +2231,7 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: 7.3.2
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2872,7 +2877,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-istanbul@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)))':
+  '@vitest/coverage-istanbul@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)))':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -2884,11 +2889,11 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+      vitest: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -2900,7 +2905,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+      vitest: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -2911,13 +2916,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0))':
+  '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@25.5.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.2(@types/node@25.5.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -3016,7 +3021,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3621,7 +3626,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minipass@3.3.6:
     dependencies:
@@ -3709,7 +3714,7 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -3826,7 +3831,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4096,7 +4101,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.1(@types/node@25.5.0):
+  vite@7.3.2(@types/node@25.5.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4108,10 +4113,10 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
 
-  vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)):
+  vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0))
+      '@vitest/mocker': 4.1.0(vite@7.3.2(@types/node@25.5.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -4128,7 +4133,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.2(@types/node@25.5.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to commit SHAs across CI, release, and CodeQL workflows
- Pin Docker base images to SHA digests (node:20-slim, ubuntu:24.04, ubuntu:22.04)
- Replace `curl|bash` NodeSource install with multi-stage COPY from official Node image
- Pin all pip/npm dependencies to exact versions in Dockerfiles and workflows
- Add pnpm overrides to resolve 6 transitive vulnerabilities (vite, path-to-regexp, brace-expansion)
- Add Dependabot config, CodeQL analysis, OpenSSF Scorecard, and security policy
- Enable branch protection on main (PR reviews, status checks, admin enforcement)
- Add SECURITY.md, CODE_OF_CONDUCT.md, ARCHITECTURE.md, SUPPLY-CHAIN-SECURITY.md

## OpenSSF Scorecard impact

| Check | Before | Expected |
|---|---|---|
| Pinned-Dependencies | 5/10 | 8+ |
| Vulnerabilities | 4/10 | 10 |
| Branch-Protection | 3/10 | 8+ |
| Code-Review | 1/10 | 7+ |
| Security-Policy | 10/10 | 10 |
| **Overall** | **7/10** | **9+** |

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] All 1678 unit tests pass (116 test files)
- [ ] CI passes on GitHub
- [ ] Scorecard re-scan shows improved score

🤖 Generated with [Claude Code](https://claude.com/claude-code)