### PR TITLE
ci(dependabot): add n-day cooldown and post-delay auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       day: monday
     commit-message:
       prefix: "ci"
+    # Supply-chain mitigation: only open a PR once a release has been public for a few
+    # days, giving the community a window to surface a bad/compromised release first.
+    # GitHub Actions supports only `default-days` (no semver-* granularity).
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: npm
     directory: /
@@ -18,6 +23,13 @@ updates:
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
+    # Supply-chain n-day delay before a PR is opened. Majors get a longer window since
+    # they are reviewed/merged manually anyway.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 3
 
   - package-ecosystem: pip
     directory: /mcp_debugger_launcher
@@ -26,3 +38,6 @@ updates:
       day: monday
     commit-message:
       prefix: "deps"
+    # pip supports only `default-days`.
+    cooldown:
+      default-days: 3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+# Enables GitHub auto-merge for low-risk Dependabot PRs. Combined with the `cooldown`
+# settings in .github/dependabot.yml, a PR is only opened after the package has been
+# public for the cooldown window, so auto-merge always happens AFTER that delay.
+#
+# Scope: semver-minor and semver-patch updates only (any ecosystem). Major bumps are
+# intentionally excluded so they are reviewed and merged manually.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Two related Dependabot hardening changes, motivated by wanting an n-day supply-chain delay before adopting new releases (so the community has a window to surface a bad/compromised package) while still keeping low-risk updates hands-off.

### 1. `cooldown` in `.github/dependabot.yml`

Dependabot only opens a PR once a release has been public for the cooldown window:

- npm: `default-days: 3`, `semver-major-days: 7` (majors are reviewed manually, so a longer window), `semver-minor-days: 3`, `semver-patch-days: 3`
- github-actions: `default-days: 3` (Actions supports only `default-days`)
- pip: `default-days: 3`

### 2. `.github/workflows/dependabot-auto-merge.yml` (new)

Enables GitHub auto-merge (squash) for Dependabot PRs, scoped to **semver-minor and semver-patch only**. Because a PR is only created *after* the cooldown window, auto-merge always happens after the delay. **Major bumps are intentionally excluded and remain manual.**

Uses `dependabot/fetch-metadata@v2` + `gh pr merge --auto --squash`, with `contents: write` / `pull-requests: write` permissions and the `GITHUB_TOKEN`.

## Context

This is the automation that was assumed to already exist: the 6 open Dependabot PRs (#100–#105) had **no conflicts** — they simply never auto-merged because nothing enabled auto-merge per-PR (`allow_auto_merge` is on at the repo level, but there was no workflow). #100–#104 have now been merged manually; this prevents the recurrence.

> Note: the auto-merge scope is minor/patch for **all** ecosystems (so a major GitHub Actions bump like checkout v7 also stays manual). If you'd prefer all Actions bumps to auto-merge regardless of semver level, adjust the `if:` condition in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)