### PR TITLE
test: make adapter unit tests hermetic (fixes Flake Hunt, PR #112 flake)

### DIFF
--- a/packages/adapter-javascript/src/javascript-debug-adapter.ts
+++ b/packages/adapter-javascript/src/javascript-debug-adapter.ts
@@ -5,7 +5,6 @@
  */
 import { EventEmitter } from 'events';
 import * as path from 'path';
-import * as fs from 'fs';
 import { fileURLToPath } from 'url';
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import {
@@ -161,12 +160,9 @@ export class JavascriptDebugAdapter extends EventEmitter implements IDebugAdapte
       
       let found = false;
       for (const adapterPath of possiblePaths) {
-        try {
-          await fs.promises.access(adapterPath, fs.constants.R_OK);
+        if (await this.dependencies.fileSystem.pathExists(adapterPath)) {
           found = true;
           break;
-        } catch {
-          // Continue checking other paths
         }
       }
       
@@ -254,12 +250,12 @@ export class JavascriptDebugAdapter extends EventEmitter implements IDebugAdapte
       '/app/node_modules/@debugmcp/adapter-javascript/vendor/js-debug/vsDebugServer.cjs'
     ];
     
-    const adapterPath = possiblePaths.find(p => fs.existsSync(p));
-    
+    const adapterPath = possiblePaths.find(p => this.dependencies.fileSystem.existsSync(p));
+
     if (!adapterPath) {
       this.dependencies.logger?.error?.(`[JavascriptDebugAdapter] js-debug vendor file not found. Searched paths:`);
       possiblePaths.forEach(p => {
-        this.dependencies.logger?.error?.(`  ${p}: ${fs.existsSync(p) ? 'EXISTS' : 'NOT FOUND'}`);
+        this.dependencies.logger?.error?.(`  ${p}: NOT FOUND`);
       });
       
       throw new AdapterError(

--- a/packages/adapter-javascript/tests/unit/factory-export.test.ts
+++ b/packages/adapter-javascript/tests/unit/factory-export.test.ts
@@ -28,7 +28,8 @@ describe('@debugmcp/adapter-javascript package', () => {
   test('initialize transitions to READY and emits initialized', async () => {
     const factory = new JavascriptAdapterFactory();
     const deps: AdapterDependencies = {
-      fileSystem: {} as unknown as IFileSystem,
+      // Report the vendored js-debug as present so validateEnvironment passes hermetically
+      fileSystem: { pathExists: async () => true } as unknown as IFileSystem,
       logger: { debug() {}, info() {}, warn() {}, error() {} } as unknown as ILogger,
       environment: {} as unknown as IEnvironment
     };

--- a/packages/adapter-javascript/tests/unit/javascript-debug-adapter.command.edge.test.ts
+++ b/packages/adapter-javascript/tests/unit/javascript-debug-adapter.command.edge.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { JavascriptDebugAdapter } from '../../src/index.js';
 
-// Minimal AdapterDependencies stub
+// Minimal AdapterDependencies stub — fileSystem reports the vendored js-debug as
+// present so these tests stay hermetic (no dependency on a real vendor/ dir).
 const deps = {
   logger: {
     info: () => {},
     error: () => {},
     debug: () => {},
     warn: () => {}
+  },
+  fileSystem: {
+    existsSync: () => true,
+    pathExists: async () => true
   }
 } as unknown as import('@debugmcp/shared').AdapterDependencies;
 

--- a/packages/adapter-javascript/tests/unit/javascript-debug-adapter.command.test.ts
+++ b/packages/adapter-javascript/tests/unit/javascript-debug-adapter.command.test.ts
@@ -11,13 +11,18 @@ function isVendorPath(p: unknown): boolean {
   return norm(p).endsWith('/vendor/js-debug/vsDebugServer.cjs');
 }
 
-// Minimal AdapterDependencies stub (adapter does not use dependencies in buildAdapterCommand)
+// Minimal AdapterDependencies stub — fileSystem reports the vendored js-debug as
+// present so these tests stay hermetic (no dependency on a real vendor/ dir).
 const deps = {
   logger: {
     info: () => {},
     error: () => {},
     debug: () => {},
     warn: () => {}
+  },
+  fileSystem: {
+    existsSync: () => true,
+    pathExists: async () => true
   },
   // Cast to satisfy type system in tests
 } as unknown as import('@debugmcp/shared').AdapterDependencies;

--- a/packages/adapter-javascript/tests/unit/javascript-debug-adapter.command.test.ts
+++ b/packages/adapter-javascript/tests/unit/javascript-debug-adapter.command.test.ts
@@ -133,3 +133,41 @@ describe('JavascriptDebugAdapter.buildAdapterCommand (stdio)', () => {
     expect(process.env.NODE_OPTIONS).toBe('--MAX-OLD-SPACE-SIZE=2048   --trace-warnings');
   });
 });
+
+describe('JavascriptDebugAdapter with vendored js-debug absent', () => {
+  const missingDeps = {
+    logger: {
+      info: () => {},
+      error: () => {},
+      debug: () => {},
+      warn: () => {}
+    },
+    fileSystem: {
+      existsSync: () => false,
+      pathExists: async () => false
+    }
+  } as unknown as import('@debugmcp/shared').AdapterDependencies;
+
+  const config = {
+    sessionId: 'test-session',
+    executablePath: '/usr/bin/node',
+    adapterHost: '127.0.0.1',
+    adapterPort: 12345,
+    logDir: '/tmp/logs',
+    scriptPath: '/tmp/app.js',
+    launchConfig: {}
+  } as unknown as import('@debugmcp/shared').AdapterConfig;
+
+  it('buildAdapterCommand throws when the vendored js-debug cannot be found', () => {
+    const adapter = new JavascriptDebugAdapter(missingDeps);
+    expect(() => adapter.buildAdapterCommand(config)).toThrow(/js-debug vendor file not found/);
+  });
+
+  it('validateEnvironment reports JS_DEBUG_NOT_FOUND when the bundle is absent', async () => {
+    const adapter = new JavascriptDebugAdapter(missingDeps);
+    const result = await adapter.validateEnvironment();
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]?.code).toBe('JS_DEBUG_NOT_FOUND');
+  });
+});

--- a/packages/adapter-rust/tests/rust-adapter.test.ts
+++ b/packages/adapter-rust/tests/rust-adapter.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { RustDebugAdapter } from '../src/rust-debug-adapter.js';
 import { RustAdapterFactory } from '../src/rust-adapter-factory.js';
-import { 
+import {
   AdapterState,
   DebugLanguage,
   DebugFeature,
@@ -13,6 +13,21 @@ import {
   AdapterConfig
 } from '@debugmcp/shared';
 import * as path from 'path';
+
+// RustAdapterFactory.validate() probes the real environment (vendored CodeLLDB on
+// disk, `cargo`/`rustc` spawns). Mock those probes so this suite is hermetic and
+// deterministic — no toolchain requirements, no spawn stalls under load.
+vi.mock('../src/utils/codelldb-resolver.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  resolveCodeLLDBExecutable: vi.fn(async () => '/mock/vendor/codelldb'),
+  getCodeLLDBVersion: vi.fn(async () => '1.11.0')
+}));
+vi.mock('../src/utils/rust-utils.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  checkCargoInstallation: vi.fn(async () => true),
+  getCargoVersion: vi.fn(async () => 'cargo 1.99.0'),
+  getRustHostTriple: vi.fn(async () => 'x86_64-unknown-linux-gnu')
+}));
 
 // Mock dependencies
 const mockDependencies: AdapterDependencies = {
@@ -266,14 +281,32 @@ describe('RustAdapterFactory', () => {
   });
   
   it('should validate environment', async () => {
-    // This will check for CodeLLDB and Cargo installation
+    // CodeLLDB/cargo probes are mocked (see vi.mock at top) — assert deterministically
     const result = await factory.validate();
-    
-    // Result will vary based on actual environment
-    expect(result).toHaveProperty('valid');
-    expect(result).toHaveProperty('errors');
-    expect(result).toHaveProperty('warnings');
-    expect(result.details).toHaveProperty('platform');
-    expect(result.details).toHaveProperty('arch');
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.details).toMatchObject({
+      codelldbPath: '/mock/vendor/codelldb',
+      codelldbVersion: '1.11.0',
+      cargoVersion: 'cargo 1.99.0',
+      hostTriple: 'x86_64-unknown-linux-gnu',
+      platform: process.platform,
+      arch: process.arch
+    });
+  });
+
+  it('should report an error when CodeLLDB is missing and a warning when cargo is missing', async () => {
+    const { resolveCodeLLDBExecutable } = await import('../src/utils/codelldb-resolver.js');
+    const { checkCargoInstallation } = await import('../src/utils/rust-utils.js');
+    vi.mocked(resolveCodeLLDBExecutable).mockResolvedValueOnce(null);
+    vi.mocked(checkCargoInstallation).mockResolvedValueOnce(false);
+
+    const result = await factory.validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('CodeLLDB not found'))).toBe(true);
+    expect(result.warnings.some(w => w.includes('Cargo not found'))).toBe(true);
   });
 });

