### PR TITLE
fix: derive packed tarball name from package.json for stable alias

### DIFF
--- a/packages/mcp-debugger/scripts/bundle-cli.js
+++ b/packages/mcp-debugger/scripts/bundle-cli.js
@@ -243,18 +243,24 @@ async function bundleCLI() {
     });
     console.log('npm pack artifact refreshed in packages/mcp-debugger/package/.');
 
-    // Copy tarball to stable name for local npx testing
-    const tgzFiles = fs.readdirSync(path.join(packageRoot, 'package'))
-      .filter(f => f.endsWith('.tgz'));
-    if (tgzFiles.length > 0) {
-      // Note: lexicographic sort may misorder semver (e.g., 0.9.0 > 0.10.0).
-      // For robustness, derive from package.json version if precise ordering matters.
-      const latestTgz = tgzFiles.sort().pop();
+    // Copy tarball to stable alias for local npx testing. Derive the exact
+    // filename from package.json — avoids two hazards in readdir-based discovery:
+    // the alias itself can win the lexicographic sort over the real tarball
+    // ('m' > 'd'), and version-named files can sort out of order (0.9.0 > 0.10.0).
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8')
+    );
+    const tarballName = `${pkg.name.replace('@', '').replace('/', '-')}-${pkg.version}.tgz`;
+    const tarballPath = path.join(packageRoot, 'package', tarballName);
+
+    if (fs.existsSync(tarballPath)) {
       fs.copyFileSync(
-        path.join(packageRoot, 'package', latestTgz),
+        tarballPath,
         path.join(packageRoot, 'package', 'mcp-debugger-latest.tgz')
       );
-      console.log(`Copied ${latestTgz} → mcp-debugger-latest.tgz`);
+      console.log(`Copied ${tarballName} → mcp-debugger-latest.tgz`);
+    } else {
+      console.warn(`Warning: expected tarball ${tarballName} not found; mcp-debugger-latest.tgz not refreshed.`);
     }
   } finally {
     execSync(`node "${preparePackScript}" restore`, {


### PR DESCRIPTION
## Summary

Fixes [#78](https://github.com/debugmcp/mcp-debugger/issues/78) — the `mcp-debugger-latest.tgz` alias became stale after its first creation and never refreshed.

The bundle script enumerated `*.tgz` in the package directory, sorted lexicographically, and `pop()`-ed the last entry as "latest". Because `'m' > 'd'`, `mcp-debugger-latest.tgz` always won that sort over `debugmcp-mcp-debugger-<version>.tgz`, so the script copied the alias onto itself. I hit this while verifying #72: the freshly-built version-named tarball was minutes old, but the alias was 7 weeks old and silently exercising a pre-fix build.

Fix: derive the expected filename from `package.json` (name + version) instead of discovering it via `readdirSync`. Also closes the existing inline TODO about lexicographic semver misordering (0.9.0 > 0.10.0) — there is no sort anymore.

## Test plan

- [x] Pre-seeded `mcp-debugger-latest.tgz` with 13 bytes of garbage, ran `pnpm --filter @debugmcp/mcp-debugger run build`, confirmed the alias was overwritten with byte-identical content to the fresh versioned tarball (`cmp` returned 0).
- [x] Bundle log shows the correct source filename: `Copied debugmcp-mcp-debugger-0.20.0.tgz → mcp-debugger-latest.tgz` (previously the log would have shown `mcp-debugger-latest.tgz → mcp-debugger-latest.tgz`).
- [x] Cross-platform: change is pure Node (`fs.readFileSync`/`JSON.parse`/`path.join`/`fs.existsSync`/`fs.copyFileSync`/`String.replace`) with identical behavior on Windows / macOS / Linux. pnpm pack's `<scope>-<name>-<version>.tgz` naming is platform-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)