### PR TITLE
fix(adapter-go): auto-infer dlv mode from program file extension

### DIFF
--- a/packages/adapter-go/src/go-debug-adapter.ts
+++ b/packages/adapter-go/src/go-debug-adapter.ts
@@ -304,12 +304,25 @@ export class GoDebugAdapter extends EventEmitter implements IDebugAdapter {
   // ===== Debug Configuration =====
   
   async transformLaunchConfig(config: GenericLaunchConfig): Promise<GoLaunchConfig> {
+    // Inference rule: a .go source file means dlv should compile-and-run
+    // (mode 'debug'); anything else (a pre-built binary) means dlv should
+    // run it directly (mode 'exec'). dlv exits with no useful error when
+    // given a binary in 'debug' mode, so this auto-detection is required
+    // for usable UX. An explicit user-supplied mode always wins (e.g.
+    // 'test', 'replay', 'core').
+    const rawConfig = config as Record<string, unknown>;
+    const userMode = rawConfig.mode as GoLaunchConfig['mode'] | undefined;
+    const program = rawConfig.program;
+    const isGoSource = typeof program === 'string'
+      && program.toLowerCase().endsWith('.go');
+    const inferredMode: GoLaunchConfig['mode'] = isGoSource ? 'debug' : 'exec';
+    const mode = userMode ?? inferredMode;
+
     const goConfig: GoLaunchConfig = {
       ...config,
       type: 'go',
       request: 'launch',
-      // Preserve mode if specified (e.g., 'test'), otherwise default to 'debug'
-      mode: (config as Record<string, unknown>).mode as GoLaunchConfig['mode'] || 'debug',
+      mode,
       // Default stopOnEntry to false: Delve returns "unknown goroutine" when
       // stack traces are requested immediately after stopping on entry.
       stopOnEntry: config.stopOnEntry ?? false,

--- a/packages/adapter-go/tests/unit/transform-launch-config.test.ts
+++ b/packages/adapter-go/tests/unit/transform-launch-config.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GoDebugAdapter } from '../../src/index.js';
+import type { AdapterDependencies, GenericLaunchConfig } from '@debugmcp/shared';
+
+const deps = {
+  logger: {
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    warn: () => {}
+  }
+} as unknown as AdapterDependencies;
+
+describe('GoDebugAdapter.transformLaunchConfig — mode inference', () => {
+  let adapter: GoDebugAdapter;
+
+  beforeEach(() => {
+    adapter = new GoDebugAdapter(deps);
+  });
+
+  it('infers mode "debug" for a .go source file', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      program: '/proj/main.go'
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.mode).toBe('debug');
+    expect(cfg.type).toBe('go');
+    expect(cfg.request).toBe('launch');
+  });
+
+  it('infers mode "exec" for a Windows .exe binary', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      program: 'C:\\proj\\hello.exe'
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.mode).toBe('exec');
+  });
+
+  it('infers mode "exec" for a bare Linux binary path with no extension', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      program: '/tmp/myapp'
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.mode).toBe('exec');
+  });
+
+  it('treats uppercase .GO extension as source (case-insensitive)', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      program: 'C:\\proj\\HELLO.GO'
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.mode).toBe('debug');
+  });
+
+  it('preserves explicit mode "test" against a _test.go program', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      program: '/proj/foo_test.go',
+      mode: 'test'
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.mode).toBe('test');
+  });
+
+  it('preserves explicit mode "exec" even when program is .go (user override wins)', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      program: '/proj/main.go',
+      mode: 'exec'
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.mode).toBe('exec');
+  });
+
+  it('preserves explicit mode "replay" with no program', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      mode: 'replay'
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.mode).toBe('replay');
+  });
+
+  it('falls through to "exec" when program is undefined and no explicit mode is set', async () => {
+    const cfg = await adapter.transformLaunchConfig(
+      {} as unknown as GenericLaunchConfig
+    );
+
+    expect(cfg.mode).toBe('exec');
+  });
+
+  it('preserves the existing transform behavior alongside mode inference', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      program: '/proj/main.go',
+      cwd: '/proj',
+      args: ['--verbose'],
+      env: { FOO: 'bar' },
+      stopOnEntry: true
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.mode).toBe('debug');
+    expect(cfg.dlvCwd).toBe('/proj');
+    expect(cfg.args).toEqual(['--verbose']);
+    expect(cfg.env).toEqual({ FOO: 'bar' });
+    expect(cfg.stopOnEntry).toBe(true);
+    expect(cfg.stackTraceDepth).toBe(50);
+    expect(cfg.showGlobalVariables).toBe(false);
+    expect(cfg.hideSystemGoroutines).toBe(true);
+  });
+
+  it('defaults stopOnEntry to false when not provided', async () => {
+    const cfg = await adapter.transformLaunchConfig({
+      program: '/proj/main.go'
+    } as unknown as GenericLaunchConfig);
+
+    expect(cfg.stopOnEntry).toBe(false);
+  });
+});

