### PR TITLE
feat: add ruby adapter, python handoff, and stewardship docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,14 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
+    - name: Setup Ruby 3.3
+      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      with:
+        ruby-version: '3.3'
+
+    - name: Install Ruby debug gem
+      run: gem install debug --no-document
+
     - name: Install Node dependencies
       run: pnpm install --frozen-lockfile
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,6 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
-    - name: Setup Ruby 3.3
-      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
-      with:
-        ruby-version: '3.3'
-
-    - name: Install Ruby debug gem
-      run: gem install debug --no-document
-
     - name: Install Node dependencies
       run: pnpm install --frozen-lockfile
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,6 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
-    - name: Setup Ruby 3.3
-      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
-      with:
-        ruby-version: '3.3'
-
-    - name: Install Ruby debug gem
-      run: gem install debug --no-document
-
     - name: Sanity versions
       run: |
         node -v
@@ -257,14 +249,6 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '21'
-
-    - name: Setup Ruby 3.3
-      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
-      with:
-        ruby-version: '3.3'
-
-    - name: Install Ruby debug gem
-      run: gem install debug --no-document
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,14 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
+    - name: Setup Ruby 3.3
+      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      with:
+        ruby-version: '3.3'
+
+    - name: Install Ruby debug gem
+      run: gem install debug --no-document
+
     - name: Sanity versions
       run: |
         node -v
@@ -250,6 +258,14 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
+    - name: Setup Ruby 3.3
+      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      with:
+        ruby-version: '3.3'
+
+    - name: Install Ruby debug gem
+      run: gem install debug --no-document
+
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
 
@@ -276,6 +292,7 @@ jobs:
         node -e 'console.log("SHARED_VERSION="+require("./packages/shared/package.json").version)' >> $GITHUB_ENV
         node -e 'console.log("ADAPTER_MOCK_VERSION="+require("./packages/adapter-mock/package.json").version)' >> $GITHUB_ENV
         node -e 'console.log("ADAPTER_PYTHON_VERSION="+require("./packages/adapter-python/package.json").version)' >> $GITHUB_ENV
+        node -e 'console.log("ADAPTER_RUBY_VERSION="+require("./packages/adapter-ruby/package.json").version)' >> $GITHUB_ENV
         node -e 'console.log("CLI_VERSION="+require("./packages/mcp-debugger/package.json").version)' >> $GITHUB_ENV
     - name: Set npm dist-tag
       run: |
@@ -295,6 +312,7 @@ jobs:
         npm pack --dry-run -w @debugmcp/shared
         npm pack --dry-run -w @debugmcp/adapter-mock
         npm pack --dry-run -w @debugmcp/adapter-python
+        npm pack --dry-run -w @debugmcp/adapter-ruby
         npm pack --dry-run -w @debugmcp/mcp-debugger
     
     - name: Publish to npm (workspaces)
@@ -320,6 +338,12 @@ jobs:
           echo "@debugmcp/adapter-python@${ADAPTER_PYTHON_VERSION} already exists, skipping"
         else
           npm publish -w @debugmcp/adapter-python --access public --provenance
+        fi
+
+        if npm view @debugmcp/adapter-ruby@${ADAPTER_RUBY_VERSION} version >/dev/null 2>&1; then
+          echo "@debugmcp/adapter-ruby@${ADAPTER_RUBY_VERSION} already exists, skipping"
+        else
+          npm publish -w @debugmcp/adapter-ruby --access public --provenance
         fi
 
         if npm view @debugmcp/mcp-debugger@${CLI_VERSION} version >/dev/null 2>&1; then
@@ -399,6 +423,7 @@ jobs:
         **Optional adapters:**
         ```bash
         npm install -g @debugmcp/adapter-python
+        npm install -g @debugmcp/adapter-ruby
         npm install -g @debugmcp/adapter-mock
         ```
         

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ npm run build
 
 # Build specific packages
 npm run build:shared
