### PR TITLE
chore: prepare v0.21.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       ref:
         description: 'Git ref (tag or branch) to release from'
         required: true
-        default: 'refs/tags/v0.20.0'
+        default: 'refs/tags/v0.21.0'
 
 permissions: {}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-05-30
+
 ### Changed
 - **Minimum Node.js raised to 22.** All packages now declare `engines.node >=22.0.0`, and the Docker image builds on `node:22-slim`. Node 18 and 20 are no longer supported (Node 20 reached end-of-life April 2026).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-debugger-monorepo",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Run-time step-through debugging for LLM agents - Monorepo root",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/adapter-dotnet/package.json
+++ b/packages/adapter-dotnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-dotnet",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": ".NET/C# debug adapter for MCP debugger using netcoredbg",
   "type": "module",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.20.0"
+    "@debugmcp/shared": "0.21.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-go/package.json
+++ b/packages/adapter-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-go",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Go debugging adapter for mcp-debugger using Delve",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-java/package.json
+++ b/packages/adapter-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-java",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Java debug adapter for MCP Debugger using JDI bridge",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-javascript/package.json
+++ b/packages/adapter-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-javascript",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "JavaScript/TypeScript debug adapter for MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -34,7 +34,7 @@
     "@vscode/debugprotocol": "^1.68.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.20.0"
+    "@debugmcp/shared": "0.21.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-mock",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Mock debug adapter for testing MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.20.0"
+    "@debugmcp/shared": "0.21.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-python/package.json
+++ b/packages/adapter-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-python",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Python debug adapter for MCP debugger using debugpy",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.20.0"
+    "@debugmcp/shared": "0.21.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-rust",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Rust debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-debugger/package.json
+++ b/packages/mcp-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/mcp-debugger",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Step-through debugging MCP server for LLMs",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/shared",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Shared interfaces, types, and utilities for MCP Debugger",
   "homepage": "https://github.com/debugmcp/mcp-debugger/tree/main/packages/shared",
   "repository": {


### PR DESCRIPTION
## Summary

Prepares the **v0.21.0** release. Version-only changes — no functional code.

- Bumps all 10 workspace packages `0.20.0` → `0.21.0` (and the `@debugmcp/shared` peerDependency pin in the python/dotnet/javascript/mock adapters).
- Datestamps the CHANGELOG `[Unreleased]` section as `[0.21.0] - 2026-05-30`.
- Points the `release.yml` workflow_dispatch default ref at `v0.21.0`.

## What's in 0.21.0

- **Minimum Node.js raised to 22**; `which` 6 → 7 (#85)
- Merged Dependabot batch: codeql-action, codecov-action, docker setup-buildx/login, pnpm/action-setup, and the npm minor/patch group (vitest, eslint, @types/node, lru-cache, typescript-eslint)
- Earlier fixes already on main since 0.20.0 (stable tarball alias #78, .NET bundle path #72)

## Verification

`scripts/release-dry-run.sh` passes (the only non-green items are the expected "uncommitted/not-on-main" prep-state notes). Publishing credentials re-validated post token-rotation: **npm ✓, Docker Hub ✓, PyPI ✓**.

## After merge

Tag `v0.21.0` on the merge commit and push it to trigger `release.yml` (npm + Docker + PyPI + GitHub release).
