### PR TITLE
fix(python-adapter): validate the configured interpreter for debugpy (fixes #106)

### DIFF
--- a/packages/adapter-python/src/python-debug-adapter.ts
+++ b/packages/adapter-python/src/python-debug-adapter.ts
@@ -147,16 +147,17 @@ export class PythonDebugAdapter extends EventEmitter implements IDebugAdapter {
   
   // ===== Environment Validation =====
   
-  async validateEnvironment(): Promise<ValidationResult> {
+  async validateEnvironment(executablePath?: string): Promise<ValidationResult> {
     const errors: ValidationError[] = [];
     const warnings: ValidationWarning[] = [];
 
     try {
-      // Check Python executable
+      // Check Python executable. Validate the interpreter the user actually configured
+      // (e.g. a virtualenv python) rather than an auto-detected system one — see issue #106.
       if (process.env.CI === 'true') {
         console.error('[PythonDebugAdapter] Resolving Python executable path...');
       }
-      const pythonPath = await this.resolveExecutablePath();
+      const pythonPath = await this.resolveExecutablePath(executablePath);
       if (process.env.CI === 'true') {
         console.error('[PythonDebugAdapter] Resolved Python path:', pythonPath);
       }
@@ -179,14 +180,26 @@ export class PythonDebugAdapter extends EventEmitter implements IDebugAdapter {
         });
       }
       
-      // Check debugpy installation
+      // Check debugpy installation. When the user configured an explicit interpreter we fail
+      // fast with a clear, correct error for that interpreter. When the interpreter was merely
+      // auto-detected (no executablePath given), debugpy may still live in the user's virtualenv,
+      // so we downgrade to a warning and re-check at launch time — consistent with the factory's
+      // #16 fix and avoids blocking virtualenv users (issue #106).
       const hasDebugpy = await this.checkDebugpyInstalled(pythonPath);
       if (!hasDebugpy) {
-        errors.push({
-          code: 'DEBUGPY_NOT_INSTALLED',
-          message: 'debugpy not installed. Run: pip install debugpy',
-          recoverable: true
-        });
+        if (executablePath) {
+          errors.push({
+            code: 'DEBUGPY_NOT_INSTALLED',
+            message: `debugpy not installed for ${pythonPath}. Run: ${pythonPath} -m pip install debugpy`,
+            recoverable: true
+          });
+        } else {
+          warnings.push({
+            code: 'DEBUGPY_NOT_INSTALLED',
+            message: 'debugpy not found in the auto-detected Python. If using a virtualenv, ' +
+              'pass its interpreter as executablePath; otherwise run: pip install debugpy'
+          });
+        }
       }
       
       // Check if in virtual environment

--- a/packages/adapter-python/tests/unit/python-debug-adapter.spec.ts
+++ b/packages/adapter-python/tests/unit/python-debug-adapter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { AdapterState, AdapterErrorCode } from '@debugmcp/shared';
+import { AdapterState } from '@debugmcp/shared';
 import { PythonDebugAdapter } from '../../src/python-debug-adapter.js';
 import type { AdapterDependencies } from '@debugmcp/shared';
 
@@ -47,20 +47,21 @@ describe('PythonDebugAdapter', () => {
     expect(events).toContain('initialized');
   });
 
-  it('fails initialize when debugpy is missing', async () => {
+  it('initialize succeeds with a warning when debugpy is missing from the auto-detected interpreter', async () => {
+    // Registration/init runs without a configured interpreter, so a missing debugpy must NOT block:
+    // it is re-checked at launch against the user's real executablePath. Regression guard for #106/#16.
     const adapter = new PythonDebugAdapter(deps);
     (adapter as any).resolveExecutablePath = vi.fn().mockResolvedValue('/usr/bin/python3');
     (adapter as any).checkPythonVersion = vi.fn().mockResolvedValue('3.10.1');
     (adapter as any).checkDebugpyInstalled = vi.fn().mockResolvedValue(false);
     (adapter as any).detectVirtualEnv = vi.fn().mockResolvedValue(false);
 
-    await expect(adapter.initialize()).rejects.toMatchObject({
-      code: AdapterErrorCode.ENVIRONMENT_INVALID,
-    });
-    expect(adapter.getState()).toBe(AdapterState.ERROR);
+    await adapter.initialize();
+    expect(adapter.getState()).toBe(AdapterState.READY);
+    expect(adapter.isReady()).toBe(true);
   });
 
-  it('validateEnvironment reports version and debugpy issues', async () => {
+  it('validateEnvironment reports version as error and missing debugpy as a warning when auto-detected', async () => {
     const adapter = new PythonDebugAdapter(deps);
     (adapter as any).resolveExecutablePath = vi.fn().mockResolvedValue('/usr/bin/python');
     (adapter as any).checkPythonVersion = vi.fn().mockResolvedValue('3.6.9');
@@ -70,12 +71,60 @@ describe('PythonDebugAdapter', () => {
     const result = await adapter.validateEnvironment();
     expect(result.valid).toBe(false);
     expect(result.errors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ code: 'PYTHON_VERSION_TOO_OLD' }),
-        expect.objectContaining({ code: 'DEBUGPY_NOT_INSTALLED' }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ code: 'PYTHON_VERSION_TOO_OLD' })]),
+    );
+    // No explicit interpreter was provided, so a missing debugpy is a warning, not an error.
+    expect(result.errors.some((e) => e.code === 'DEBUGPY_NOT_INSTALLED')).toBe(false);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'DEBUGPY_NOT_INSTALLED' })]),
     );
     expect(deps.logger.info).toHaveBeenCalledWith('[PythonDebugAdapter] Virtual environment detected');
+  });
+
+  describe('configured-interpreter validation (issue #106)', () => {
+    it('forwards the configured executablePath to resolveExecutablePath', async () => {
+      // Root-cause guard: validateEnvironment must check the interpreter the user configured,
+      // not an auto-detected one. Pre-fix this was called with undefined.
+      const adapter = new PythonDebugAdapter(deps);
+      const resolveSpy = vi.fn().mockResolvedValue('/project/.venv/bin/python');
+      (adapter as any).resolveExecutablePath = resolveSpy;
+      (adapter as any).checkPythonVersion = vi.fn().mockResolvedValue('3.12.0');
+      (adapter as any).checkDebugpyInstalled = vi.fn().mockResolvedValue(true);
+      (adapter as any).detectVirtualEnv = vi.fn().mockResolvedValue(true);
+
+      await adapter.validateEnvironment('/project/.venv/bin/python');
+
+      expect(resolveSpy).toHaveBeenCalledWith('/project/.venv/bin/python');
+    });
+
+    it('passes when the configured venv python has debugpy even if the global one does not', async () => {
+      const adapter = new PythonDebugAdapter(deps);
+      // resolveExecutablePath echoes an explicit preferred path, as findPythonExecutable does.
+      (adapter as any).resolveExecutablePath = vi.fn(async (p?: string) => p ?? '/usr/bin/python3');
+      (adapter as any).checkPythonVersion = vi.fn().mockResolvedValue('3.12.0');
+      (adapter as any).checkDebugpyInstalled = vi.fn(async (p: string) => p === '/project/.venv/bin/python');
+      (adapter as any).detectVirtualEnv = vi.fn().mockResolvedValue(true);
+
+      const result = await adapter.validateEnvironment('/project/.venv/bin/python');
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('reports missing debugpy as an error when an explicit interpreter was provided', async () => {
+      const adapter = new PythonDebugAdapter(deps);
+      (adapter as any).resolveExecutablePath = vi.fn(async (p?: string) => p ?? '/usr/bin/python3');
+      (adapter as any).checkPythonVersion = vi.fn().mockResolvedValue('3.12.0');
+      (adapter as any).checkDebugpyInstalled = vi.fn().mockResolvedValue(false);
+      (adapter as any).detectVirtualEnv = vi.fn().mockResolvedValue(false);
+
+      const result = await adapter.validateEnvironment('/project/.venv/bin/python');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code: 'DEBUGPY_NOT_INSTALLED' })]),
+      );
+    });
   });
 
   it('dispose resets state to UNINITIALIZED', async () => {

--- a/packages/shared/src/interfaces/debug-adapter.ts
+++ b/packages/shared/src/interfaces/debug-adapter.ts
@@ -58,8 +58,10 @@ export interface IDebugAdapter extends EventEmitter {
   
   /**
    * Validate that the environment is properly configured for debugging
+   * @param executablePath Optional user-configured interpreter to validate. When provided,
+   *   validation should check this exact interpreter rather than an auto-detected one.
    */
-  validateEnvironment(): Promise<ValidationResult>;
+  validateEnvironment(executablePath?: string): Promise<ValidationResult>;
   
   /**
    * Get list of required dependencies for this adapter

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -435,7 +435,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     let executablePath = config.executablePath;
 
     if (this.adapter) {
-      const validation = await this.adapter.validateEnvironment();
+      // Validate the interpreter the user configured (if any) rather than an auto-detected one,
+      // so a venv that has debugpy is not rejected because the system Python lacks it (issue #106).
+      const validation = await this.adapter.validateEnvironment(executablePath);
       if (!validation.valid) {
         throw new Error(
           `Invalid environment for ${this.adapter.language}: ${validation.errors[0].message}`

--- a/tests/unit/adapter-python/python-debug-adapter.test.ts
+++ b/tests/unit/adapter-python/python-debug-adapter.test.ts
@@ -58,7 +58,9 @@ describe('PythonDebugAdapter', () => {
     expect(result.errors[0]?.code).toBe('PYTHON_VERSION_TOO_OLD');
   });
 
-  it('reports debugpy missing even when Python version passes checks', async () => {
+  it('reports missing debugpy as a warning when no interpreter was configured (issue #106)', async () => {
+    // With no explicit executablePath, debugpy may still be in the user's virtualenv, so a missing
+    // system debugpy is a warning (re-checked at launch), not a blocking error.
     const deps = createDependencies();
     const adapter = new PythonDebugAdapter(deps);
     (adapter as any).resolveExecutablePath = vi.fn().mockResolvedValue('/usr/bin/python');
@@ -68,8 +70,9 @@ describe('PythonDebugAdapter', () => {
 
     const result = await adapter.validateEnvironment();
 
-    expect(result.valid).toBe(false);
-    expect(result.errors.map((entry: { code: string }) => entry.code)).toContain('DEBUGPY_NOT_INSTALLED');
+    expect(result.valid).toBe(true);
+    expect(result.errors.map((entry: { code: string }) => entry.code)).not.toContain('DEBUGPY_NOT_INSTALLED');
+    expect(result.warnings.map((entry: { code: string }) => entry.code)).toContain('DEBUGPY_NOT_INSTALLED');
     expect(deps.logger.info).toHaveBeenCalledWith('[PythonDebugAdapter] Virtual environment detected');
   });
 

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -286,6 +286,36 @@ describe('ProxyManager.start', () => {
     expect(launchProxySpy).not.toHaveBeenCalled();
   });
 
+  it('validates the user-configured interpreter, not an auto-detected one (issue #106)', async () => {
+    const validateEnvironment = vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] });
+    const resolveExecutablePath = vi.fn();
+    const adapter = {
+      language: DebugLanguage.PYTHON,
+      validateEnvironment,
+      resolveExecutablePath
+    } as unknown as IDebugAdapter;
+
+    proxyManager = new ProxyManager(
+      adapter,
+      proxyProcessLauncher,
+      fileSystem,
+      logger
+    );
+
+    const config: ProxyConfig = {
+      ...baseConfig,
+      language: DebugLanguage.PYTHON,
+      executablePath: '/project/.venv/bin/python'
+    };
+
+    await proxyManager.start(config);
+
+    // The configured venv interpreter must be the one validated for debugpy.
+    expect(validateEnvironment).toHaveBeenCalledWith('/project/.venv/bin/python');
+    // A provided path is used directly — no auto-detection fallback.
+    expect(resolveExecutablePath).not.toHaveBeenCalled();
+  });
+
   describe('init retry handling', () => {
     beforeEach(() => {
       vi.useFakeTimers();


### PR DESCRIPTION
## Summary

Fixes #106 (a recurrence of #16). Python debugging failed with `debugpy not installed. Run: pip install debugpy` when **debugpy lived in the user's virtualenv** and the venv interpreter was passed as `executablePath`, because validation checked the wrong interpreter.

## Root cause

`PythonDebugAdapter.validateEnvironment()` resolved the interpreter via `this.resolveExecutablePath()` **with no argument**, so `findPythonExecutable(undefined, …)` auto-detected a system Python and `checkDebugpyInstalled()` ran against it — never the `executablePath` the user configured. `ProxyManager.prepareSpawnContext` had `config.executablePath` in hand but called `validateEnvironment()` without it. The factory's `validate()` was already softened for #16, but the adapter's launch-time check reintroduced the hard, wrong-interpreter failure.

## Fix

Thread the configured interpreter through so the **right** Python is validated:

- `IDebugAdapter.validateEnvironment(executablePath?)` — new optional param (backward compatible; the other 7 adapters keep their no-arg implementations).
- The Python adapter forwards it to `resolveExecutablePath()`. Missing debugpy is a **hard error when an explicit interpreter was given** (fail fast, with the exact path) but only a **warning when auto-detected** — consistent with the factory's #16 fix, so registration/init never blocks a virtualenv user.
- `ProxyManager.prepareSpawnContext` passes `config.executablePath` into `validateEnvironment` (order preserved: validate before resolve).

## Tests

- New adapter unit tests: `validateEnvironment` forwards the path; a configured venv with debugpy passes even when the system Python lacks it; explicit-missing → error, auto-detect-missing → warning. (Confirmed RED before the fix.)
- New proxy-manager test asserts the configured `executablePath` reaches `validateEnvironment`.
- Updated two existing tests that encoded the old wrong-interpreter semantics.
- Verified end-to-end against **real venvs** (one with debugpy, one without) using the built adapter. Full local suite: 2395 passed.

Reported with a clear repro and a proposed patch by @wdhongtw — thank you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)