--- a/tests/e2e/mcp-server-smoke-go.test.ts
+++ b/tests/e2e/mcp-server-smoke-go.test.ts
@@ -207,7 +207,10 @@ describe('MCP Server Go Debugging Smoke Test @requires-go', () => {
       const bpResponse = parseSdkToolResult(bpResult);
       console.log('[Go Smoke Test] Breakpoint response:', bpResponse);
 
-      // 3. Start debugging (exec mode for pre-compiled binary)
+      // 3. Start debugging — scriptPath is a pre-compiled binary, and the
+      // adapter must auto-infer mode 'exec' from the absence of a .go
+      // extension. Do NOT pass an explicit mode here; that's the property
+      // under test.
       console.log('[Go Smoke Test] Starting debugging...');
       const startResult = await mcpClient!.callTool({
         name: 'start_debugging',
@@ -216,7 +219,6 @@ describe('MCP Server Go Debugging Smoke Test @requires-go', () => {
           scriptPath: testBinary, // Pre-compiled binary
           args: [],
           dapLaunchArgs: {
-            mode: 'exec',
             stopOnEntry: false
           }
         }


### PR DESCRIPTION
## Summary

- Go adapter `transformLaunchConfig` no longer hardcodes `dlv` `mode: 'debug'`. It now infers `mode: 'debug'` for `.go` source files and `mode: 'exec'` for everything else (pre-built binaries on Windows/Linux/macOS), while still preserving any explicit user-supplied `mode` (so `'test' | 'replay' | 'core'` continue to work).
- Adds the first unit-test directory for the Go adapter (10 cases covering both inference branches, override precedence, case-insensitivity, defensive fallbacks, and preservation of existing transform defaults).
- Drops the now-unnecessary `mode: 'exec'` workaround from the Go E2E smoke test so it validates auto-detection end-to-end.

## Why

A `/testdebugger` sweep on 2026-04-28 surfaced that calling `start_debugging` with a pre-built Go binary instead of a `.go` source file crashed the proxy with `Code: 0, Signal: undefined`. Root cause: the adapter unconditionally fell back to `mode: 'debug'`, so `dlv` tried to compile the binary as Go source and exited silently.

`dlv`'s rule is simple: `.go` source → `mode: 'debug'` (compile-and-run); pre-built binary → `mode: 'exec'` (run directly). File extension answers the question cleanly — Go does not need anything like `packages/adapter-rust/src/utils/binary-detector.ts` (which exists for Rust because it must distinguish MSVC vs GNU PDB/DWARF formats).

Per the project's "core remains language-agnostic" principle, the fix is contained entirely inside the Go adapter package — no changes to `src/server.ts` or `src/session/`.

## Test plan

- [x] `npm run build` — succeeds.
- [x] `npm run lint` — clean, no new warnings.
- [x] `npm run test:unit` — 1708/1708 across 118 files. The new file shows up as `packages/adapter-go/tests/unit/transform-launch-config.test.ts (10 tests)`.
- [x] `npx vitest run tests/e2e/mcp-server-smoke-go.test.ts` against real `go 1.26.1` + `dlv 1.26.2` on Windows — 3/3 passing, including the previously-failing-without-workaround binary debug flow.
- [ ] Reviewer: re-run `/testdebugger` Go matrix and confirm the binary scenario, which previously crashed, now passes across all transports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)