### PR TITLE
fix: include netcoredbg-bridge-core.js in npm bundle and correct resolver path

### DIFF
--- a/packages/adapter-dotnet/src/DotnetDebugAdapter.ts
+++ b/packages/adapter-dotnet/src/DotnetDebugAdapter.ts
@@ -296,8 +296,8 @@ export class DotnetDebugAdapter extends EventEmitter implements IDebugAdapter {
     const possiblePaths = [
       // Development: running from compiled adapter package dist/
       path.resolve(__dirname, 'utils', 'netcoredbg-bridge.js'),
-      // Bundled NPX distribution (cli.mjs is in dist/, bridge copied alongside)
-      path.resolve(__dirname, '..', 'packages', 'adapter-dotnet', 'dist', 'utils', 'netcoredbg-bridge.js'),
+      // Bundled NPX distribution (cli.mjs is in dist/, bridge copied at dist/packages/adapter-dotnet/dist/utils/)
+      path.resolve(__dirname, 'packages', 'adapter-dotnet', 'dist', 'utils', 'netcoredbg-bridge.js'),
       // Monorepo source tree fallback
       path.resolve(__dirname, '..', '..', '..', '..', 'packages', 'adapter-dotnet', 'dist', 'utils', 'netcoredbg-bridge.js'),
       // CWD-relative fallback

--- a/packages/mcp-debugger/scripts/bundle-cli.js
+++ b/packages/mcp-debugger/scripts/bundle-cli.js
@@ -211,15 +211,24 @@ async function bundleCLI() {
     console.warn('Run: pnpm -w -F @debugmcp/adapter-rust run build:adapter');
   }
 
-  // Copy netcoredbg bridge script for .NET adapter
-  const bridgeSrc = path.join(repoRoot, 'packages/adapter-dotnet/dist/utils/netcoredbg-bridge.js');
-  if (fs.existsSync(bridgeSrc)) {
-    const bridgeDestDir = path.join(distDir, 'packages', 'adapter-dotnet', 'dist', 'utils');
-    fs.mkdirSync(bridgeDestDir, { recursive: true });
-    fs.cpSync(bridgeSrc, path.join(bridgeDestDir, 'netcoredbg-bridge.js'));
-    console.log('Copied netcoredbg bridge script.');
+  // Copy .NET adapter runtime utils. The bridge entry imports ./netcoredbg-bridge-core.js
+  // at runtime in the spawned child Node process, so the core file must be present on
+  // disk next to the entry — tsup only inlines into cli.mjs, not the spawned worker.
+  const dotnetUtilsSrc = path.join(repoRoot, 'packages/adapter-dotnet/dist/utils');
+  if (fs.existsSync(dotnetUtilsSrc)) {
+    const dotnetUtilsDest = path.join(distDir, 'packages', 'adapter-dotnet', 'dist', 'utils');
+    fs.mkdirSync(dotnetUtilsDest, { recursive: true });
+    fs.cpSync(dotnetUtilsSrc, dotnetUtilsDest, {
+      recursive: true,
+      filter: (src) => {
+        const stat = fs.statSync(src);
+        if (stat.isDirectory()) return true;
+        return src.endsWith('.js');
+      }
+    });
+    console.log('Copied .NET adapter runtime utils (netcoredbg bridge + core).');
   } else {
-    console.warn('Warning: netcoredbg-bridge.js not found; .NET debugging may fail in NPX distribution.');
+    console.warn('Warning: packages/adapter-dotnet/dist/utils/ not found; .NET debugging will fail in NPX distribution.');
   }
 
   // Mirror dist into the package/ directory used by npm pack artifacts.

--- a/packages/mcp-debugger/test-bundle.cjs
+++ b/packages/mcp-debugger/test-bundle.cjs
@@ -40,8 +40,12 @@ console.log('Bundle path:', bundlePath);
     console.log('\nChecking for required runtime assets:');
     const requiredAssets = [
       {
-        name: 'netcoredbg bridge (.NET)',
+        name: 'netcoredbg bridge entry (.NET)',
         path: 'packages/adapter-dotnet/dist/utils/netcoredbg-bridge.js'
+      },
+      {
+        name: 'netcoredbg bridge core (.NET)',
+        path: 'packages/adapter-dotnet/dist/utils/netcoredbg-bridge-core.js'
       },
       {
         name: 'proxy bundle',


### PR DESCRIPTION
## Summary

Fixes [#72](https://github.com/debugmcp/mcp-debugger/issues/72) — the .NET adapter was broken in published `@debugmcp/mcp-debugger@0.19.0` and `0.20.0`. `list_supported_languages` reported the adapter as `installed: true`, but `attach_to_process` failed.

Two layered bugs, plus the test gap that let this ship:

- **bundle-cli.js** copied `netcoredbg-bridge.js` by name but missed its runtime ESM peer `netcoredbg-bridge-core.js`. tsup inlines into `cli.mjs` only; the bridge runs as a separate Node child process, so the core file must exist on disk next to the entry. Switched to a recursive `.js` copy of `dist/utils/`, matching the convention already used for the js-debug and CodeLLDB vendor directories.
- **DotnetDebugAdapter.ts** bundled-NPX candidate path used a stray `..` that resolved *out* of `dist/`, but the bundle puts the bridge *inside* `dist/`. Dropped the `..` so the path matches the actual bundled layout.
- **test-bundle.cjs** previously asserted only the bridge entry was present; now also asserts `netcoredbg-bridge-core.js`, so a future broken publish fails the smoke test.

The reproduction described in #72 was confirmed locally on the pre-fix tarball (only `netcoredbg-bridge.js` shipped) and verified to be fully resolved on the post-fix tarball (all three util files present, resolver path matches the bundled location).

## Test plan

- [x] `pnpm --filter @debugmcp/mcp-debugger run build` produces a tarball containing both `netcoredbg-bridge.js` and `netcoredbg-bridge-core.js` under `package/dist/packages/adapter-dotnet/dist/utils/`
- [x] `npx vitest run packages/adapter-dotnet/tests/unit/dotnet-bridge-fallback.test.ts` — 3/3 pass
- [x] `npm test` — 2308/2309 pass locally (one unrelated Rust e2e failure caused by a local Windows toolchain DLL init issue; CI on `main` is green)
- [ ] CI on this PR runs cleanly across all OSes
- [ ] Optional: end-to-end smoke against the freshly-built tarball with a .NET target (`testpublished` skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)