### PR TITLE
fix(java-adapter): honor SKIP_ADAPTER_VENDOR and skip gracefully on old javac

### DIFF
--- a/packages/adapter-java/scripts/compile-jdi-bridge.js
+++ b/packages/adapter-java/scripts/compile-jdi-bridge.js
@@ -20,6 +20,7 @@ const JAVA_DIR = resolve(__dirname, '..', 'java');
 const SOURCE_FILE = resolve(JAVA_DIR, 'JdiDapServer.java');
 const OUT_DIR = resolve(JAVA_DIR, 'out');
 const CLASS_FILE = resolve(OUT_DIR, 'JdiDapServer.class');
+const TARGET_RELEASE = 21;
 
 function findJavac() {
   // Check JAVA_HOME first
@@ -40,6 +41,20 @@ function findJavac() {
   return null;
 }
 
+function getJavacMajorVersion(javac) {
+  try {
+    // `javac -version` prints "javac <major>.<minor>.<patch>" on stdout (JDK 9+)
+    const output = execFileSync(javac, ['-version'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    const match = /javac\s+(\d+)/.exec(output);
+    return match ? Number(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
 function needsCompilation() {
   if (!existsSync(CLASS_FILE)) return true;
   if (!existsSync(SOURCE_FILE)) return false; // nothing to compile
@@ -52,6 +67,11 @@ function needsCompilation() {
 function main() {
   if (process.env.SKIP_JDI_COMPILE) {
     console.log('[compile-jdi-bridge] Skipping (SKIP_JDI_COMPILE set)');
+    return;
+  }
+
+  if ((process.env.SKIP_ADAPTER_VENDOR || '').trim().toLowerCase() === 'true') {
+    console.log('[compile-jdi-bridge] Skipping (SKIP_ADAPTER_VENDOR=true)');
     return;
   }
 
@@ -68,7 +88,15 @@ function main() {
   const javac = findJavac();
   if (!javac) {
     console.warn('[compile-jdi-bridge] javac not found. JDI bridge will not be available.');
-    console.warn('[compile-jdi-bridge] Install JDK 21+ and ensure javac is on PATH or set JAVA_HOME.');
+    console.warn(`[compile-jdi-bridge] Install JDK ${TARGET_RELEASE}+ and ensure javac is on PATH or set JAVA_HOME.`);
+    // Don't fail hard — adapter will report the error at runtime
+    return;
+  }
+
+  const javacVersion = getJavacMajorVersion(javac);
+  if (javacVersion !== null && javacVersion < TARGET_RELEASE) {
+    console.warn(`[compile-jdi-bridge] javac ${javacVersion} is too old (need ${TARGET_RELEASE}+). JDI bridge will not be available.`);
+    console.warn(`[compile-jdi-bridge] Install JDK ${TARGET_RELEASE}+ and ensure javac is on PATH or set JAVA_HOME.`);
     // Don't fail hard — adapter will report the error at runtime
     return;
   }
@@ -79,7 +107,7 @@ function main() {
   console.log(`[compile-jdi-bridge] Compiling JdiDapServer.java with ${javac}`);
   try {
     execFileSync(javac, [
-      '--release', '21',
+      '--release', String(TARGET_RELEASE),
       SOURCE_FILE,
       '-d', OUT_DIR
     ], {


### PR DESCRIPTION
## Problem

The nightly **Flake Hunt** workflow has failed on every run since it was added in #110 — on both `ubuntu-latest` and `windows-latest` — before any tests execute:

```
packages/adapter-java build:adapter: error: release version 21 not supported
[compile-jdi-bridge] Compilation failed
ELIFECYCLE Command failed with exit code 1.
```

## Root cause

Flake Hunt intentionally installs no language toolchains and sets `SKIP_ADAPTER_VENDOR=true` on `pnpm install`. The rust and javascript vendor scripts honor that variable, but `compile-jdi-bridge.js` only honored its own `SKIP_JDI_COMPILE`, so the JDI bridge compile ran anyway. The hosted runners ship Temurin **17** as the default JDK (`/usr/lib/jvm/temurin-17-jdk-amd64`, `Java_Temurin-Hotspot_jdk\17.0.19-10`), and javac 17 cannot target `--release 21`, so the root postinstall hard-failed. Main CI never hits this because it runs `actions/setup-java` with JDK 21 before installing.

## Fix

- Skip JDI bridge compilation when `SKIP_ADAPTER_VENDOR=true`, matching the convention used by the rust/javascript vendor scripts (and documented in the README).
- When javac is present but older than JDK 21, warn and skip instead of failing the install — the same graceful degradation already used when javac is missing entirely ("adapter will report the error at runtime"). Genuine compile errors under JDK 21+ still fail hard, so main CI keeps its protection.

## Verification

All paths exercised by running the script directly on Windows:

- `SKIP_ADAPTER_VENDOR=true` → skip message, exit 0
- Normal run with JDK 21 → compiles successfully (javac under `C:\Program Files\...` — spaces handled via `execFileSync`)
- Too-old javac (simulated by temporarily raising the required release) → warns and exits 0
- Version regex handles `javac 17.0.19` → 17, `javac 21.0.10` → 21, `javac 25-ea` → 25, empty output → `null` (proceeds and lets javac itself report)

After merge, a `workflow_dispatch` run of Flake Hunt should confirm the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
