### PR TITLE
fix(tests): unbreak npx e2e guard and docker image staleness check

### DIFF
--- a/scripts/docker-build-if-needed.js
+++ b/scripts/docker-build-if-needed.js
@@ -41,15 +41,22 @@ async function restorePackageManifestIfNeeded() {
   }
 }
 
+// Runtime and build artifacts that .dockerignore excludes from the image
+// (logs, dist, pack output, ...). Tests write logs under packages/ mid-run,
+// so counting these mtimes would mark a just-built image as stale and force
+// a needless (and destructive) rebuild between suites of the same run.
+const SKIPPED_DIRS = new Set(['node_modules', 'logs', 'dist', 'package-cache', 'package', 'sessions', 'coverage']);
+const SKIPPED_FILE_PATTERN = /\.(log|tsbuildinfo|tgz)$/;
+
 function getLatestModifiedTime(dir, newestTime = new Date(0)) {
   const entries = readdirSync(dir, { withFileTypes: true });
 
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
 
-    if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
+    if (entry.isDirectory() && !entry.name.startsWith('.') && !SKIPPED_DIRS.has(entry.name)) {
       newestTime = getLatestModifiedTime(fullPath, newestTime);
-    } else if (entry.isFile()) {
+    } else if (entry.isFile() && !SKIPPED_FILE_PATTERN.test(entry.name)) {
       const stats = statSync(fullPath);
       if (stats.mtime > newestTime) {
         newestTime = stats.mtime;
@@ -90,12 +97,27 @@ async function main() {
   let imageBuildTime = null;
 
   try {
-    const output = execSync(`docker inspect ${IMAGE_NAME} --format="{{.Created}}"`, {
+    // Prefer LastTagTime over Created: with BuildKit layer caching, a rebuild
+    // that fully cache-hits produces an identical image whose Created is the
+    // ORIGINAL build time, so comparing against Created marks the image as
+    // outdated forever. LastTagTime advances on every successful build.
+    const output = execSync(`docker inspect ${IMAGE_NAME} --format="{{.Created}}|{{json .Metadata.LastTagTime}}"`, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore']
     });
     imageExists = true;
-    imageBuildTime = new Date(output.trim());
+    const [created, lastTagJson] = output.trim().split('|');
+    let buildTime = new Date(created);
+    try {
+      const lastTag = new Date(JSON.parse(lastTagJson));
+      // Zero value ("0001-01-01...") means the tag time is unknown (e.g. pulled image)
+      if (!isNaN(lastTag) && lastTag.getFullYear() > 1971 && lastTag > buildTime) {
+        buildTime = lastTag;
+      }
+    } catch {
+      // Malformed/missing LastTagTime — fall back to Created
+    }
+    imageBuildTime = buildTime;
   } catch {
     imageExists = false;
   }
@@ -156,15 +178,9 @@ async function main() {
 
   if (needsBuild) {
     try {
-      if (imageExists) {
-        console.log(`[Docker Build] Removing old ${IMAGE_NAME} image...`);
-        try {
-          execSync(`docker rmi ${IMAGE_NAME}`, { stdio: 'inherit' });
-        } catch {
-          console.warn('[Docker Build] Warning: Could not remove old image');
-        }
-      }
-
+      // No pre-build `docker rmi`: a successful `docker build -t` retags
+      // atomically (the old image just goes dangling), and a failed rebuild
+      // must leave the previous working image in place for other suites.
       console.log(`[Docker Build] Building ${IMAGE_NAME}...`);
       const timestamp = Date.now();
       execSync(`docker build . -t ${IMAGE_NAME} --build-arg CACHEBUST=${timestamp}`, {

--- a/tests/e2e/docker/docker-test-utils.ts
+++ b/tests/e2e/docker/docker-test-utils.ts
@@ -49,6 +49,9 @@ export async function buildDockerImage(config: DockerTestConfig = {}): Promise<v
       try {
         await execAsync(`node "${scriptPath}"`, {
           cwd: ROOT,
+          // Full docker build output flows through here; the 1MB default
+          // maxBuffer would kill an otherwise-succeeding build.
+          maxBuffer: 64 * 1024 * 1024,
           env: {
             ...process.env,
             DOCKER_IMAGE_NAME: imageName
@@ -56,6 +59,15 @@ export async function buildDockerImage(config: DockerTestConfig = {}): Promise<v
         });
       } catch (error) {
         dockerBuildPromise = null;
+        // Surface the build output — exec errors otherwise show only
+        // "Command failed: node ..." with no hint of what broke.
+        const execError = error as Error & { stdout?: string; stderr?: string };
+        if (execError.stdout) {
+          console.error('[Docker Test] Build stdout:\n' + execError.stdout);
+        }
+        if (execError.stderr) {
+          console.error('[Docker Test] Build stderr:\n' + execError.stderr);
+        }
         throw error;
       }
     })();
@@ -66,7 +78,7 @@ export async function buildDockerImage(config: DockerTestConfig = {}): Promise<v
 
 async function runDockerBuild(imageName: string): Promise<void> {
   try {
-    const { stderr } = await execAsync(`docker build -t ${imageName} .`, { cwd: ROOT });
+    const { stderr } = await execAsync(`docker build -t ${imageName} .`, { cwd: ROOT, maxBuffer: 64 * 1024 * 1024 });
     if (stderr && stderr.trim().length > 0) {
       console.warn('[Docker Test] Build warnings:', stderr);
     }

--- a/tests/e2e/npx/npx-test-utils.ts
+++ b/tests/e2e/npx/npx-test-utils.ts
@@ -27,7 +27,9 @@ const PACK_CACHE_DIR = path.join(PACKAGE_DIR, 'package-cache');
 const PACKAGE_JSON_PATH = path.join(PACKAGE_DIR, 'package.json');
 const PACKAGE_BACKUP_PATH = path.join(PACKAGE_DIR, 'package.json.backup');
 const ROOT_DIST_DIR = path.join(ROOT, 'dist');
-const ROOT_BUNDLE_ENTRY = path.join(ROOT_DIST_DIR, 'bundle.cjs');
+// dist/index.js is what `npm run build` (tsc) emits; dist/bundle.cjs exists
+// only inside the Docker image build and must not be required here.
+const ROOT_DIST_ENTRY = path.join(ROOT_DIST_DIR, 'index.js');
 const PACKAGE_DIST_ENTRY = path.join(PACKAGE_DIST_DIR, 'cli.mjs');
 
 async function acquirePackLock(): Promise<void> {
@@ -86,12 +88,12 @@ async function pathExists(filePath: string): Promise<boolean> {
 // Fail fast if the workspace hasn't been built. Building is the job of the
 // `pretest:e2e:npx` npm hook (build once), not of each test.
 async function ensureWorkspaceBuilt(): Promise<void> {
-  const needsRootBuild = !(await pathExists(ROOT_BUNDLE_ENTRY));
+  const needsRootBuild = !(await pathExists(ROOT_DIST_ENTRY));
   const needsPackageBuild = !(await pathExists(PACKAGE_DIST_ENTRY));
 
   if (needsRootBuild || needsPackageBuild) {
     const missing = [
-      needsRootBuild ? `root bundle (${ROOT_BUNDLE_ENTRY})` : null,
+      needsRootBuild ? `root dist (${ROOT_DIST_ENTRY})` : null,
       needsPackageBuild ? `mcp-debugger package dist (${PACKAGE_DIST_ENTRY})` : null
     ].filter(Boolean).join(' and ');
     throw new Error(


### PR DESCRIPTION
## Summary

Fixes three local e2e failures that appeared after the #110 test refactor: both npx smoke suites failing deterministically, and the docker javascript smoke failing flakily mid-run.

### npx smokes: guard checked an artifact the host build never produces

`ensureWorkspaceBuilt()` in `tests/e2e/npx/npx-test-utils.ts` failed fast unless `dist/bundle.cjs` exists — but that file is created only by `scripts/bundle.js` **inside the Dockerfile builder stage**; no host `npm run build` ever produces it. Before #110 the check silently ran `pnpm build` when the file was missing (which also never created it) and proceeded, so it was vestigial; the fail-fast conversion turned it into a guaranteed failure on every freshly built workspace. CI never runs the npx suites, so it went unnoticed.

Fix: point the guard at `dist/index.js`, which the host build actually emits. The `packages/mcp-debugger/dist/cli.mjs` check (what the pack actually consumes) is unchanged.

### docker smoke: false-stale scan → destructive rmi → transient network failure

Evidence-backed chain (from file mtimes, `docker images`, and `docker buildx history logs` of the failed build):

1. `scripts/docker-build-if-needed.js` compared image age against the newest file under `src/`, `scripts/`, `packages/` — including **runtime artifacts** (`packages/logs/*.log` written by earlier suites in the same run, pack tarballs, `packages/*/dist`), all of which `.dockerignore` excludes from the image anyway. A just-built, working `mcp-debugger:test` image was declared outdated mid-run.
2. The script ran `docker rmi` **before** rebuilding, destroying the working image.
3. The forced rebuild died in `pnpm install` on a transient DNS failure (`ENOTFOUND registry.npmjs.org`), leaving no image at all.

Fixes in `scripts/docker-build-if-needed.js`:
- Skip `.dockerignore`'d runtime/build artifacts in the mtime scan (`logs`, `dist`, `package-cache`, pack output, `*.log`/`*.tsbuildinfo`/`*.tgz`).
- Drop the pre-build `docker rmi`: `docker build -t` retags atomically on success, and a failed rebuild now leaves the previous working image in place for sibling suites and reruns (still exits 1 — no silent fallback).
- Compare against `Metadata.LastTagTime` instead of `Created`: BuildKit cache-hit rebuilds reproduce an identical image whose `Created` is the *original* build time, so images looked permanently outdated (found during verification — every run was rebuilding).

Hardening in `tests/e2e/docker/docker-test-utils.ts`: 64 MB `maxBuffer` on the build `exec` calls (the 1 MB default can kill an otherwise-succeeding build) and build stdout/stderr is logged on failure instead of a bare `Command failed: node …`.

## Verification

- `npm run test:e2e:npx` — 2 files / 4 tests pass (previously both suites threw at the guard immediately after a fresh build).
- `tests/e2e/docker/docker-smoke-javascript.test.ts` — 5/5 pass.
- Appending to `packages/logs/debug-mcp-server.log` (the exact mid-run trigger) → `[Docker Build] Image is up to date`, no rebuild.
- Touching `src/index.ts` → rebuild correctly triggered; the following run reports up to date (no more permanent-stale loop).
- Pre-push hook: lint, clean build, 2292 unit + 21 integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