--- a/tests/unit/shared/adapter-policy-go.test.ts
+++ b/tests/unit/shared/adapter-policy-go.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
 import { GoAdapterPolicy } from '../../../packages/shared/src/interfaces/adapter-policy-go.js';
 import { SessionState } from '@debugmcp/shared';
+
+// validateExecutable dynamically imports child_process — mock it so no real
+// process is ever spawned (hermetic; no dependency on installed tools or load).
+vi.mock('child_process', () => ({ spawn: vi.fn() }));
+
+/** Fake child whose stdout/exit/error behavior is scripted per test. */
+function mockSpawnChild(script: (child: EventEmitter & { stdout: EventEmitter }) => void): void {
+  vi.mocked(spawn).mockImplementationOnce(() => {
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter };
+    child.stdout = new EventEmitter();
+    // Emit after validateExecutable has attached its listeners
+    setImmediate(() => script(child));
+    return child as unknown as ReturnType<typeof spawn>;
+  });
+}
 
 describe('GoAdapterPolicy', () => {
   // ===== Identity =====
@@ -437,15 +454,39 @@ describe('GoAdapterPolicy', () => {
   // ===== validateExecutable =====
 
   describe('validateExecutable', () => {
-    it('resolves true for a command that exists and exits 0', async () => {
-      // validateExecutable runs `command version` — git supports `git version`
-      const result = await GoAdapterPolicy.validateExecutable!('git');
+    it('resolves true when the command produces output and exits 0', async () => {
+      mockSpawnChild((child) => {
+        child.stdout.emit('data', 'Delve Debugger Version: 1.0.0');
+        child.emit('exit', 0);
+      });
+      const result = await GoAdapterPolicy.validateExecutable!('dlv');
       expect(result).toBe(true);
-    }, 10000);
+      expect(spawn).toHaveBeenCalledWith('dlv', ['version'], expect.anything());
+    });
 
-    it('resolves false for a command that does not exist', async () => {
+    it('resolves false when the command does not exist (spawn error)', async () => {
+      mockSpawnChild((child) => {
+        child.emit('error', new Error('spawn ENOENT'));
+      });
       const result = await GoAdapterPolicy.validateExecutable!('nonexistent_command_that_does_not_exist_12345');
       expect(result).toBe(false);
-    }, 10000);
+    });
+
+    it('resolves false when the command exits non-zero', async () => {
+      mockSpawnChild((child) => {
+        child.stdout.emit('data', 'some error text');
+        child.emit('exit', 1);
+      });
+      const result = await GoAdapterPolicy.validateExecutable!('dlv');
+      expect(result).toBe(false);
+    });
+
+    it('resolves false when the command exits 0 without output', async () => {
+      mockSpawnChild((child) => {
+        child.emit('exit', 0);
+      });
+      const result = await GoAdapterPolicy.validateExecutable!('dlv');
+      expect(result).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Problem

With #116 merged, Flake Hunt executes for the first time — and fails deterministically on both OSes ([validation run](https://github.com/debugmcp/mcp-debugger/actions/runs/28575215007)): several unit tests depend on the machine environment, exactly the hermeticity bug class the workflow header calls out. Two of them also fail outside Flake Hunt: the rust `should validate environment` test flaked PR #112's Windows CI job and local pre-push runs (15s timeout under load, 155ms in isolation).

## Changes

**adapter-javascript** — `buildAdapterCommand()` and `validateEnvironment()` located the vendored js-debug bundle with direct `fs` calls, so 9 pure-logic tests (NODE_OPTIONS handling, arg construction, initialize lifecycle) failed wherever vendoring was skipped. They now use the injected `AdapterDependencies.fileSystem` — the DI seam that already exists and that production callers (`adapter-registry.ts`) always populate with the full `IFileSystem`. Tests stub it.

**adapter-policy-go** — the `validateExecutable` tests spawned a real `git` process (timing out under parallel load: 5/20 Flake Hunt runs). `child_process` is now mocked with a scripted fake child. Bonus coverage: exit-nonzero and exit-0-without-output paths, untestable against real processes.

**adapter-rust** — `RustAdapterFactory.validate()` probed the real environment (vendored CodeLLDB on disk, `cargo`/`rustc` spawns) and the test asserted only result shape "since results vary by environment". The probes are now module-mocked and results asserted exactly. Bonus coverage: missing-CodeLLDB error + missing-cargo warning case.

## Verification

- **Flake Hunt environment reproduced locally**: renamed both `vendor/` directories away and re-ran all affected files — 82/82 pass with no vendored artifacts on disk.
- Full `unit` project: 2290/2290 pass.
- Local flake hunt (`FLAKE_RUNS=3`, within-file shuffle): 3/3 seeds green.
- `@debugmcp/adapter-javascript` builds; lint clean.
- Flake Hunt dispatched on this branch (link in comments) as the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