-npm run build:adapters       # Build mock + python adapters
+npm run build:adapters       # Build mock + python + ruby adapters
 npm run build:adapters:all   # Build all adapters including JavaScript
 npm run build:packages       # Build all packages in correct order via build-packages.cjs
 

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Public ownership signals for this repository are documented in [Project Stewards
 
 ## 👥 Contributors
 
+- [@Poyraxx](https://github.com/Poyraxx) (Poyrax) — Ruby adapter (rdbg)
 - [@swinyx](https://github.com/swinyx) (Swinyx) — Go adapter (Delve)
 - [@roofpig95008](https://github.com/roofpig95008) (Richard Berlin) — Java adapter (JDI bridge)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="assets/logo.png" alt="MCP Debugger Logo - A stylized circuit board with debug breakpoints" width="400" height="400">
 </div>
 
-**A headless, agentic debugger over MCP — let your AI agents debug running programs in six languages.**
+**A headless, agentic debugger over MCP — let your AI agents debug running programs in seven languages.**
 
 [![CI](https://github.com/debugmcp/mcp-debugger/actions/workflows/ci.yml/badge.svg)](https://github.com/debugmcp/mcp-debugger/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/debugmcp/mcp-debugger/branch/main/graph/badge.svg)](https://codecov.io/gh/debugmcp/mcp-debugger)
@@ -15,7 +15,7 @@
 
 ## 🎯 Overview
 
-mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through debugging as structured tool calls. It lets AI agents set breakpoints, inspect variables, evaluate expressions, and step through running programs across six languages — driving real language debuggers through the Debug Adapter Protocol (DAP).
+mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through debugging as structured tool calls. It lets AI agents set breakpoints, inspect variables, evaluate expressions, and step through running programs across seven languages — driving real language debuggers through the Debug Adapter Protocol (DAP).
 
 > 🆕 **v0.21.0** — the minimum runtime is now **Node.js 22+** (Node 20 reached end-of-life). See the [CHANGELOG](./CHANGELOG.md) for the full release history.
 
@@ -23,13 +23,14 @@ mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through 
 
 - 🌐 **Multi-language support** – Clean adapter pattern for any language
 - 🐍 **Python debugging via debugpy** – Full DAP protocol support
+- 💎 **Ruby debugging via rdbg** – Launch and attach workflows for Ruby and Rails projects
 - 🟨 **JavaScript (Node.js) debugging via js-debug** – VSCode's proven debugger
 - 🦀 **Rust debugging via CodeLLDB** – Debug Rust & Cargo projects (Linux/macOS; Windows needs the GNU toolchain — see [Rust on Windows](docs/rust-debugging-windows.md))
 - 🐹 **Go debugging via Delve** – Full DAP support for Go programs
 - ☕ **Java debugging via JDI bridge** – Launch and attach modes with JDK 21+
 - 🔷 **.NET/C# debugging via netcoredbg** – Debug .NET applications with full DAP support
 - 🧪 **Mock adapter for testing** – Test without external dependencies
-- 🛰️ **Out-of-IDE & remote attach** – Attach over host/port to a process on another machine or inside a container (Python via debugpy, Java via JDWP), with source-path mapping
+- 🛰️ **Out-of-IDE & remote attach** – Attach over host/port to a process on another machine or inside a container (Python via debugpy, Ruby via rdbg, Java via JDWP), with source-path mapping
 - 🔌 **STDIO and Streamable HTTP transports** – Works with any MCP client (legacy SSE transport is deprecated)
 - 📦 **Zero-runtime dependencies** – Self-contained bundles via esbuild + tsup
 - ⚡ **npx ready** – Run directly with `npx @debugmcp/mcp-debugger` - no installation needed
@@ -41,7 +42,7 @@ mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through 
 
 ## 🚀 Quick Start
 
-> **Requirements:** Node.js 22+ for the server. Each language you debug also needs its own toolchain installed (Python + debugpy, Node.js, Go + Delve, JDK 21+, .NET SDK, or the Rust toolchain).
+> **Requirements:** Node.js 22+ for the server. Each language you debug also needs its own toolchain installed (Python + debugpy, Ruby + the `debug` gem / `rdbg`, Node.js, Go + Delve, JDK 21+, .NET SDK, or the Rust toolchain).
 
 ### For MCP Clients (Claude Desktop, etc.)
 
@@ -108,7 +109,7 @@ mcp-debugger exposes debugging operations as MCP tools that can be called with s
 // Tool: create_debug_session
 // Request:
 {
-  "language": "python",  // or "javascript", "rust", "go", "java", "dotnet", or "mock" for testing
+  "language": "python",  // or "ruby", "javascript", "rust", "go", "java", "dotnet", or "mock" for testing
   "name": "My Debug Session"
 }
 // Response:
@@ -168,6 +169,8 @@ Version 0.10.0 introduces a clean adapter pattern that separates language-agnost
         │Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   │
         └──────────┘└──────────┘└──────────┘└──────────┘└──────────┘└──────────┘└──────���───┘
 ```
+
+Current built-in language adapters are Python, Ruby, JavaScript, Rust, Go, Java, and .NET, plus a mock adapter for testing.
 
 ### Adding Language Support
 
@@ -307,9 +310,11 @@ Then get the local variables:
 - 🧩 [Adapter API Reference](./docs/architecture/adapter-api-reference.md) – Adapter, factory, loader, and registry contracts
 - 🔄 [Migration Guide](./docs/migration-guide.md) – Upgrading to v0.15.0 (dynamic loading)
 - 🐍 [Python Debugging Guide](./docs/python/README.md) – Python-specific features
+- 💎 [Ruby Debugging Guide](./docs/ruby/README.md) – Ruby debugging with `rdbg`
 - 🟨 [JavaScript Debugging Guide](./docs/javascript/README.md) – JavaScript/TypeScript features
 - 🐹 [Go Debugging Guide](./docs/go/README.md) – Go debugging with Delve
 - ☕ [Java Debugging Guide](./docs/java/README.md) – Java debugging with JDI bridge
+- 🧭 [Project Stewardship](./docs/project-stewardship.md) – Public ownership and maintainer signals
 - [Rust Debugging on Windows](docs/rust-debugging-windows.md) - Toolchain requirements and troubleshooting
 - 🔧 [Troubleshooting](./docs/troubleshooting.md) – Common issues & solutions
 
@@ -377,9 +382,9 @@ See [tests/README.md](./tests/README.md) for detailed testing instructions.
 
 ## 📊 Project Status
 
-- ✅ **Production Ready**: v0.21.0 with six language adapters and polished multi-language distribution
+- ✅ **Production Ready**: v0.21.0 with seven language adapters and polished multi-language distribution
 - ✅ **Clean architecture** with a dynamic adapter pattern
-- ✅ **Python · JavaScript/TypeScript · Go · Java · .NET/C#**: Full step-through debugging
+- ✅ **Python · Ruby · JavaScript/TypeScript · Go · Java · .NET/C#**: Full step-through debugging
 - 🦀 **Rust**: Full support on Linux/macOS/Windows (Windows requires the GNU toolchain; MSVC is not supported by CodeLLDB)
 - 🟢 **Runtime**: Node.js 22+
 - 📈 **Active Development**: Regular updates and improvements
@@ -388,10 +393,14 @@ See [tests/README.md](./tests/README.md) for detailed testing instructions.
 
 MIT License - see [LICENSE](./LICENSE) for details.
 
+## 🧭 Project Stewardship
+
+Public ownership signals for this repository are documented in [Project Stewardship](./docs/project-stewardship.md), including the GitHub organization, CODEOWNERS coverage, maintainer contact, and the currently public human contributors called out in the repo.
+
 ## 👥 Contributors
 
-- [@swinyx](https://github.com/swinyx) — Go adapter (Delve)
-- [@roofpig95008](https://github.com/roofpig95008) — Java adapter (JDI bridge)
+- [@swinyx](https://github.com/swinyx) (Swinyx) — Go adapter (Delve)
+- [@roofpig95008](https://github.com/roofpig95008) (Richard Berlin) — Java adapter (JDI bridge)
 
 ## 🙏 Acknowledgments
 
@@ -399,6 +408,7 @@ Built with:
 - [Model Context Protocol](https://github.com/anthropics/model-context-protocol) by Anthropic
 - [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) by Microsoft
 - [debugpy](https://github.com/microsoft/debugpy) for Python debugging
+- [debug](https://github.com/ruby/debug) for Ruby debugging
 
 ---
 

--- a/docs/agent-debugging-guide.md
+++ b/docs/agent-debugging-guide.md
@@ -1,6 +1,6 @@
 # MCP Debugger Usage Guide for AI Agents
 
-This guide explains how to correctly use the MCP Debugger tools when testing debugging functionality across all supported languages (Python, JavaScript, Rust, Go, Java, .NET/C#).
+This guide explains how to correctly use the MCP Debugger tools when testing debugging functionality across all supported languages (Python, Ruby, JavaScript, Rust, Go, Java, and .NET/C#).
 
 ## Key Concepts
 
@@ -208,6 +208,25 @@ frame_id = stack["stackFrames"][0]["id"]
 get_local_variables(sessionId=session_id)
 ```
 
+## Ruby Debugging
+
+**Prerequisites**: Ruby 2.7+ installed. `rdbg` must be available through the standard `debug` gem.
+
+**Testing sequence:**
+```python
+# 1. Create session
+session_id = create_debug_session(language="ruby")
+
+# 2. Set breakpoint
+set_breakpoint(sessionId=session_id, file="/path/to/app.rb", line=12)
+
+# 3. Start debugging
+start_debugging(sessionId=session_id, scriptPath="/path/to/app.rb")
+
+# 4. Inspect variables
+get_local_variables(sessionId=session_id)
+```
+
 ## Go Debugging
 
 **Prerequisites**: Go 1.18+ installed. Delve debugger must be installed: `go install github.com/go-delve/delve/cmd/dlv@latest`.
@@ -284,9 +303,10 @@ get_local_variables(sessionId=session_id)
 
 ## Summary
 
-The MCP Debugger is fully functional for Python, JavaScript, Rust, Go, Java, and .NET/C#. The key insights are:
+The MCP Debugger is fully functional for Python, Ruby, JavaScript, Rust, Go, Java, and .NET/C#. The key insights are:
 - **JavaScript**: Stack trace filtering hides internal frames; may need `continue_execution` if initially stopped at internals
 - **Python**: Use variablesReference to expand variable containers
+- **Ruby**: Supports launch and attach flows through `rdbg`; use Bundler mode for Rails and RSpec-style entrypoints
 - **Rust**: CodeLLDB adapter is vendored; the GNU toolchain is required for reliable debugging -- MSVC-built binaries may produce errors with CodeLLDB. Set `RUST_MSVC_BEHAVIOR` env var to control MSVC handling
 - **Go**: Uses Delve's native DAP support
 - **Java**: Use FQCN for breakpoints, pass `mainClass`/`classpath` via `dapLaunchArgs`

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -49,6 +49,7 @@ Each supported language implements the IDebugAdapter interface:
 
 - **[MockDebugAdapter](../../packages/adapter-mock/)** - Reference implementation for testing
 - **[PythonDebugAdapter](../../packages/adapter-python/)** - Python/debugpy support
+- **[RubyDebugAdapter](../../packages/adapter-ruby/)** - Ruby/rdbg support
 - **[JavascriptDebugAdapter](../../packages/adapter-javascript/)** - JavaScript/Node.js support
 - **[RustDebugAdapter](../../packages/adapter-rust/)** - Rust/CodeLLDB support
 - **[GoDebugAdapter](../../packages/adapter-go/)** - Go/Delve support
@@ -261,6 +262,7 @@ async endSession(exitCode: number) {
 
 ## Version History
 
+- **v0.21.0** - Ruby adapter, 8 adapters total
 - **v0.19.0** - .NET/C# adapter, 7 language adapters total
 - **v0.18.0** - Go adapter, Java adapter
 - **v0.17.0** - Rust adapter

--- a/docs/architecture/adapter-pattern-design.md
+++ b/docs/architecture/adapter-pattern-design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Debug Adapter Pattern powers mcp-debugger as a multi-language debugging platform supporting 7 languages (Python, JavaScript, Rust, Go, Java, .NET/C#, and Mock). This design uses a **dual-pattern architecture** that combines two complementary adapter patterns:
+The Debug Adapter Pattern powers mcp-debugger as a multi-language debugging platform supporting 7 programming languages plus a mock adapter (Python, Ruby, JavaScript, Rust, Go, Java, and .NET/C#). This design uses a **dual-pattern architecture** that combines two complementary adapter patterns:
 
 1. **IDebugAdapter Interface**: Complete adapter implementations for full language support
 2. **AdapterPolicy Interface**: Lightweight policies for language-specific session management behaviors
@@ -87,6 +87,7 @@ graph TD
     
     subgraph "Language Adapters"
         PA[PythonAdapter]
+        RBA[RubyAdapter]
         NA[JavascriptAdapter]
         RA[RustAdapter]
         GA[GoAdapter]
@@ -96,6 +97,7 @@ graph TD
     end
 
     AR --> PA
+    AR --> RBA
     AR --> NA
     AR --> RA
     AR --> GA

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Debug MCP Server
 
-This guide will walk you through testing the Debug MCP Server locally with a simple Python example. The server also supports JavaScript, Rust, Go, Java, and .NET/C# debugging -- see the language-specific guides for details.
+This guide will walk you through testing the Debug MCP Server locally with a simple Python example. The server also supports Ruby, JavaScript, Rust, Go, Java, and .NET/C# debugging -- see the language-specific guides for details.
 
 ## Prerequisites
 

--- a/docs/project-stewardship.md
+++ b/docs/project-stewardship.md
@@ -15,6 +15,7 @@ This document summarizes the public ownership and maintainer signals for `debugm
 
 These are the human contributors currently named in the repository README:
 
+- [Poyrax](https://github.com/Poyraxx) — Ruby adapter (rdbg)
 - [Swinyx](https://github.com/swinyx) — Go adapter (Delve)
 - [Richard Berlin](https://github.com/roofpig95008) — Java adapter (JDI bridge)
 

--- a/docs/project-stewardship.md
+++ b/docs/project-stewardship.md
@@ -1,0 +1,31 @@
+# Project Stewardship
+
+This document summarizes the public ownership and maintainer signals for `debugmcp/mcp-debugger` as of June 1, 2026.
+
+## Public ownership signals
+
+- The repository is hosted under the public GitHub organization [`debugmcp`](https://github.com/debugmcp).
+- The `debugmcp` organization currently shows no public members on its GitHub organization page.
+- Repository review ownership is routed through `@debugmcp` in [`CODEOWNERS`](../CODEOWNERS).
+- Package metadata in the repository lists `debugmcp <debug@sycamore.llc>` as the maintainer contact in the root [`package.json`](../package.json) and [`packages/shared/package.json`](../packages/shared/package.json).
+- Published npm package: [`@debugmcp/mcp-debugger`](https://www.npmjs.com/package/@debugmcp/mcp-debugger)
+- Published Docker image: [`debugmcp/mcp-debugger`](https://hub.docker.com/r/debugmcp/mcp-debugger)
+
+## Publicly identified human contributors
+
+These are the human contributors currently named in the repository README:
+
+- [Swinyx](https://github.com/swinyx) — Go adapter (Delve)
+- [Richard Berlin](https://github.com/roofpig95008) — Java adapter (JDI bridge)
+
+## What is not publicly stated today
+
+- The repository does not currently publish a full maintainer roster with named humans.
+- The `debugmcp` GitHub organization does not expose public member identities.
+- No separate governance file currently names an owning company beyond the maintainer contact metadata above.
+
+## Contact and update path
+
+- For repository questions or proposals, open an issue in [`debugmcp/mcp-debugger`](https://github.com/debugmcp/mcp-debugger/issues).
+- For package-maintainer contact, use `debug@sycamore.llc` as listed in the repository metadata.
+- If additional maintainers want to be publicly listed, this file and the main README should be updated together.

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -1,24 +1,23 @@
-# Python Debugging with Debug MCP Server
+# Python Debugging with mcp-debugger
 
-The Debug MCP Server provides support for Python debugging through the [debugpy](https://github.com/microsoft/debugpy) library. This document explains how to use the Python debugging capabilities.
+mcp-debugger supports Python debugging through [debugpy](https://github.com/microsoft/debugpy). You can either launch Python directly from MCP or attach MCP to an already-running `debugpy` endpoint for a VS Code handoff.
 
 ## Prerequisites
 
-Before using the Python debugging features, ensure you have:
+Before using the Python adapter, ensure you have:
 
 1. Python 3.7 or higher installed
-2. The debugpy package installed:
-   ```bash
-   pip install debugpy
-   ```
+2. `debugpy` installed in the Python environment you want to debug
 
-## Debugging Workflow
-
-### 1. Create a Debug Session
-
-First, create a Python debug session:
-
+```bash
+pip install debugpy
 ```
+
+## Launch a Python program from MCP
+
+### 1. Create a session
+
+```text
 use_mcp_tool(
   tool_name="create_debug_session",
   arguments={
@@ -28,13 +27,9 @@ use_mcp_tool(
 )
 ```
 
-This returns a session ID that you'll use for all subsequent debugging commands.
+### 2. Set breakpoints
 
-### 2. Set Breakpoints
-
-Set breakpoints in your code before starting execution:
-
-```
+```text
 use_mcp_tool(
   tool_name="set_breakpoint",
   arguments={
@@ -47,7 +42,7 @@ use_mcp_tool(
 
 You can also set conditional breakpoints:
 
-```
+```text
 use_mcp_tool(
   tool_name="set_breakpoint",
   arguments={
@@ -59,11 +54,9 @@ use_mcp_tool(
 )
 ```
 
-### 3. Start Debugging
+### 3. Start debugging
 
-Start debugging your Python script:
-
-```
+```text
 use_mcp_tool(
   tool_name="start_debugging",
   arguments={
@@ -74,104 +67,27 @@ use_mcp_tool(
 )
 ```
 
-### 4. Control Execution
+### 4. Control execution
 
-When execution pauses at a breakpoint, you can:
-
-#### Step Over (execute current line and pause at next line)
-```
-use_mcp_tool(
-  tool_name="step_over",
-  arguments={
-    "sessionId": "your-session-id"
-  }
-)
+```text
+use_mcp_tool(tool_name="step_over", arguments={ "sessionId": "your-session-id" })
+use_mcp_tool(tool_name="step_into", arguments={ "sessionId": "your-session-id" })
+use_mcp_tool(tool_name="step_out", arguments={ "sessionId": "your-session-id" })
+use_mcp_tool(tool_name="continue_execution", arguments={ "sessionId": "your-session-id" })
+use_mcp_tool(tool_name="pause_execution", arguments={ "sessionId": "your-session-id" })
 ```
 
-#### Step Into (go into functions called on current line)
-```
-use_mcp_tool(
-  tool_name="step_into",
-  arguments={
-    "sessionId": "your-session-id"
-  }
-)
-```
+### 5. Inspect state
 
-#### Step Out (run until exiting current function)
-```
-use_mcp_tool(
-  tool_name="step_out",
-  arguments={
-    "sessionId": "your-session-id"
-  }
-)
-```
+When paused, the most direct inspection flow is:
 
-#### Continue (run until next breakpoint)
-```
-use_mcp_tool(
-  tool_name="continue_execution",
-  arguments={
-    "sessionId": "your-session-id"
-  }
-)
-```
+1. `get_stack_trace`
+2. `get_scopes`
+3. `get_variables`
 
-#### Pause (pause a running program)
-```
-use_mcp_tool(
-  tool_name="pause_execution",
-  arguments={
-    "sessionId": "your-session-id"
-  }
-)
-```
+For a shortcut, use `get_local_variables`:
 
-### 5. Examine Program State
-
-When paused, you can examine the program's state using the `get_stack_trace` -> `get_scopes` -> `get_variables` sequence. Each step returns numeric handles that feed into the next:
-
-#### Step 1: Get the Stack Trace
-```
-use_mcp_tool(
-  tool_name="get_stack_trace",
-  arguments={
-    "sessionId": "your-session-id"
-  }
-)
-```
-This returns stack frames, each with a numeric `id` (the frame ID).
-
-#### Step 2: Get Scopes for a Frame
-Use the `id` from the top stack frame:
-```
-use_mcp_tool(
-  tool_name="get_scopes",
-  arguments={
-    "sessionId": "your-session-id",
-    "frameId": 3
-  }
-)
-```
-This returns scopes (e.g., "Locals", "Globals"), each with a numeric `variablesReference`.
-
-#### Step 3: Get Variables for a Scope
-Use the `variablesReference` from a scope (not the frame ID):
-```
-use_mcp_tool(
-  tool_name="get_variables",
-  arguments={
-    "sessionId": "your-session-id",
-    "scope": 5
-  }
-)
-```
-The `scope` parameter is the numeric `variablesReference` from `get_scopes`.
-
-#### Shortcut: Get Local Variables
-For convenience, `get_local_variables` performs the full stack->scopes->variables traversal in a single call:
-```
+```text
 use_mcp_tool(
   tool_name="get_local_variables",
   arguments={
@@ -180,8 +96,9 @@ use_mcp_tool(
 )
 ```
 
-#### Evaluate Expressions
-```
+Evaluate expressions in the current frame:
+
+```text
 use_mcp_tool(
   tool_name="evaluate_expression",
   arguments={
@@ -191,18 +108,9 @@ use_mcp_tool(
 )
 ```
 
-#### View Stack Trace
-```
-use_mcp_tool(
-  tool_name="get_stack_trace",
-  arguments={
-    "sessionId": "your-session-id"
-  }
-)
-```
+Get source context around the current line:
 
-#### Get Source Context
-```
+```text
 use_mcp_tool(
   tool_name="get_source_context",
   arguments={
@@ -214,11 +122,9 @@ use_mcp_tool(
 )
 ```
 
-### 6. Close the Session
+### 6. Close the session
 
-When finished debugging, close the session:
-
-```
+```text
 use_mcp_tool(
   tool_name="close_debug_session",
   arguments={
@@ -227,10 +133,88 @@ use_mcp_tool(
 )
 ```
 
-## Debugging Tips
+## VS Code handoff with `attach_to_process`
 
-1. Always check if breakpoints are verified (some lines cannot have breakpoints, like blank lines)
-2. If the debugger doesn't stop at a breakpoint, ensure the file path is correct and absolute
-3. Use source context to see code around your current position
-4. The stack trace shows the call hierarchy that led to the current position
-5. Expressions are evaluated against the current paused debug context (current frame when available), with the evaluation context defaulting to `'variables'`
+Issue #7 asked for a practical way to move from MCP-driven debugging into VS Code. The supported workflow is a handoff through a shared `debugpy` endpoint:
+
+1. Start the target under `debugpy`
+2. Attach `mcp-debugger` to that port
+3. Detach MCP when you are ready
+4. Attach VS Code to the same host and port
+
+### 1. Start the target with `debugpy`
+
+```bash
+python -m debugpy --listen 127.0.0.1:5678 --wait-for-client app.py
+```
+
+### 2. Attach MCP
+
+```text
+use_mcp_tool(
+  tool_name="create_debug_session",
+  arguments={
+    "language": "python",
+    "name": "Python Attach Session"
+  }
+)
+```
+
+```text
+use_mcp_tool(
+  tool_name="attach_to_process",
+  arguments={
+    "sessionId": "your-session-id",
+    "host": "127.0.0.1",
+    "port": 5678,
+    "sourcePaths": ["/path/to/your/workspace"]
+  }
+)
+```
+
+`sourcePaths` becomes `pathMappings` for the Python attach configuration, which keeps local source lookup aligned with the debug target.
+
+### 3. Detach MCP before opening VS Code
+
+Use `detach_from_process` when you want to hand control to VS Code:
+
+```text
+use_mcp_tool(
+  tool_name="detach_from_process",
+  arguments={
+    "sessionId": "your-session-id"
+  }
+)
+```
+
+Treat this as a handoff, not a simultaneous dual-client session.
+
+### 4. Attach VS Code to the same `debugpy` endpoint
+
+Add a `launch.json` entry like this:
+
+```json
+{
+  "name": "Python: Attach to debugpy",
+  "type": "python",
+  "request": "attach",
+  "connect": {
+    "host": "127.0.0.1",
+    "port": 5678
+  },
+  "justMyCode": true,
+  "pathMappings": [
+    {
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "${workspaceFolder}"
+    }
+  ]
+}
+```
+
+## Tips
+
+1. Breakpoints are only fully verified after the adapter finishes initialization.
+2. Prefer absolute file paths when debugging across shells, containers, or editors.
+3. If breakpoints do not bind, confirm the Python interpreter that launched `debugpy` matches the code you are editing.
+4. Use `get_local_variables` for fast MCP inspection and switch to the full stack/scopes flow only when you need more detail.

--- a/docs/ruby/README.md
+++ b/docs/ruby/README.md
@@ -1,0 +1,164 @@
+# Ruby Debugging with mcp-debugger
+
+mcp-debugger supports Ruby debugging through the standard `debug` gem and its `rdbg` command-line frontend. You can launch Ruby directly from MCP or attach MCP to an existing `rdbg` port.
+
+## Prerequisites
+
+Before using the Ruby adapter, ensure you have:
+
+1. Ruby 2.7 or higher installed
+2. The `debug` gem available in the runtime you want to debug
+
+Ruby 3.1 and newer ship `debug` in the standard library. On older setups, install it manually:
+
+```bash
+gem install debug
+```
+
+Verify that `rdbg` is available:
+
+```bash
+rdbg --version
+```
+
+## Launch a Ruby program from MCP
+
+### 1. Create a session
+
+```text
+use_mcp_tool(
+  tool_name="create_debug_session",
+  arguments={
+    "language": "ruby",
+    "name": "Ruby Debug Session"
+  }
+)
+```
+
+### 2. Set breakpoints
+
+```text
+use_mcp_tool(
+  tool_name="set_breakpoint",
+  arguments={
+    "sessionId": "your-session-id",
+    "file": "/path/to/app.rb",
+    "line": 12
+  }
+)
+```
+
+### 3. Start debugging
+
+For a plain Ruby script:
+
+```text
+use_mcp_tool(
+  tool_name="start_debugging",
+  arguments={
+    "sessionId": "your-session-id",
+    "scriptPath": "/path/to/app.rb",
+    "args": ["--verbose"]
+  }
+)
+```
+
+For Bundler-driven commands such as Rails, RSpec, or rake:
+
+```text
+use_mcp_tool(
+  tool_name="start_debugging",
+  arguments={
+    "sessionId": "your-session-id",
+    "scriptPath": "spec/models/user_spec.rb",
+    "adapterLaunchConfig": {
+      "useBundler": true,
+      "bundlePath": "bundle"
+    }
+  }
+)
+```
+
+The Ruby adapter launches `rdbg` in VS Code-compatible DAP mode and forwards the target command through `-c -- ...`.
+
+### 4. Control execution
+
+```text
+use_mcp_tool(tool_name="step_over", arguments={ "sessionId": "your-session-id" })
+use_mcp_tool(tool_name="step_into", arguments={ "sessionId": "your-session-id" })
+use_mcp_tool(tool_name="step_out", arguments={ "sessionId": "your-session-id" })
+use_mcp_tool(tool_name="continue_execution", arguments={ "sessionId": "your-session-id" })
+use_mcp_tool(tool_name="pause_execution", arguments={ "sessionId": "your-session-id" })
+```
+
+### 5. Inspect state
+
+Use `get_local_variables`, `get_stack_trace`, `get_scopes`, `get_variables`, and `evaluate_expression` exactly as you would in other language adapters.
+
+## Attach to an existing `rdbg` session
+
+Issue #46 called out the workflow where a Ruby program is already running under `rdbg` and MCP should attach to it. That flow is supported.
+
+### 1. Start the target with `rdbg`
+
+Plain Ruby:
+
+```bash
+rdbg --open=vscode --host 127.0.0.1 --port 12345 --nonstop -c -- ruby app.rb
+```
+
+Bundler or Rails:
+
+```bash
+rdbg --open=vscode --host 127.0.0.1 --port 12345 --nonstop -c -- bundle exec ruby app.rb
+```
+
+### 2. Create a Ruby session in MCP
+
+```text
+use_mcp_tool(
+  tool_name="create_debug_session",
+  arguments={
+    "language": "ruby",
+    "name": "Ruby Attach Session"
+  }
+)
+```
+
+### 3. Attach to the `rdbg` port
+
+```text
+use_mcp_tool(
+  tool_name="attach_to_process",
+  arguments={
+    "sessionId": "your-session-id",
+    "host": "127.0.0.1",
+    "port": 12345,
+    "sourcePaths": ["/path/to/your/project"]
+  }
+)
+```
+
+After the attach completes, breakpoints, stepping, stack inspection, and expression evaluation work through the existing `rdbg` session.
+
+## Known Ruby gotcha: `pry-byebug`
+
+Projects that load `pry-byebug` or other TracePoint-heavy debugger helpers can interfere with line breakpoints in `rdbg`.
+
+If breakpoints appear to bind inconsistently:
+
+1. Prefer `rdbg` as the active debugger for that run.
+2. Remove `pry-byebug` from the debug execution path when possible.
+3. Use an explicit source breakpoint in code when needed:
+
+```ruby
+binding.break if defined?(DEBUGGER__)
+```
+
+This is especially useful in Rails and RSpec entrypoints where other debugging gems may already be loaded.
+
+## Tips
+
+1. Use `useBundler: true` for Rails, RSpec, and rake-style commands so the same Gemfile context is used during debugging.
+2. If `rdbg` is installed but not found, confirm the Ruby environment on your PATH matches the one that owns the gem.
+3. For attach workflows, start the target with a fixed host and port so both MCP and external tools can reconnect predictably.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -34,7 +34,7 @@ This document provides a complete reference for all tools available in mcp-debug
 Creates a new debugging session.
 
 **Parameters:**
-- `language` (string, required): The programming language to debug. Languages are discovered dynamically from installed adapters. The default fallback languages (when dynamic discovery is unavailable) are `"python"` and `"mock"`. When all adapters are available, the full list is: `"python"`, `"javascript"`, `"rust"`, `"go"`, `"java"`, `"dotnet"`, `"mock"`. The actual list depends on which `@debugmcp/adapter-*` packages are discoverable at runtime.
+- `language` (string, required): The programming language to debug. Languages are discovered dynamically from installed adapters. The default fallback languages (when dynamic discovery is unavailable) are `"python"` and `"mock"`. When all adapters are available, the full list is: `"python"`, `"ruby"`, `"javascript"`, `"rust"`, `"go"`, `"java"`, `"dotnet"`, `"mock"`. The actual list depends on which `@debugmcp/adapter-*` packages are discoverable at runtime.
 - `name` (string, optional): A descriptive name for the debug session. Defaults to `"session-<8 chars>"` (e.g., `"session-a4d1acc8"`).
 - `executablePath` (string, optional): Path to the language interpreter/executable (e.g., Python interpreter path).
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "prebuild": "node scripts/clean-src-artifacts.cjs && rimraf dist && pnpm run vendor:adapters",
     "build": "pnpm run build:packages && tsc -b -f . && pnpm run postbuild && pnpm run bundle",
     "build:shared": "pnpm --filter @debugmcp/shared build",
-    "build:adapters": "pnpm --filter @debugmcp/adapter-mock build && pnpm --filter @debugmcp/adapter-python build",
-    "build:adapters:all": "pnpm --filter @debugmcp/adapter-mock build && pnpm --filter @debugmcp/adapter-python build && pnpm --filter @debugmcp/adapter-javascript build",
+    "build:adapters": "pnpm --filter @debugmcp/adapter-mock build && pnpm --filter @debugmcp/adapter-python build && pnpm --filter @debugmcp/adapter-ruby build",
+    "build:adapters:all": "pnpm --filter @debugmcp/adapter-mock build && pnpm --filter @debugmcp/adapter-python build && pnpm --filter @debugmcp/adapter-ruby build && pnpm --filter @debugmcp/adapter-javascript build",
     "dev:js": "pnpm -w -F @debugmcp/adapter-javascript build && pnpm -w -F @debugmcp/adapter-javascript run build:adapter",
     "build:packages": "node scripts/build-packages.cjs",
     "build:packages:ci": "cross-env BUILD_SCRIPT=build:ci node scripts/build-packages.cjs",
@@ -155,6 +155,7 @@
     "@debugmcp/adapter-javascript": "workspace:*",
     "@debugmcp/adapter-mock": "workspace:*",
     "@debugmcp/adapter-python": "workspace:*",
+    "@debugmcp/adapter-ruby": "workspace:*",
     "@debugmcp/adapter-rust": "workspace:*"
   },
   "devDependencies": {

--- a/packages/adapter-python/src/python-debug-adapter.ts
+++ b/packages/adapter-python/src/python-debug-adapter.ts
@@ -21,7 +21,9 @@ import {
   AdapterCommand,
   AdapterConfig,
   GenericLaunchConfig,
+  GenericAttachConfig,
   LanguageSpecificLaunchConfig,
+  LanguageSpecificAttachConfig,
   DebugFeature,
   FeatureRequirement,
   AdapterCapabilities,
@@ -57,6 +59,22 @@ interface PythonLaunchConfig extends LanguageSpecificLaunchConfig {
   showReturnValue?: boolean;    // Show function return values
   subProcess?: boolean;         // Debug child processes
   [key: string]: unknown;       // Required by LanguageSpecificLaunchConfig
+}
+
+interface PythonAttachConfig extends LanguageSpecificAttachConfig {
+  type: 'python';
+  request: 'attach';
+  name: string;
+  connect: {
+    host: string;
+    port: number;
+  };
+  justMyCode: boolean;
+  subProcess: boolean;
+  pathMappings?: Array<{ localRoot: string; remoteRoot: string }>;
+  stopOnEntry?: boolean;
+  cwd?: string;
+  env?: Record<string, string>;
 }
 
 /**
@@ -366,6 +384,56 @@ export class PythonDebugAdapter extends EventEmitter implements IDebugAdapter {
       justMyCode: true,
       env: {},
       cwd: process.cwd()
+    };
+  }
+
+  supportsAttach(): boolean {
+    return true;
+  }
+
+  supportsDetach(): boolean {
+    return true;
+  }
+
+  transformAttachConfig(config: GenericAttachConfig): PythonAttachConfig {
+    if (typeof config.port !== 'number') {
+      throw new AdapterError(
+        'Python attach requires a debugpy host and port',
+        AdapterErrorCode.ENVIRONMENT_INVALID
+      );
+    }
+
+    const attachConfig: PythonAttachConfig = {
+      type: 'python',
+      request: 'attach',
+      name: 'Python: Attach',
+      connect: {
+        host: config.host || '127.0.0.1',
+        port: config.port
+      },
+      justMyCode: config.justMyCode ?? true,
+      subProcess: true,
+      stopOnEntry: config.stopOnEntry,
+      cwd: config.cwd,
+      env: config.env
+    };
+
+    if (Array.isArray(config.sourcePaths) && config.sourcePaths.length > 0) {
+      attachConfig.pathMappings = config.sourcePaths.map((sourcePath) => ({
+        localRoot: sourcePath,
+        remoteRoot: sourcePath
+      }));
+    }
+
+    return attachConfig;
+  }
+
+  getDefaultAttachConfig(): Partial<GenericAttachConfig> {
+    return {
+      request: 'attach',
+      host: '127.0.0.1',
+      stopOnEntry: true,
+      justMyCode: true
     };
   }
   

--- a/packages/adapter-python/tests/unit/python-debug-adapter.spec.ts
+++ b/packages/adapter-python/tests/unit/python-debug-adapter.spec.ts
@@ -94,4 +94,28 @@ describe('PythonDebugAdapter', () => {
     const message = adapter.translateErrorMessage(new Error('ENOENT: no such file'));
     expect(message).toContain('ENOENT');
   });
+
+  it('builds a debugpy attach configuration', () => {
+    const adapter = new PythonDebugAdapter(deps);
+    const config = adapter.transformAttachConfig({
+      request: 'attach',
+      host: '127.0.0.1',
+      port: 5678
+    });
+
+    expect(config).toEqual({
+      type: 'python',
+      request: 'attach',
+      name: 'Python: Attach',
+      connect: {
+        host: '127.0.0.1',
+        port: 5678
+      },
+      justMyCode: true,
+      subProcess: true,
+      stopOnEntry: undefined,
+      cwd: undefined,
+      env: undefined
+    });
+  });
 });

--- a/packages/adapter-ruby/package.json
+++ b/packages/adapter-ruby/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@debugmcp/adapter-ruby",
+  "version": "0.21.0",
+  "description": "Ruby debug adapter for MCP debugger using rdbg",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "build:ci": "tsc -b -f",
+    "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "dependencies": {
+    "@debugmcp/shared": "workspace:*",
+    "@vscode/debugprotocol": "^1.68.0",
+    "which": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "@types/which": "^3.0.4",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "peerDependencies": {
+    "@debugmcp/shared": "0.21.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/debugmcp/mcp-debugger.git",
+    "directory": "packages/adapter-ruby"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/adapter-ruby/src/index.ts
+++ b/packages/adapter-ruby/src/index.ts
@@ -1,0 +1,10 @@
+export { RubyAdapterFactory } from './ruby-adapter-factory.js';
+export { RubyDebugAdapter } from './ruby-debug-adapter.js';
+export {
+  findRubyExecutable,
+  getRubyVersion,
+  findRdbgExecutable,
+  getRdbgVersion,
+  getRubySearchPaths,
+  getRdbgSearchPaths
+} from './utils/ruby-utils.js';

--- a/packages/adapter-ruby/src/ruby-adapter-factory.ts
+++ b/packages/adapter-ruby/src/ruby-adapter-factory.ts
@@ -1,0 +1,83 @@
+import { IDebugAdapter } from '@debugmcp/shared';
+import {
+  IAdapterFactory,
+  AdapterDependencies,
+  AdapterMetadata,
+  FactoryValidationResult
+} from '@debugmcp/shared';
+import { DebugLanguage } from '@debugmcp/shared';
+import { RubyDebugAdapter } from './ruby-debug-adapter.js';
+import {
+  findRubyExecutable,
+  getRubyVersion,
+  findRdbgExecutable,
+  getRdbgVersion
+} from './utils/ruby-utils.js';
+
+export class RubyAdapterFactory implements IAdapterFactory {
+  createAdapter(dependencies: AdapterDependencies): IDebugAdapter {
+    return new RubyDebugAdapter(dependencies);
+  }
+
+  getMetadata(): AdapterMetadata {
+    return {
+      language: DebugLanguage.RUBY,
+      displayName: 'Ruby',
+      version: '0.21.0',
+      author: 'mcp-debugger team',
+      description: 'Debug Ruby applications using rdbg',
+      documentationUrl: 'https://github.com/debugmcp/mcp-debugger/tree/main/docs/ruby',
+      minimumDebuggerVersion: '1.7.0',
+      fileExtensions: ['.rb', '.rake', '.gemspec']
+    };
+  }
+
+  async validate(): Promise<FactoryValidationResult> {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    let rubyPath: string | undefined;
+    let rubyVersion: string | undefined;
+    let rdbgPath: string | undefined;
+    let rdbgVersion: string | undefined;
+
+    try {
+      rubyPath = await findRubyExecutable();
+      rubyVersion = await getRubyVersion(rubyPath) || undefined;
+
+      if (rubyVersion) {
+        const [major, minor] = rubyVersion.split('.').map(Number);
+        if (major < 2 || (major === 2 && minor < 7)) {
+          errors.push(`Ruby 2.7 or higher required. Current version: ${rubyVersion}`);
+        }
+      } else {
+        warnings.push('Could not determine Ruby version');
+      }
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : 'Ruby executable not found');
+    }
+
+    try {
+      rdbgPath = await findRdbgExecutable();
+      rdbgVersion = await getRdbgVersion(rdbgPath) || undefined;
+      if (!rdbgVersion) {
+        warnings.push('Could not determine rdbg version');
+      }
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : 'rdbg not found');
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+      details: {
+        rubyPath,
+        rubyVersion,
+        rdbgPath,
+        rdbgVersion,
+        platform: process.platform,
+        timestamp: new Date().toISOString()
+      }
+    };
+  }
+}

--- a/packages/adapter-ruby/src/ruby-debug-adapter.ts
+++ b/packages/adapter-ruby/src/ruby-debug-adapter.ts
@@ -1,0 +1,596 @@
+import { EventEmitter } from 'events';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import {
+  IDebugAdapter,
+  AdapterState,
+  ValidationResult,
+  ValidationError,
+  ValidationWarning,
+  DependencyInfo,
+  AdapterConfig,
+  AdapterCommand,
+  GenericLaunchConfig,
+  GenericAttachConfig,
+  LanguageSpecificLaunchConfig,
+  LanguageSpecificAttachConfig,
+  DebugFeature,
+  FeatureRequirement,
+  AdapterCapabilities,
+  AdapterError,
+  AdapterErrorCode,
+  AdapterEvents
+} from '@debugmcp/shared';
+import { DebugLanguage } from '@debugmcp/shared';
+import { AdapterDependencies } from '@debugmcp/shared';
+import {
+  findRubyExecutable,
+  findRdbgExecutable,
+  getRubyVersion,
+  getRdbgVersion,
+  getRubySearchPaths
+} from './utils/ruby-utils.js';
+
+interface RubyPathCacheEntry {
+  path: string;
+  timestamp: number;
+  version?: string;
+}
+
+interface RubyLaunchConfig extends LanguageSpecificLaunchConfig {
+  type?: string;
+  request?: 'launch';
+  name?: string;
+  script?: string;
+  command?: string;
+  debugPort?: string;
+  localfs?: boolean;
+  localfsMap?: string;
+  useTerminal?: boolean;
+  showProtocolLog?: boolean;
+  useBundler?: boolean;
+  bundlePath?: string;
+  [key: string]: unknown;
+}
+
+interface RubyAttachConfig extends LanguageSpecificAttachConfig {
+  type: 'rdbg';
+  request: 'attach';
+  name: string;
+  debugPort: string;
+  localfs: boolean;
+  localfsMap?: string;
+  stopOnEntry?: boolean;
+  justMyCode?: boolean;
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export class RubyDebugAdapter extends EventEmitter implements IDebugAdapter {
+  readonly language = DebugLanguage.RUBY;
+  readonly name = 'Ruby Debug Adapter (rdbg)';
+
+  private state: AdapterState = AdapterState.UNINITIALIZED;
+  private dependencies: AdapterDependencies;
+  private rubyPathCache = new Map<string, RubyPathCacheEntry>();
+  private rdbgPathCache = new Map<string, RubyPathCacheEntry>();
+  private readonly cacheTimeout = 60000;
+  private currentThreadId: number | null = null;
+  private connected = false;
+  private resolvedRdbgPath: string | null = null;
+
+  constructor(dependencies: AdapterDependencies) {
+    super();
+    this.dependencies = dependencies;
+  }
+
+  async initialize(): Promise<void> {
+    this.transitionTo(AdapterState.INITIALIZING);
+
+    try {
+      const validation = await this.validateEnvironment();
+      if (!validation.valid) {
+        this.transitionTo(AdapterState.ERROR);
+        throw new AdapterError(
+          validation.errors[0]?.message || 'Ruby environment validation failed',
+          AdapterErrorCode.ENVIRONMENT_INVALID
+        );
+      }
+
+      this.transitionTo(AdapterState.READY);
+      this.emit('initialized');
+    } catch (error) {
+      this.transitionTo(AdapterState.ERROR);
+      throw error;
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.rubyPathCache.clear();
+    this.rdbgPathCache.clear();
+    this.currentThreadId = null;
+    this.connected = false;
+    this.resolvedRdbgPath = null;
+    this.state = AdapterState.UNINITIALIZED;
+    this.emit('disposed');
+  }
+
+  getState(): AdapterState {
+    return this.state;
+  }
+
+  isReady(): boolean {
+    return this.state === AdapterState.READY ||
+      this.state === AdapterState.CONNECTED ||
+      this.state === AdapterState.DEBUGGING;
+  }
+
+  getCurrentThreadId(): number | null {
+    return this.currentThreadId;
+  }
+
+  private transitionTo(newState: AdapterState): void {
+    const oldState = this.state;
+    this.state = newState;
+    this.emit('stateChanged', oldState, newState);
+  }
+
+  async validateEnvironment(): Promise<ValidationResult> {
+    const errors: ValidationError[] = [];
+    const warnings: ValidationWarning[] = [];
+
+    try {
+      const rubyPath = await this.resolveExecutablePath();
+      const rubyVersion = await this.checkRubyVersion(rubyPath);
+
+      if (rubyVersion) {
+        const [major, minor] = rubyVersion.split('.').map(Number);
+        if (major < 2 || (major === 2 && minor < 7)) {
+          errors.push({
+            code: 'RUBY_VERSION_TOO_OLD',
+            message: `Ruby 2.7 or higher required. Current version: ${rubyVersion}`,
+            recoverable: false
+          });
+        }
+      } else {
+        warnings.push({
+          code: 'RUBY_VERSION_CHECK_FAILED',
+          message: 'Could not determine Ruby version'
+        });
+      }
+    } catch (error) {
+      errors.push({
+        code: 'RUBY_NOT_FOUND',
+        message: error instanceof Error ? error.message : 'Ruby executable not found',
+        recoverable: false
+      });
+    }
+
+    try {
+      const rdbgPath = await this.resolveRdbgPath();
+      const rdbgVersion = await this.checkRdbgVersion(rdbgPath);
+      if (!rdbgVersion) {
+        warnings.push({
+          code: 'RDBG_VERSION_CHECK_FAILED',
+          message: 'Could not determine rdbg version'
+        });
+      }
+    } catch (error) {
+      errors.push({
+        code: 'RDBG_NOT_FOUND',
+        message: error instanceof Error ? error.message : 'rdbg not found',
+        recoverable: true
+      });
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings
+    };
+  }
+
+  getRequiredDependencies(): DependencyInfo[] {
+    return [
+      {
+        name: 'Ruby',
+        version: '2.7+',
+        required: true,
+        installCommand: 'Install Ruby from https://www.ruby-lang.org/'
+      },
+      {
+        name: 'debug gem (rdbg)',
+        version: '1.7+',
+        required: true,
+        installCommand: 'gem install debug'
+      }
+    ];
+  }
+
+  async resolveExecutablePath(preferredPath?: string): Promise<string> {
+    const cacheKey = preferredPath || 'default';
+    const cached = this.rubyPathCache.get(cacheKey);
+
+    if (cached && Date.now() - cached.timestamp < this.cacheTimeout) {
+      return cached.path;
+    }
+
+    const rubyPath = await findRubyExecutable(preferredPath, this.dependencies.logger);
+    this.rubyPathCache.set(cacheKey, {
+      path: rubyPath,
+      timestamp: Date.now()
+    });
+
+    return rubyPath;
+  }
+
+  getDefaultExecutableName(): string {
+    return process.platform === 'win32' ? 'ruby.exe' : 'ruby';
+  }
+
+  getExecutableSearchPaths(): string[] {
+    return getRubySearchPaths();
+  }
+
+  buildAdapterCommand(config: AdapterConfig): AdapterCommand {
+    const launchConfig = config.launchConfig as RubyLaunchConfig;
+    const rdbgPath = this.resolvedRdbgPath || process.env.RDBG_PATH || (process.platform === 'win32' ? 'rdbg.bat' : 'rdbg');
+    const targetCommand = this.buildTargetCommand(config, launchConfig);
+    const stopOnEntry = launchConfig.stopOnEntry ?? false;
+    const args = [
+      '--open=vscode',
+      '--host', config.adapterHost,
+      '--port', config.adapterPort.toString(),
+    ];
+
+    if (!stopOnEntry) {
+      args.push('--nonstop');
+    }
+
+    return {
+      command: rdbgPath,
+      args: [...args, '-c', '--', ...targetCommand],
+      env: {
+        ...process.env,
+        RUBY_DEBUG_DAP_SHOW_PROTOCOL: process.env.DEBUG ? '1' : '0'
+      }
+    };
+  }
+
+  private buildTargetCommand(config: AdapterConfig, launchConfig: RubyLaunchConfig): string[] {
+    if (launchConfig.useBundler) {
+      return [
+        launchConfig.bundlePath || 'bundle',
+        'exec',
+        config.executablePath,
+        config.scriptPath,
+        ...(config.scriptArgs || [])
+      ];
+    }
+
+    return [
+      config.executablePath,
+      config.scriptPath,
+      ...(config.scriptArgs || [])
+    ];
+  }
+
+  getAdapterModuleName(): string {
+    return 'rdbg';
+  }
+
+  getAdapterInstallCommand(): string {
+    return 'gem install debug';
+  }
+
+  async transformLaunchConfig(config: GenericLaunchConfig): Promise<RubyLaunchConfig> {
+    const rawConfig = config as Record<string, unknown>;
+    const script = typeof rawConfig.program === 'string'
+      ? rawConfig.program
+      : typeof rawConfig.script === 'string'
+        ? rawConfig.script
+        : undefined;
+
+    const rubyConfig: RubyLaunchConfig = {
+      ...config,
+      type: 'rdbg',
+      request: 'launch',
+      name: 'Ruby: Current File',
+      script,
+      localfs: rawConfig.localfs === false ? false : true,
+      debugPort: typeof rawConfig.debugPort === 'string' ? rawConfig.debugPort : undefined,
+      useTerminal: false,
+      showProtocolLog: process.env.DEBUG === '1' || process.env.DEBUG === 'true',
+      stopOnEntry: config.stopOnEntry ?? false,
+      justMyCode: config.justMyCode ?? true,
+      cwd: config.cwd ?? process.cwd()
+    };
+
+    if (typeof rawConfig.command === 'string') {
+      rubyConfig.command = rawConfig.command;
+    }
+
+    if (typeof rawConfig.localfsMap === 'string') {
+      rubyConfig.localfsMap = rawConfig.localfsMap;
+    }
+
+    if (typeof rawConfig.bundlePath === 'string') {
+      rubyConfig.bundlePath = rawConfig.bundlePath;
+    }
+
+    if (typeof rawConfig.useBundler === 'boolean') {
+      rubyConfig.useBundler = rawConfig.useBundler;
+    }
+
+    return rubyConfig;
+  }
+
+  getDefaultLaunchConfig(): Partial<GenericLaunchConfig> {
+    return {
+      stopOnEntry: false,
+      justMyCode: true,
+      env: {},
+      cwd: process.cwd()
+    };
+  }
+
+  supportsAttach(): boolean {
+    return true;
+  }
+
+  supportsDetach(): boolean {
+    return true;
+  }
+
+  transformAttachConfig(config: GenericAttachConfig): RubyAttachConfig {
+    const rawConfig = config as Record<string, unknown>;
+    const host = config.host || '127.0.0.1';
+    const port = config.port;
+
+    if (typeof port !== 'number') {
+      throw new AdapterError(
+        'Ruby attach requires a debug port opened by rdbg',
+        AdapterErrorCode.ENVIRONMENT_INVALID
+      );
+    }
+
+    const attachConfig: RubyAttachConfig = {
+      type: 'rdbg',
+      request: 'attach',
+      name: 'Ruby: Attach',
+      debugPort: this.buildDebugPort(host, port),
+      localfs: this.isLocalHost(host),
+      stopOnEntry: config.stopOnEntry,
+      justMyCode: config.justMyCode ?? true
+    };
+
+    if (typeof rawConfig.localfsMap === 'string') {
+      attachConfig.localfsMap = rawConfig.localfsMap;
+    }
+
+    if (config.cwd) {
+      attachConfig.cwd = config.cwd;
+    }
+
+    if (config.env) {
+      attachConfig.env = config.env;
+    }
+
+    return attachConfig;
+  }
+
+  getDefaultAttachConfig(): Partial<GenericAttachConfig> {
+    return {
+      request: 'attach',
+      host: '127.0.0.1',
+      stopOnEntry: true,
+      justMyCode: true
+    };
+  }
+
+  async sendDapRequest<T extends DebugProtocol.Response>(
+    _command: string,
+    _args?: unknown
+  ): Promise<T> {
+    return {} as T;
+  }
+
+  handleDapEvent(event: DebugProtocol.Event): void {
+    switch (event.event) {
+      case 'stopped':
+        this.transitionTo(AdapterState.DEBUGGING);
+        if (event.body?.threadId) {
+          this.currentThreadId = event.body.threadId;
+        }
+        break;
+      case 'continued':
+        this.transitionTo(AdapterState.DEBUGGING);
+        break;
+      case 'terminated':
+        this.transitionTo(AdapterState.DISCONNECTED);
+        break;
+    }
+
+    type AdapterEventName = Extract<keyof AdapterEvents, string | symbol>;
+    this.emit(event.event as AdapterEventName, event.body);
+  }
+
+  handleDapResponse(_response: DebugProtocol.Response): void {
+  }
+
+  async connect(_host: string, _port: number): Promise<void> {
+    this.connected = true;
+    this.transitionTo(AdapterState.CONNECTED);
+    this.emit('connected');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this.currentThreadId = null;
+    this.transitionTo(AdapterState.DISCONNECTED);
+    this.emit('disconnected');
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  getInstallationInstructions(): string {
+    return `Ruby Debugging Setup:
+
+1. Install Ruby 2.7 or higher:
+   - https://www.ruby-lang.org/
+
+2. Install the debug gem:
+   gem install debug
+
+3. Verify installation:
+   ruby --version
+   rdbg --version`;
+  }
+
+  getMissingExecutableError(): string {
+    return `Ruby not found. Please ensure Ruby 2.7+ is installed and available in PATH.`;
+  }
+
+  translateErrorMessage(error: Error): string {
+    const message = error.message.toLowerCase();
+
+    if (message.includes('rdbg') && message.includes('not found')) {
+      return 'rdbg not found. Install the debug gem with: gem install debug';
+    }
+
+    if (message.includes('ruby') && message.includes('not found')) {
+      return this.getMissingExecutableError();
+    }
+
+    if (message.includes('permission denied')) {
+      return 'Permission denied accessing Ruby or rdbg. Check file permissions.';
+    }
+
+    if (message.includes('connection refused') || message.includes('could not connect')) {
+      return 'Could not connect to the rdbg DAP server. Check for port conflicts or firewall rules.';
+    }
+
+    return error.message;
+  }
+
+  supportsFeature(feature: DebugFeature): boolean {
+    const supportedFeatures = [
+      DebugFeature.CONDITIONAL_BREAKPOINTS,
+      DebugFeature.FUNCTION_BREAKPOINTS,
+      DebugFeature.EXCEPTION_BREAKPOINTS,
+      DebugFeature.EVALUATE_FOR_HOVERS,
+      DebugFeature.TERMINATE_REQUEST
+    ];
+
+    return supportedFeatures.includes(feature);
+  }
+
+  getFeatureRequirements(feature: DebugFeature): FeatureRequirement[] {
+    switch (feature) {
+      case DebugFeature.CONDITIONAL_BREAKPOINTS:
+        return [{
+          type: 'dependency',
+          description: 'debug gem with DAP support',
+          required: true
+        }];
+      case DebugFeature.EXCEPTION_BREAKPOINTS:
+        return [{
+          type: 'dependency',
+          description: 'rdbg exception breakpoint support',
+          required: true
+        }];
+      default:
+        return [];
+    }
+  }
+
+  getCapabilities(): AdapterCapabilities {
+    return {
+      supportsConfigurationDoneRequest: true,
+      supportsFunctionBreakpoints: true,
+      supportsConditionalBreakpoints: true,
+      supportsHitConditionalBreakpoints: true,
+      supportsEvaluateForHovers: true,
+      exceptionBreakpointFilters: [
+        {
+          filter: 'any',
+          label: 'Rescue any exception',
+          default: false,
+          supportsCondition: true
+        }
+      ],
+      supportsCompletionsRequest: true,
+      supportsTerminateRequest: true,
+      supportTerminateDebuggee: true
+    };
+  }
+
+  private async resolveRdbgPath(preferredPath?: string): Promise<string> {
+    const cacheKey = preferredPath || 'default';
+    const cached = this.rdbgPathCache.get(cacheKey);
+
+    if (cached && Date.now() - cached.timestamp < this.cacheTimeout) {
+      this.resolvedRdbgPath = cached.path;
+      return cached.path;
+    }
+
+    const rdbgPath = await findRdbgExecutable(preferredPath, this.dependencies.logger);
+    this.rdbgPathCache.set(cacheKey, {
+      path: rdbgPath,
+      timestamp: Date.now()
+    });
+    this.resolvedRdbgPath = rdbgPath;
+    return rdbgPath;
+  }
+
+  private async checkRubyVersion(rubyPath: string): Promise<string | null> {
+    const cached = this.rubyPathCache.get(rubyPath) || this.rubyPathCache.get('default');
+    if (cached?.version) {
+      return cached.version;
+    }
+
+    const version = await getRubyVersion(rubyPath);
+    if (version) {
+      this.rubyPathCache.set(rubyPath, {
+        ...(cached ?? {}),
+        path: rubyPath,
+        version,
+        timestamp: Date.now()
+      });
+    }
+
+    return version;
+  }
+
+  private async checkRdbgVersion(rdbgPath: string): Promise<string | null> {
+    const cached = this.rdbgPathCache.get(rdbgPath) || this.rdbgPathCache.get('default');
+    if (cached?.version) {
+      return cached.version;
+    }
+
+    const version = await getRdbgVersion(rdbgPath);
+    if (version) {
+      this.rdbgPathCache.set(rdbgPath, {
+        ...(cached ?? {}),
+        path: rdbgPath,
+        version,
+        timestamp: Date.now()
+      });
+    }
+
+    return version;
+  }
+
+  private buildDebugPort(host: string, port: number): string {
+    if (host === '127.0.0.1' || host === 'localhost') {
+      return String(port);
+    }
+
+    return `${host}:${port}`;
+  }
+
+  private isLocalHost(host: string): boolean {
+    return host === '127.0.0.1' || host === 'localhost' || host === '::1';
+  }
+}

--- a/packages/adapter-ruby/src/utils/ruby-utils.ts
+++ b/packages/adapter-ruby/src/utils/ruby-utils.ts
@@ -1,0 +1,197 @@
+import { spawn } from 'child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import which from 'which';
+
+interface Logger {
+  debug?(message: string): void;
+  error?(message: string): void;
+}
+
+const noopLogger: Logger = {};
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    const mode = process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK;
+    await fs.promises.access(filePath, mode);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveCandidate(command: string): Promise<string | null> {
+  try {
+    return await which(command);
+  } catch {
+    return null;
+  }
+}
+
+async function findExecutable(
+  preferredPath: string | undefined,
+  envVar: string | undefined,
+  candidates: string[],
+  searchPaths: string[],
+  label: string,
+  logger: Logger = noopLogger
+): Promise<string> {
+  const tried: string[] = [];
+
+  const directCandidates = [preferredPath, envVar].filter(
+    (candidate): candidate is string => typeof candidate === 'string' && candidate.length > 0
+  );
+
+  for (const candidate of directCandidates) {
+    const resolved = await resolveCandidate(candidate);
+    if (resolved) {
+      logger.debug?.(`[RubyUtils] Using ${label} from explicit path: ${resolved}`);
+      return resolved;
+    }
+    if (await fileExists(candidate)) {
+      logger.debug?.(`[RubyUtils] Using ${label} from explicit file path: ${candidate}`);
+      return candidate;
+    }
+    tried.push(candidate);
+  }
+
+  for (const candidate of candidates) {
+    const resolved = await resolveCandidate(candidate);
+    if (resolved) {
+      logger.debug?.(`[RubyUtils] Found ${label} on PATH: ${resolved}`);
+      return resolved;
+    }
+    tried.push(candidate);
+  }
+
+  for (const searchPath of searchPaths) {
+    for (const candidate of candidates) {
+      const fullPath = path.join(searchPath, candidate);
+      if (await fileExists(fullPath)) {
+        logger.debug?.(`[RubyUtils] Found ${label} in common path: ${fullPath}`);
+        return fullPath;
+      }
+      tried.push(fullPath);
+    }
+  }
+
+  throw new Error(`${label} not found. Tried: ${tried.join(', ')}`);
+}
+
+export function getRubySearchPaths(): string[] {
+  const paths: string[] = [];
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+
+  if (process.platform === 'win32') {
+    paths.push(
+      'C:\\Ruby31-x64\\bin',
+      'C:\\Ruby32-x64\\bin',
+      'C:\\Ruby33-x64\\bin',
+      'C:\\Ruby34-x64\\bin',
+      path.join(home, 'scoop', 'apps', 'ruby', 'current', 'bin')
+    );
+  } else if (process.platform === 'darwin') {
+    paths.push(
+      '/usr/local/bin',
+      '/opt/homebrew/bin',
+      path.join(home, '.rubies', 'default', 'bin')
+    );
+  } else {
+    paths.push(
+      '/usr/bin',
+      '/usr/local/bin',
+      path.join(home, '.rubies', 'default', 'bin')
+    );
+  }
+
+  if (process.env.PATH) {
+    paths.push(...process.env.PATH.split(path.delimiter));
+  }
+
+  return Array.from(new Set(paths.filter(Boolean)));
+}
+
+export function getRdbgSearchPaths(): string[] {
+  const paths: string[] = [];
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+
+  if (process.platform === 'win32') {
+    paths.push(
+      path.join(home, 'scoop', 'apps', 'ruby', 'current', 'bin'),
+      path.join(home, '.local', 'share', 'gem', 'ruby', 'bin')
+    );
+  } else {
+    paths.push(
+      '/usr/local/bin',
+      '/usr/bin',
+      path.join(home, '.gem', 'bin'),
+      path.join(home, '.local', 'share', 'gem', 'ruby', 'bin')
+    );
+  }
+
+  if (process.env.PATH) {
+    paths.push(...process.env.PATH.split(path.delimiter));
+  }
+
+  return Array.from(new Set(paths.filter(Boolean)));
+}
+
+export async function findRubyExecutable(
+  preferredPath?: string,
+  logger: Logger = noopLogger
+): Promise<string> {
+  const envRuby = process.env.RUBY_PATH || process.env.RUBY_EXECUTABLE;
+  const candidates = process.platform === 'win32' ? ['ruby.exe', 'ruby'] : ['ruby'];
+  return findExecutable(preferredPath, envRuby, candidates, getRubySearchPaths(), 'Ruby', logger);
+}
+
+export async function findRdbgExecutable(
+  preferredPath?: string,
+  logger: Logger = noopLogger
+): Promise<string> {
+  const envRdbg = process.env.RDBG_PATH;
+  const candidates = process.platform === 'win32' ? ['rdbg.bat', 'rdbg.cmd', 'rdbg.exe', 'rdbg'] : ['rdbg'];
+  return findExecutable(preferredPath, envRdbg, candidates, getRdbgSearchPaths(), 'rdbg', logger);
+}
+
+export async function getRubyVersion(rubyPath: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn(rubyPath, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let output = '';
+
+    child.stdout?.on('data', (data) => { output += data.toString(); });
+    child.stderr?.on('data', (data) => { output += data.toString(); });
+
+    child.on('error', () => resolve(null));
+    child.on('exit', (code) => {
+      if (code !== 0 || output.length === 0) {
+        resolve(null);
+        return;
+      }
+
+      const match = output.match(/ruby\s+(\d+\.\d+\.\d+)/i);
+      resolve(match ? match[1] : output.trim());
+    });
+  });
+}
+
+export async function getRdbgVersion(rdbgPath: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn(rdbgPath, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let output = '';
+
+    child.stdout?.on('data', (data) => { output += data.toString(); });
+    child.stderr?.on('data', (data) => { output += data.toString(); });
+
+    child.on('error', () => resolve(null));
+    child.on('exit', (code) => {
+      if (code !== 0 || output.length === 0) {
+        resolve(null);
+        return;
+      }
+
+      const match = output.match(/(?:rdbg|debug)\s+(\d+\.\d+\.\d+)/i);
+      resolve(match ? match[1] : output.trim());
+    });
+  });
+}

--- a/packages/adapter-ruby/tests/unit/ruby-debug-adapter.test.ts
+++ b/packages/adapter-ruby/tests/unit/ruby-debug-adapter.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { RubyDebugAdapter } from '../../src/ruby-debug-adapter.js';
+import { AdapterError, AdapterState, DebugFeature } from '@debugmcp/shared';
+
+vi.mock('../../src/utils/ruby-utils.js', () => ({
+  findRubyExecutable: vi.fn(),
+  getRubyVersion: vi.fn(),
+  findRdbgExecutable: vi.fn(),
+  getRdbgVersion: vi.fn(),
+  getRubySearchPaths: vi.fn().mockReturnValue(['/usr/bin'])
+}));
+
+const { findRubyExecutable, getRubyVersion, findRdbgExecutable, getRdbgVersion } = await import('../../src/utils/ruby-utils.js');
+
+const createDependencies = () => ({
+  fileSystem: {} as unknown,
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  },
+  environment: {} as unknown,
+  networkManager: undefined
+});
+
+describe('RubyDebugAdapter', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('caches resolveExecutablePath results', async () => {
+    vi.mocked(findRubyExecutable).mockResolvedValue('/usr/bin/ruby');
+    const adapter = new RubyDebugAdapter(createDependencies());
+
+    const first = await adapter.resolveExecutablePath();
+    const second = await adapter.resolveExecutablePath();
+
+    expect(first).toBe('/usr/bin/ruby');
+    expect(second).toBe('/usr/bin/ruby');
+    expect(findRubyExecutable).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks environment invalid when Ruby version is too old', async () => {
+    vi.mocked(findRubyExecutable).mockResolvedValue('/usr/bin/ruby');
+    vi.mocked(getRubyVersion).mockResolvedValue('2.6.10');
+    vi.mocked(findRdbgExecutable).mockResolvedValue('/usr/bin/rdbg');
+    vi.mocked(getRdbgVersion).mockResolvedValue('1.9.1');
+
+    const adapter = new RubyDebugAdapter(createDependencies());
+    const result = await adapter.validateEnvironment();
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]?.code).toBe('RUBY_VERSION_TOO_OLD');
+  });
+
+  it('reports missing rdbg', async () => {
+    vi.mocked(findRubyExecutable).mockResolvedValue('/usr/bin/ruby');
+    vi.mocked(getRubyVersion).mockResolvedValue('3.3.0');
+    vi.mocked(findRdbgExecutable).mockRejectedValue(new Error('rdbg not found'));
+
+    const adapter = new RubyDebugAdapter(createDependencies());
+    const result = await adapter.validateEnvironment();
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map((entry) => entry.code)).toContain('RDBG_NOT_FOUND');
+  });
+
+  it('builds an rdbg adapter command', () => {
+    const adapter = new RubyDebugAdapter(createDependencies());
+    (adapter as unknown as { resolvedRdbgPath: string }).resolvedRdbgPath = '/usr/bin/rdbg';
+
+    const command = adapter.buildAdapterCommand({
+      sessionId: 'ruby-session',
+      executablePath: '/usr/bin/ruby',
+      adapterHost: '127.0.0.1',
+      adapterPort: 8123,
+      logDir: '/tmp/logs',
+      scriptPath: '/workspace/app.rb',
+      scriptArgs: ['one', 'two'],
+      launchConfig: {}
+    });
+
+    expect(command.command).toBe('/usr/bin/rdbg');
+    expect(command.args).toEqual([
+      '--open=vscode',
+      '--host', '127.0.0.1',
+      '--port', '8123',
+      '--nonstop',
+      '-c',
+      '--',
+      '/usr/bin/ruby',
+      '/workspace/app.rb',
+      'one',
+      'two'
+    ]);
+  });
+
+  it('builds a launch config with rdbg fields', async () => {
+    const adapter = new RubyDebugAdapter(createDependencies());
+    const config = await adapter.transformLaunchConfig({
+      program: '/workspace/app.rb',
+      stopOnEntry: true,
+      justMyCode: false
+    });
+
+    expect(config.type).toBe('rdbg');
+    expect(config.request).toBe('launch');
+    expect(config.script).toBe('/workspace/app.rb');
+    expect(config.localfs).toBe(true);
+    expect(config.stopOnEntry).toBe(true);
+  });
+
+  it('transforms attach config for an existing rdbg port', () => {
+    const adapter = new RubyDebugAdapter(createDependencies());
+    const config = adapter.transformAttachConfig({
+      request: 'attach',
+      host: '127.0.0.1',
+      port: 12345,
+      stopOnEntry: true
+    });
+
+    expect(adapter.supportsAttach?.()).toBe(true);
+    expect(adapter.supportsDetach?.()).toBe(true);
+    expect(config).toEqual(
+      expect.objectContaining({
+        type: 'rdbg',
+        request: 'attach',
+        debugPort: '12345',
+        localfs: true,
+        stopOnEntry: true
+      })
+    );
+  });
+
+  it('exposes ruby capabilities and lifecycle transitions', async () => {
+    const adapter = new RubyDebugAdapter(createDependencies());
+
+    expect(adapter.supportsFeature(DebugFeature.CONDITIONAL_BREAKPOINTS)).toBe(true);
+    expect(adapter.supportsFeature(DebugFeature.DATA_BREAKPOINTS)).toBe(false);
+    expect(adapter.getCapabilities().supportsFunctionBreakpoints).toBe(true);
+
+    vi.spyOn(adapter, 'validateEnvironment').mockResolvedValue({ valid: true, errors: [], warnings: [] });
+    await adapter.initialize();
+    expect(adapter.getState()).toBe(AdapterState.READY);
+
+    await adapter.connect('127.0.0.1', 8123);
+    expect(adapter.getState()).toBe(AdapterState.CONNECTED);
+    await adapter.disconnect();
+    expect(adapter.getState()).toBe(AdapterState.DISCONNECTED);
+  });
+
+  it('throws AdapterError when environment validation fails during initialize', async () => {
+    const adapter = new RubyDebugAdapter(createDependencies());
+    vi.spyOn(adapter, 'validateEnvironment').mockResolvedValue({
+      valid: false,
+      errors: [{ code: 'BAD_ENV', message: 'bad env', recoverable: false }],
+      warnings: []
+    });
+
+    await expect(adapter.initialize()).rejects.toBeInstanceOf(AdapterError);
+    expect(adapter.getState()).toBe(AdapterState.ERROR);
+  });
+});

--- a/packages/adapter-ruby/tsconfig.json
+++ b/packages/adapter-ruby/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {
+      "@debugmcp/shared": ["../shared/dist"],
+      "@debugmcp/shared/*": ["../shared/dist/*"]
+    },
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "references": [
+    { "path": "../shared" }
+  ],
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/mcp-debugger/README.md
+++ b/packages/mcp-debugger/README.md
@@ -1,6 +1,6 @@
 # @debugmcp/mcp-debugger
 
-Step-through debugging MCP server for LLMs
+Step-through debugging MCP server for LLMs across seven languages
 
 ## Installation
 
@@ -33,6 +33,7 @@ mcp-debugger sse --port 3001
 All language adapters are bundled into the CLI package. No separate installation is needed. The following adapters are included:
 
 - **Python** (`@debugmcp/adapter-python`) - Python debugging via debugpy
+- **Ruby** (`@debugmcp/adapter-ruby`) - Ruby debugging via rdbg
 - **JavaScript** (`@debugmcp/adapter-javascript`) - JavaScript/Node.js debugging via js-debug
 - **Rust** (`@debugmcp/adapter-rust`) - Rust debugging via CodeLLDB
 - **Go** (`@debugmcp/adapter-go`) - Go debugging via Delve
@@ -40,7 +41,7 @@ All language adapters are bundled into the CLI package. No separate installation
 - **.NET** (`@debugmcp/adapter-dotnet`) - .NET debugging via netcoredbg
 - **Mock** (`@debugmcp/adapter-mock`) - Mock adapter for testing
 
-**System Requirements:** Node.js 22+ is required to run mcp-debugger. You also need the language runtimes and debug tools installed on your system (e.g., Python + debugpy, Go + Delve, JDK 21+, netcoredbg with a compatible .NET runtime).
+**System Requirements:** Node.js 22+ is required to run mcp-debugger. You also need the language runtimes and debug tools installed on your system (e.g., Python + debugpy, Ruby + the `debug` gem / `rdbg`, Go + Delve, JDK 21+, netcoredbg with a compatible .NET runtime).
 
 ### Check Rust binary compatibility
 ```bash

--- a/packages/mcp-debugger/package.json
+++ b/packages/mcp-debugger/package.json
@@ -37,6 +37,7 @@
     "@debugmcp/adapter-javascript": "workspace:*",
     "@debugmcp/adapter-python": "workspace:*",
     "@debugmcp/adapter-mock": "workspace:*",
+    "@debugmcp/adapter-ruby": "workspace:*",
     "@debugmcp/adapter-rust": "workspace:*",
     "@debugmcp/shared": "workspace:*"
   }

--- a/packages/mcp-debugger/src/batteries-included.ts
+++ b/packages/mcp-debugger/src/batteries-included.ts
@@ -10,6 +10,7 @@
 import { JavascriptAdapterFactory } from '@debugmcp/adapter-javascript';
 import { PythonAdapterFactory } from '@debugmcp/adapter-python';
 import { MockAdapterFactory } from '@debugmcp/adapter-mock';
+import { RubyAdapterFactory } from '@debugmcp/adapter-ruby';
 import { GoAdapterFactory } from '@debugmcp/adapter-go';
 import { RustAdapterFactory } from '@debugmcp/adapter-rust';
 import { JavaAdapterFactory } from '@debugmcp/adapter-java';
@@ -17,7 +18,7 @@ import { DotnetAdapterFactory } from '@debugmcp/adapter-dotnet';
 import type { IAdapterFactory } from '@debugmcp/shared';
 
 interface BundledAdapterEntry {
-  language: 'javascript' | 'python' | 'mock' | 'go' | 'rust' | 'java' | 'dotnet';
+  language: 'javascript' | 'python' | 'mock' | 'ruby' | 'go' | 'rust' | 'java' | 'dotnet';
   factoryCtor: new () => IAdapterFactory;
 }
 
@@ -27,6 +28,7 @@ const adapters: BundledAdapterEntry[] = [
   { language: 'javascript', factoryCtor: JavascriptAdapterFactory },
   { language: 'python', factoryCtor: PythonAdapterFactory },
   { language: 'mock', factoryCtor: MockAdapterFactory },
+  { language: 'ruby', factoryCtor: RubyAdapterFactory },
   { language: 'go', factoryCtor: GoAdapterFactory },
   { language: 'rust', factoryCtor: RustAdapterFactory },
   { language: 'java', factoryCtor: JavaAdapterFactory },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -173,6 +173,7 @@ export type {
 export { DefaultAdapterPolicy } from './interfaces/adapter-policy.js';
 export { JsDebugAdapterPolicy } from './interfaces/adapter-policy-js.js';
 export { PythonAdapterPolicy } from './interfaces/adapter-policy-python.js';
+export { RubyAdapterPolicy } from './interfaces/adapter-policy-ruby.js';
 export { RustAdapterPolicy } from './interfaces/adapter-policy-rust.js';
 export { GoAdapterPolicy } from './interfaces/adapter-policy-go.js';
 export { JavaAdapterPolicy } from './interfaces/adapter-policy-java.js';

--- a/packages/shared/src/interfaces/adapter-policy-ruby.ts
+++ b/packages/shared/src/interfaces/adapter-policy-ruby.ts
@@ -1,0 +1,224 @@
+import type { DebugProtocol } from '@vscode/debugprotocol';
+import type { AdapterPolicy, AdapterSpecificState, CommandHandling } from './adapter-policy.js';
+import { SessionState } from '@debugmcp/shared';
+import type { StackFrame, Variable } from '../models/index.js';
+import type { DapClientBehavior, DapClientContext, ReverseRequestResult } from './dap-client-behavior.js';
+
+export const RubyAdapterPolicy: AdapterPolicy = {
+  name: 'ruby',
+  supportsReverseStartDebugging: false,
+  childSessionStrategy: 'none',
+  shouldDeferParentConfigDone: () => false,
+  buildChildStartArgs: () => {
+    throw new Error('RubyAdapterPolicy does not support child sessions');
+  },
+  isChildReadyEvent: (evt: DebugProtocol.Event): boolean => {
+    return evt?.event === 'initialized';
+  },
+  extractLocalVariables: (
+    stackFrames: StackFrame[],
+    scopes: Record<number, DebugProtocol.Scope[]>,
+    variables: Record<number, Variable[]>
+  ): Variable[] => {
+    if (!stackFrames || stackFrames.length === 0) {
+      return [];
+    }
+
+    const topFrame = stackFrames[0];
+    const frameScopes = scopes[topFrame.id];
+    if (!frameScopes || frameScopes.length === 0) {
+      return [];
+    }
+
+    const localScope = frameScopes.find((scope) =>
+      scope.name === 'Locals' || scope.name === 'Local'
+    );
+
+    if (!localScope) {
+      return [];
+    }
+
+    return variables[localScope.variablesReference] || [];
+  },
+  getLocalScopeName: (): string[] => {
+    return ['Locals', 'Local'];
+  },
+  getDapAdapterConfiguration: () => {
+    return {
+      type: 'rdbg'
+    };
+  },
+  resolveExecutablePath: (providedPath?: string) => {
+    if (providedPath) {
+      return providedPath;
+    }
+
+    return process.env.RUBY_PATH || process.env.RUBY_EXECUTABLE || 'ruby';
+  },
+  getDebuggerConfiguration: () => {
+    return {
+      requiresStrictHandshake: false,
+      skipConfigurationDone: false,
+      supportsVariableType: true
+    };
+  },
+  isSessionReady: (state: SessionState) => state === SessionState.PAUSED,
+  validateExecutable: async (rubyCmd: string): Promise<boolean> => {
+    const { spawn } = await import('child_process');
+
+    return new Promise((resolve) => {
+      const child = spawn(rubyCmd, ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+
+      let hasOutput = false;
+      child.stdout?.on('data', () => {
+        hasOutput = true;
+      });
+      child.stderr?.on('data', () => {
+        hasOutput = true;
+      });
+
+      child.on('error', () => resolve(false));
+      child.on('exit', (code) => resolve(code === 0 && hasOutput));
+    });
+  },
+  requiresCommandQueueing: (): boolean => false,
+  shouldQueueCommand: (): CommandHandling => {
+    return {
+      shouldQueue: false,
+      shouldDefer: false,
+      reason: 'Ruby adapter does not queue commands'
+    };
+  },
+  createInitialState: (): AdapterSpecificState => {
+    return {
+      initialized: false,
+      configurationDone: false
+    };
+  },
+  updateStateOnCommand: (command: string, _args: unknown, state: AdapterSpecificState): void => {
+    if (command === 'configurationDone') {
+      state.configurationDone = true;
+    }
+  },
+  updateStateOnEvent: (event: string, _body: unknown, state: AdapterSpecificState): void => {
+    if (event === 'initialized') {
+      state.initialized = true;
+    }
+  },
+  isInitialized: (state: AdapterSpecificState): boolean => {
+    return state.initialized;
+  },
+  isConnected: (state: AdapterSpecificState): boolean => {
+    return state.initialized;
+  },
+  matchesAdapter: (adapterCommand: { command: string; args: string[] }): boolean => {
+    const commandStr = adapterCommand.command.toLowerCase();
+    const argsStr = adapterCommand.args.join(' ').toLowerCase();
+
+    return commandStr.includes('rdbg') ||
+      argsStr.includes('rdbg') ||
+      argsStr.includes('--stop-at-load');
+  },
+  getInitializationBehavior: () => {
+    return {
+      sendLaunchBeforeConfig: true
+    };
+  },
+  getDapClientBehavior: (): DapClientBehavior => {
+    return {
+      handleReverseRequest: async (request: DebugProtocol.Request, context: DapClientContext): Promise<ReverseRequestResult> => {
+        if (request.command === 'runInTerminal') {
+          context.sendResponse(request, {});
+          return { handled: true };
+        }
+        return { handled: false };
+      },
+      childRoutedCommands: undefined,
+      mirrorBreakpointsToChild: false,
+      deferParentConfigDone: false,
+      pauseAfterChildAttach: false,
+      normalizeAdapterId: undefined,
+      childInitTimeout: 5000,
+      suppressPostAttachConfigDone: false
+    };
+  },
+  filterStackFrames: (frames: StackFrame[], includeInternals: boolean): StackFrame[] => {
+    if (includeInternals) {
+      return frames;
+    }
+
+    return frames.filter((frame) => {
+      const filePath = frame.file || '';
+      return !filePath.startsWith('<internal:') && !filePath.includes('/gems/');
+    });
+  },
+  isInternalFrame: (frame: StackFrame): boolean => {
+    const filePath = frame.file || '';
+    return filePath.startsWith('<internal:') || filePath.includes('/gems/');
+  },
+  getAdapterSpawnConfig: (payload) => {
+    const launchConfig = (payload.launchConfig ?? {}) as Record<string, unknown>;
+    if (launchConfig.request === 'attach') {
+      const debugPortValue = launchConfig.debugPort;
+      let host = '127.0.0.1';
+      let port: number | undefined;
+
+      if (typeof debugPortValue === 'number') {
+        port = debugPortValue;
+      } else if (typeof debugPortValue === 'string') {
+        const parts = debugPortValue.split(':');
+        if (parts.length === 1) {
+          const parsedPort = Number(parts[0]);
+          if (!Number.isNaN(parsedPort)) {
+            port = parsedPort;
+          }
+        } else {
+          const parsedPort = Number(parts[parts.length - 1]);
+          if (!Number.isNaN(parsedPort)) {
+            host = parts.slice(0, -1).join(':') || host;
+            port = parsedPort;
+          }
+        }
+      }
+
+      return {
+        command: '',
+        args: [],
+        host,
+        port: port || payload.adapterPort,
+        logDir: payload.logDir,
+        connectOnly: true
+      };
+    }
+
+    if (payload.adapterCommand) {
+      return {
+        command: payload.adapterCommand.command,
+        args: payload.adapterCommand.args,
+        host: payload.adapterHost,
+        port: payload.adapterPort,
+        logDir: payload.logDir,
+        env: payload.adapterCommand.env
+      };
+    }
+
+    return {
+      command: process.platform === 'win32' ? 'rdbg.bat' : 'rdbg',
+      args: [
+        '--command',
+        '--open',
+        '--host', payload.adapterHost,
+        '--port', String(payload.adapterPort),
+        '--stop-at-load',
+        '--',
+        payload.executablePath || 'ruby',
+        payload.scriptPath
+      ],
+      host: payload.adapterHost,
+      port: payload.adapterPort,
+      logDir: payload.logDir
+    };
+  }
+};

--- a/packages/shared/src/interfaces/adapter-policy.ts
+++ b/packages/shared/src/interfaces/adapter-policy.ts
@@ -323,6 +323,7 @@ export interface AdapterPolicy {
     adapterPort: number;
     logDir: string;
     scriptPath: string;
+    launchConfig?: LanguageSpecificLaunchConfig;
     adapterCommand?: { command: string; args: string[]; env?: Record<string, string> };
   }): {
     command: string;
@@ -332,6 +333,7 @@ export interface AdapterPolicy {
     logDir: string;
     cwd?: string;
     env?: NodeJS.ProcessEnv;
+    connectOnly?: boolean;
   } | undefined;
 }
 

--- a/packages/shared/src/models/index.ts
+++ b/packages/shared/src/models/index.ts
@@ -80,6 +80,7 @@ export type LanguageSpecificAttachConfig = Record<string, unknown>;
  */
 export enum DebugLanguage {
   PYTHON = 'python',
+  RUBY = 'ruby',
   JAVASCRIPT = 'javascript',
   RUST = 'rust',
   GO = 'go',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@debugmcp/adapter-python':
         specifier: workspace:*
         version: link:packages/adapter-python
+      '@debugmcp/adapter-ruby':
+        specifier: workspace:*
+        version: link:packages/adapter-ruby
       '@debugmcp/adapter-rust':
         specifier: workspace:*
         version: link:packages/adapter-rust
@@ -283,6 +286,31 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.7)(@vitest/coverage-v8@4.1.7)(vite@7.3.2(@types/node@25.9.1))
 
+  packages/adapter-ruby:
+    dependencies:
+      '@debugmcp/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@vscode/debugprotocol':
+        specifier: ^1.68.0
+        version: 1.68.0
+      which:
+        specifier: ^7.0.0
+        version: 7.0.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.7)(@vitest/coverage-v8@4.1.7)(vite@7.3.2(@types/node@25.9.1))
+
   packages/adapter-rust:
     dependencies:
       '@debugmcp/shared':
@@ -337,6 +365,9 @@ importers:
       '@debugmcp/adapter-python':
         specifier: workspace:*
         version: link:../adapter-python
+      '@debugmcp/adapter-ruby':
+        specifier: workspace:*
+        version: link:../adapter-ruby
       '@debugmcp/adapter-rust':
         specifier: workspace:*
         version: link:../adapter-rust

--- a/scripts/build-packages.cjs
+++ b/scripts/build-packages.cjs
@@ -17,6 +17,7 @@ const packages = [
   '@debugmcp/shared',
   '@debugmcp/adapter-mock',
   '@debugmcp/adapter-python',
+  '@debugmcp/adapter-ruby',
   '@debugmcp/adapter-javascript',
   ...(!disabledLanguages.has('rust') ? ['@debugmcp/adapter-rust'] : []),
   ...(!disabledLanguages.has('go') ? ['@debugmcp/adapter-go'] : []),

--- a/src/adapters/adapter-loader.ts
+++ b/src/adapters/adapter-loader.ts
@@ -139,6 +139,7 @@ export class AdapterLoader {
       { name: 'mock', packageName: '@debugmcp/adapter-mock', description: 'Mock adapter for testing' },
       { name: 'python', packageName: '@debugmcp/adapter-python', description: 'Python debugger using debugpy' },
       { name: 'javascript', packageName: '@debugmcp/adapter-javascript', description: 'JavaScript/TypeScript debugger using js-debug' },
+      { name: 'ruby', packageName: '@debugmcp/adapter-ruby', description: 'Ruby debugger using rdbg' },
       { name: 'rust', packageName: '@debugmcp/adapter-rust', description: 'Rust debugger using CodeLLDB' },
       { name: 'go', packageName: '@debugmcp/adapter-go', description: 'Go debugger using Delve' },
       { name: 'java', packageName: '@debugmcp/adapter-java', description: 'Java debugger using JDI bridge' },

--- a/src/container/dependencies.ts
+++ b/src/container/dependencies.ts
@@ -117,7 +117,7 @@ export function createProductionDependencies(config: ContainerConfig = {}): Depe
   // Adapters are loaded dynamically on-demand by the AdapterRegistry via AdapterLoader.
   // In container runtime, pre-register known adapters using dynamic import (fire-and-forget)
   if (process.env.MCP_CONTAINER === 'true') {
-    const tryRegister = (lang: 'mock' | 'python' | 'javascript' | 'rust' | 'go' | 'java', factoryName: string) => {
+    const tryRegister = (lang: 'mock' | 'python' | 'javascript' | 'ruby' | 'rust' | 'go' | 'java', factoryName: string) => {
       if (isLanguageDisabled(lang)) {
         logger.info?.(`[AdapterRegistry] Skipping bundled adapter '${lang}' (disabled via env).`);
         return;
@@ -142,6 +142,7 @@ export function createProductionDependencies(config: ContainerConfig = {}): Depe
     tryRegister('mock', 'MockAdapterFactory');
     tryRegister('python', 'PythonAdapterFactory');
     tryRegister('javascript', 'JavascriptAdapterFactory');
+    tryRegister('ruby', 'RubyAdapterFactory');
     tryRegister('rust', 'RustAdapterFactory');
     tryRegister('go', 'GoAdapterFactory');
     tryRegister('java', 'JavaAdapterFactory');

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -35,6 +35,7 @@ import {
   RustAdapterPolicy,
   GoAdapterPolicy,
   JavaAdapterPolicy,
+  RubyAdapterPolicy,
   DotnetAdapterPolicy,
   MockAdapterPolicy
 } from '@debugmcp/shared';
@@ -119,6 +120,8 @@ export class DapProxyWorker {
       return RustAdapterPolicy;
     } else if (GoAdapterPolicy.matchesAdapter(adapterCommand)) {
       return GoAdapterPolicy;
+    } else if (RubyAdapterPolicy.matchesAdapter(adapterCommand)) {
+      return RubyAdapterPolicy;
     } else if (JavaAdapterPolicy.matchesAdapter(adapterCommand)) {
       return JavaAdapterPolicy;
     } else if (DotnetAdapterPolicy.matchesAdapter(adapterCommand)) {
@@ -290,6 +293,7 @@ export class DapProxyWorker {
       adapterPort: payload.adapterPort,
       logDir: payload.logDir,
       scriptPath: payload.scriptPath,
+      launchConfig: payload.launchConfig,
       adapterCommand: payload.adapterCommand
     });
     
@@ -297,7 +301,9 @@ export class DapProxyWorker {
       throw new Error(`Cannot determine adapter command for dry run (policy: ${this.adapterPolicy.name})`);
     }
     
-    const fullCommand = `${spawnConfig.command} ${spawnConfig.args.join(' ')}`;
+    const fullCommand = spawnConfig.connectOnly
+      ? `[direct-connect] ${spawnConfig.host}:${spawnConfig.port}`
+      : `${spawnConfig.command} ${spawnConfig.args.join(' ')}`;
     
     this.logger!.warn(`[Worker DRY_RUN] Would execute: ${fullCommand}`);
     this.logger!.warn(`[Worker DRY_RUN] Script to debug: ${payload.scriptPath}`);
@@ -334,6 +340,7 @@ export class DapProxyWorker {
       adapterPort: payload.adapterPort,
       logDir: payload.logDir,
       scriptPath: payload.scriptPath,
+      launchConfig: payload.launchConfig,
       adapterCommand: payload.adapterCommand
     });
     
@@ -344,32 +351,35 @@ export class DapProxyWorker {
     // In container mode, default adapter cwd to workspace root so that
     // relative paths in DAP launch args (classpath, cwd, etc.) resolve
     // against the mounted project directory rather than /app.
-    if (process.env.MCP_WORKSPACE_ROOT && !spawnConfig.cwd) {
+    if (process.env.MCP_WORKSPACE_ROOT && !spawnConfig.cwd && !spawnConfig.connectOnly) {
       spawnConfig.cwd = process.env.MCP_WORKSPACE_ROOT;
     }
 
-    // Spawn adapter process using the config from the policy
-    const spawnResult = await this.processManager!.spawn(spawnConfig);
+    if (!spawnConfig.connectOnly) {
+      const spawnResult = await this.processManager!.spawn(spawnConfig);
 
-    this.adapterProcess = spawnResult.process;
-    this.logger!.info(`[Worker] Adapter spawned with PID: ${spawnResult.pid}`);
+      this.adapterProcess = spawnResult.process;
+      this.logger!.info(`[Worker] Adapter spawned with PID: ${spawnResult.pid}`);
 
-    // Monitor adapter process
-    this.adapterProcess.on('error', (err) => {
-      this.logger!.error('[Worker] Adapter process error:', err);
-      this.sendError(`Adapter process error: ${err.message}`);
-    });
+      this.adapterProcess.on('error', (err) => {
+        this.logger!.error('[Worker] Adapter process error:', err);
+        this.sendError(`Adapter process error: ${err.message}`);
+      });
 
-    this.adapterProcess.on('exit', (code, signal) => {
-      this.logger!.info(`[Worker] Adapter process exited. Code: ${code}, Signal: ${signal}`);
-      this.sendStatus('adapter_exited', { code, signal });
-    });
+      this.adapterProcess.on('exit', (code, signal) => {
+        this.logger!.info(`[Worker] Adapter process exited. Code: ${code}, Signal: ${signal}`);
+        this.sendStatus('adapter_exited', { code, signal });
+      });
+    } else {
+      this.adapterProcess = null;
+      this.logger!.info(`[Worker] Connecting directly to adapter at ${spawnConfig.host}:${spawnConfig.port}`);
+    }
 
     // Connect to adapter
     try {
       this.dapClient = await this.connectionManager!.connectWithRetry(
-        payload.adapterHost,
-        payload.adapterPort
+        spawnConfig.host,
+        spawnConfig.port
       );
 
       // Set up event handlers

--- a/src/server.ts
+++ b/src/server.ts
@@ -231,6 +231,14 @@ export class DebugMcpServer {
             requiresExecutable: true,
             defaultExecutable: 'python'
           };
+        case DebugLanguage.RUBY:
+          return {
+            id: DebugLanguage.RUBY,
+            displayName: 'Ruby',
+            version: '1.0.0',
+            requiresExecutable: true,
+            defaultExecutable: 'ruby'
+          };
         case DebugLanguage.MOCK:
           return {
             id: DebugLanguage.MOCK,

--- a/src/session/session-manager-data.ts
+++ b/src/session/session-manager-data.ts
@@ -9,6 +9,7 @@ import {
   AdapterPolicy,
   DefaultAdapterPolicy,
   PythonAdapterPolicy,
+  RubyAdapterPolicy,
   JsDebugAdapterPolicy,
   RustAdapterPolicy,
   GoAdapterPolicy,
@@ -33,6 +34,8 @@ export abstract class SessionManagerData extends SessionManagerCore {
         return PythonAdapterPolicy;
       case DebugLanguage.JAVASCRIPT:
         return JsDebugAdapterPolicy;
+      case DebugLanguage.RUBY:
+        return RubyAdapterPolicy;
       case DebugLanguage.RUST:
         return RustAdapterPolicy;
       case DebugLanguage.GO:

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -16,6 +16,7 @@ import {
   AdapterPolicy,
   DefaultAdapterPolicy,
   PythonAdapterPolicy,
+  RubyAdapterPolicy,
   JsDebugAdapterPolicy,
   RustAdapterPolicy,
   GoAdapterPolicy,
@@ -78,6 +79,8 @@ export class SessionStore {
     switch (language) {
       case DebugLanguage.PYTHON:
         return PythonAdapterPolicy;
+      case DebugLanguage.RUBY:
+        return RubyAdapterPolicy;
       case DebugLanguage.JAVASCRIPT:
         return JsDebugAdapterPolicy;
       case DebugLanguage.RUST:

--- a/tests/core/unit/server/server-language-discovery.test.ts
+++ b/tests/core/unit/server/server-language-discovery.test.ts
@@ -97,6 +97,46 @@ describe('Server Language Discovery Tests', () => {
     });
   });
 
+  describe('Ruby availability and metadata', () => {
+    it('should report ruby metadata when dynamically discovered', async () => {
+      debugServer = new DebugMcpServer();
+      const { callToolHandler } = getToolHandlers(mockServer);
+
+      mockAdapterRegistry.listLanguages = vi.fn().mockResolvedValue(['python', 'mock', 'ruby']);
+      mockAdapterRegistry.listAvailableAdapters = vi.fn().mockResolvedValue([
+        { name: 'python', packageName: '@debugmcp/adapter-python', installed: true, description: 'Python debugger using debugpy' },
+        { name: 'mock', packageName: '@debugmcp/adapter-mock', installed: true, description: 'Mock adapter for testing' },
+        { name: 'ruby', packageName: '@debugmcp/adapter-ruby', installed: true, description: 'Ruby debugger using rdbg' }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'list_supported_languages',
+          arguments: {}
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      const rubyAvail = content.available.find((adapter: any) => adapter.language === 'ruby');
+      const rubyMeta = content.languages.find((meta: any) => meta.id === 'ruby');
+
+      expect(rubyAvail).toEqual({
+        language: 'ruby',
+        package: '@debugmcp/adapter-ruby',
+        installed: true,
+        description: 'Ruby debugger using rdbg'
+      });
+      expect(rubyMeta).toEqual({
+        id: 'ruby',
+        displayName: 'Ruby',
+        version: '1.0.0',
+        requiresExecutable: true,
+        defaultExecutable: 'ruby'
+      });
+    });
+  });
+
   describe('getSupportedLanguagesAsync', () => {
     it('should return languages from dynamic discovery when available', async () => {
       debugServer = new DebugMcpServer();

--- a/tests/core/unit/session/models.test.ts
+++ b/tests/core/unit/session/models.test.ts
@@ -211,9 +211,10 @@ describe('Session Models', () => {
         expect(DebugLanguage.MOCK).toBe('mock');
       });
 
-      it('should have exactly 7 language options including javascript, rust, go, java, and dotnet', () => {
+      it('should have exactly 8 language options including ruby, javascript, rust, go, java, and dotnet', () => {
         const languages = Object.values(DebugLanguage);
-        expect(languages).toHaveLength(7);
+        expect(languages).toHaveLength(8);
+        expect(languages).toContain('ruby');
         expect(languages).toContain('javascript');
         expect(languages).toContain('rust');
         expect(languages).toContain('go');

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -26,7 +26,8 @@ import {
   JsDebugAdapterPolicy,
   PythonAdapterPolicy,
   GoAdapterPolicy,
-  JavaAdapterPolicy
+  JavaAdapterPolicy,
+  RubyAdapterPolicy
 } from '@debugmcp/shared';
 
 // Mock implementations
@@ -258,6 +259,14 @@ describe('DapProxyWorker', () => {
         args: ['dap', '--listen=:9876']
       });
       expect(policy.name).toBe('go');
+    });
+
+    it('should select Ruby policy for rdbg adapter', () => {
+      const policy = (worker as any).selectAdapterPolicy({
+        command: 'rdbg',
+        args: ['--open=vscode', '--port', '12345']
+      });
+      expect(policy.name).toBe('ruby');
     });
 
     it('should select Java policy for JdiDapServer adapter', () => {
@@ -596,6 +605,64 @@ describe('DapProxyWorker', () => {
       );
       expect(statusCall).toBeDefined();
       expect(worker.getState()).toBe(ProxyState.CONNECTED);
+    });
+
+    it('startAdapterAndConnect should connect directly for Ruby attach sessions', async () => {
+      const payload: ProxyInitPayload = {
+        cmd: 'init',
+        sessionId: 'ruby-attach-session',
+        executablePath: 'ruby',
+        adapterHost: '127.0.0.1',
+        adapterPort: 8123,
+        logDir: '/logs',
+        scriptPath: 'attach://remote',
+        launchConfig: {
+          request: 'attach',
+          type: 'rdbg',
+          debugPort: '127.0.0.1:12345'
+        },
+        adapterCommand: {
+          command: 'rdbg',
+          args: ['--open=vscode', '--port', '8123', '-c', '--', 'ruby', 'app.rb']
+        }
+      };
+
+      const processStub = {
+        spawn: vi.fn(),
+        shutdown: vi.fn().mockResolvedValue(undefined)
+      };
+
+      const connectionStub = {
+        connectWithRetry: vi.fn().mockResolvedValue(mockDapClient),
+        setAdapterPolicy: vi.fn(),
+        setupEventHandlers: vi.fn((client: EventEmitter, handlers: Record<string, () => void>) => {
+          if (handlers.onInitialized) client.on('initialized', handlers.onInitialized);
+        }),
+        initializeSession: vi.fn().mockImplementation(async () => {
+          setImmediate(() => (mockDapClient as EventEmitter).emit('initialized'));
+        }),
+        sendAttachRequest: vi.fn().mockResolvedValue(undefined),
+        setBreakpoints: vi.fn().mockResolvedValue(undefined),
+        sendConfigurationDone: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined)
+      };
+
+      (worker as any).logger = mockLogger;
+      (worker as any).processManager = processStub;
+      (worker as any).connectionManager = connectionStub;
+      (worker as any).adapterPolicy = RubyAdapterPolicy;
+      (worker as any).adapterState = RubyAdapterPolicy.createInitialState();
+      (worker as any).currentInitPayload = payload;
+      (worker as any).state = ProxyState.INITIALIZING;
+
+      await (worker as any).startAdapterAndConnect(payload);
+
+      expect(processStub.spawn).not.toHaveBeenCalled();
+      expect(connectionStub.connectWithRetry).toHaveBeenCalledWith('127.0.0.1', 12345);
+      expect(connectionStub.sendAttachRequest).toHaveBeenCalledWith(
+        mockDapClient,
+        payload.launchConfig
+      );
     });
 
     it('startAdapterAndConnect should defer initialized and send launch before configurationDone when sendLaunchBeforeConfig is true', async () => {

--- a/tests/unit/adapter-python/python-debug-adapter.test.ts
+++ b/tests/unit/adapter-python/python-debug-adapter.test.ts
@@ -276,6 +276,41 @@ describe('PythonDebugAdapter', () => {
     expect(config.justMyCode).toBe(false);
   });
 
+  it('transforms attach configuration for debugpy handoff', () => {
+    const adapter = new PythonDebugAdapter(createDependencies());
+    const config = adapter.transformAttachConfig({
+      request: 'attach',
+      host: '127.0.0.1',
+      port: 5678,
+      sourcePaths: ['/workspace/app'],
+      stopOnEntry: true,
+      justMyCode: false
+    });
+
+    expect(adapter.supportsAttach?.()).toBe(true);
+    expect(adapter.supportsDetach?.()).toBe(true);
+    expect(config).toEqual({
+      type: 'python',
+      request: 'attach',
+      name: 'Python: Attach',
+      connect: {
+        host: '127.0.0.1',
+        port: 5678
+      },
+      justMyCode: false,
+      subProcess: true,
+      pathMappings: [
+        {
+          localRoot: '/workspace/app',
+          remoteRoot: '/workspace/app'
+        }
+      ],
+      stopOnEntry: true,
+      cwd: undefined,
+      env: undefined
+    });
+  });
+
   it('disposes by clearing state and emitting event', async () => {
     const adapter = new PythonDebugAdapter(createDependencies());
     const disposed = vi.fn();
@@ -318,5 +353,17 @@ describe('PythonDebugAdapter', () => {
     expect(defaults.justMyCode).toBe(true);
     expect(defaults.env).toEqual({});
     expect(defaults.cwd).toBe(process.cwd());
+  });
+
+  it('returns default attach configuration snapshot', () => {
+    const adapter = new PythonDebugAdapter(createDependencies());
+    const defaults = adapter.getDefaultAttachConfig?.();
+
+    expect(defaults).toEqual({
+      request: 'attach',
+      host: '127.0.0.1',
+      stopOnEntry: true,
+      justMyCode: true
+    });
   });
 });

--- a/tests/unit/adapters/adapter-loader.test.ts
+++ b/tests/unit/adapters/adapter-loader.test.ts
@@ -292,7 +292,7 @@ describe('AdapterLoader', () => {
 
       const adapters = await adapterLoader.listAvailableAdapters();
 
-      expect(adapters).toHaveLength(7);
+      expect(adapters).toHaveLength(8);
 
       const pythonAdapter = adapters.find(a => a.name === 'python');
       expect(pythonAdapter).toEqual({
@@ -315,6 +315,14 @@ describe('AdapterLoader', () => {
         name: 'javascript',
         packageName: '@debugmcp/adapter-javascript',
         description: 'JavaScript/TypeScript debugger using js-debug',
+        installed: false
+      });
+
+      const rubyAdapter = adapters.find(a => a.name === 'ruby');
+      expect(rubyAdapter).toEqual({
+        name: 'ruby',
+        packageName: '@debugmcp/adapter-ruby',
+        description: 'Ruby debugger using rdbg',
         installed: false
       });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -146,6 +146,7 @@ export default defineConfig({
       { find: '@debugmcp/shared', replacement: path.resolve(__dirname, './packages/shared/src/index.ts') },
       { find: '@debugmcp/adapter-mock', replacement: path.resolve(__dirname, './packages/adapter-mock/src/index.ts') },
       { find: '@debugmcp/adapter-python', replacement: path.resolve(__dirname, './packages/adapter-python/src/index.ts') },
+      { find: '@debugmcp/adapter-ruby', replacement: path.resolve(__dirname, './packages/adapter-ruby/src/index.ts') },
       { find: '@debugmcp/adapter-javascript', replacement: path.resolve(__dirname, './packages/adapter-javascript/src/index.ts') },
       { find: '@debugmcp/adapter-go', replacement: path.resolve(__dirname, './packages/adapter-go/src/index.ts') },
       { find: '@debugmcp/adapter-rust', replacement: path.resolve(__dirname, './packages/adapter-rust/src/index.ts') },


### PR DESCRIPTION
## Summary
- add a first-class Ruby adapter package with core registration, attach support, tests, and release wiring
- add Python attach support for debugpy handoff workflows so MCP sessions can move cleanly into VS Code
- document public ownership signals and maintainer contact, and refresh language/support docs to include Ruby

## Testing
- node scripts/build-packages.cjs
- pnpm vitest run tests/unit/adapter-python/python-debug-adapter.test.ts packages/adapter-python/tests/unit/python-debug-adapter.spec.ts packages/adapter-ruby/tests/unit/ruby-debug-adapter.test.ts tests/unit/adapters/adapter-loader.test.ts tests/core/unit/session/models.test.ts tests/core/unit/server/server-language-discovery.test.ts tests/proxy/dap-proxy-worker.test.ts

Closes #46
Closes #7
Closes #77