### PR TITLE
fix(session): report correct state from pause_execution

### DIFF
--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -1192,40 +1192,129 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       return { success: false, error: `Cannot pause in state: ${session.state}`, state: session.state };
     }
 
-    try {
-      this.logger.debug(`[SessionManager] pauseExecution: sending DAP pause for session=${sessionId} currentState=${session.state}`);
-      // DAP pause request: threadId 0 should pause all threads per DAP spec,
-      // but some adapters (e.g. netcoredbg) reject threadId=0 with E_INVALIDARG.
-      // When no explicit threadId is provided, discover one via a threads request.
-      let effectiveThreadId = threadId ?? 0;
-      if (effectiveThreadId === 0) {
-        try {
-          const threadsResp = await session.proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {});
-          const threads = threadsResp?.body?.threads;
-          if (Array.isArray(threads) && threads.length > 0 && typeof threads[0]?.id === 'number') {
-            effectiveThreadId = threads[0].id;
-            this.logger.info(`[SessionManager pause] Auto-discovered threadId=${effectiveThreadId} for pause`);
-          }
-        } catch {
-          // threads request failed — fall through with threadId=0
+    this.logger.debug(`[SessionManager] pauseExecution: sending DAP pause for session=${sessionId} currentState=${session.state}`);
+    // DAP pause request: threadId 0 should pause all threads per DAP spec,
+    // but some adapters (e.g. netcoredbg) reject threadId=0 with E_INVALIDARG.
+    // When no explicit threadId is provided, discover one via a threads request.
+    let effectiveThreadId = threadId ?? 0;
+    if (effectiveThreadId === 0) {
+      try {
+        const threadsResp = await session.proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {});
+        const threads = threadsResp?.body?.threads;
+        if (Array.isArray(threads) && threads.length > 0 && typeof threads[0]?.id === 'number') {
+          effectiveThreadId = threads[0].id;
+          this.logger.info(`[SessionManager pause] Auto-discovered threadId=${effectiveThreadId} for pause`);
         }
+      } catch {
+        // threads request failed — fall through with threadId=0
       }
-      await session.proxyManager.sendDapRequest('pause', { threadId: effectiveThreadId });
-
-      this.logger.info(
-        `[SessionManager pause] DAP 'pause' sent for session ${sessionId}. Waiting for stopped event.`
-      );
-
-      // The stopped event handler will set state to PAUSED and update threadId.
-      // Return success — the caller should poll or wait for state change.
-      return { success: true, state: session.state };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(
-        `[SessionManager pause] Error sending 'pause' for session ${sessionId}: ${errorMessage}`
-      );
-      throw error;
     }
+
+    const proxyManager = session.proxyManager;
+
+    // The pause response only acknowledges the request; the state transition
+    // to PAUSED happens when the asynchronous 'stopped' event is handled by
+    // the core handleStopped listener. Adapters differ on whether the event
+    // arrives before or after the response, so listen for it (registered
+    // BEFORE sending the request) and only settle once the stop is observed.
+    return new Promise<DebugResult>((resolve, reject) => {
+      let settled = false;
+      let stopEventSeen = false;
+
+      const cleanup = () => {
+        proxyManager.off('stopped', onStopped);
+        proxyManager.off('terminated', onEnded);
+        proxyManager.off('exited', onEnded);
+        proxyManager.off('exit', onEnded);
+        clearTimeout(timeout);
+      };
+
+      const settle = (result: DebugResult) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(result);
+      };
+
+      const onStopped = async () => {
+        stopEventSeen = true;
+        // Try to get current location from stack trace
+        let location: { file: string; line: number; column?: number } | undefined;
+        try {
+          // Wait a brief moment for state to settle after stopped event
+          await new Promise(resolve => setTimeout(resolve, 10));
+
+          const stackFrames = await this.getStackTrace(sessionId);
+          if (stackFrames && stackFrames.length > 0) {
+            const topFrame = stackFrames[0];
+            location = {
+              file: topFrame.file,
+              line: topFrame.line,
+              column: topFrame.column
+            };
+          }
+        } catch (error) {
+          this.logger.debug(`[SessionManager pause ${sessionId}] Could not capture location:`, error);
+        }
+        this.logger.info(
+          `[SessionManager pause] Paused session ${sessionId}. Current state: ${session.state}`
+        );
+        const data: { message: string; location?: { file: string; line: number; column?: number } } = { message: 'Paused' };
+        if (location) {
+          data.location = location;
+        }
+        settle({ success: true, state: session.state, data });
+      };
+
+      const onEnded = () => settle({
+        success: true,
+        state: session.state,
+        data: { message: 'Session ended before pause took effect' }
+      });
+
+      const timeout = setTimeout(() => {
+        this.logger.warn(
+          `[SessionManager pause] Timeout waiting for stopped event in session ${sessionId}`
+        );
+        settle({
+          success: false,
+          error: ErrorMessages.pauseTimeout(5),
+          state: session.state,
+        });
+      }, 5000);
+
+      proxyManager.on('stopped', onStopped);
+      proxyManager.on('terminated', onEnded);
+      proxyManager.on('exited', onEnded);
+      proxyManager.on('exit', onEnded);
+
+      proxyManager
+        .sendDapRequest('pause', { threadId: effectiveThreadId })
+        .then(() => {
+          this.logger.info(
+            `[SessionManager pause] DAP 'pause' sent for session ${sessionId}. Waiting for stopped event.`
+          );
+          // Guard: if the stopped event fired before the listeners above were
+          // registered (e.g. during the threads-discovery await), the state is
+          // already PAUSED and no further event will arrive.
+          if (session.state === SessionState.PAUSED && !stopEventSeen) {
+            settle({ success: true, state: session.state, data: { message: 'Paused' } });
+          }
+        })
+        .catch((error: unknown) => {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          this.logger.error(
+            `[SessionManager pause] Error sending 'pause' for session ${sessionId}: ${errorMessage}`
+          );
+          if (!settled) {
+            settled = true;
+            cleanup();
+            reject(error instanceof Error ? error : new Error(errorMessage));
+          }
+        });
+    });
   }
 
   async listThreads(sessionId: string): Promise<Array<{ id: number; name: string }>> {

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -40,7 +40,20 @@ export const ErrorMessages = {
     `Step operation did not complete within ${timeout}s. ` +
     `The debug adapter may have crashed or the program may be stuck. ` +
     `Try restarting your debug session.`,
-  
+
+  /**
+   * Error message for pause operation timeouts
+   * Occurs when: A pause request doesn't receive a 'stopped' event within the timeout
+   * Used in: src/session/session-manager-operations.ts
+   * Default timeout: 5 seconds
+   * @param timeout - The timeout duration in seconds
+   */
+  pauseTimeout: (timeout: number) =>
+    `Pause request was accepted but no 'stopped' event arrived within ${timeout}s. ` +
+    `The program may not be pausable right now (e.g. blocked in native code). ` +
+    `Check the session state or try again.`,
+
+
   /**
    * Error message for adapter ready timeouts
    * Occurs when: Waiting for the debug adapter to be configured times out

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -2331,14 +2331,42 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
   });
 
   describe('pause with threadId', () => {
+    // pause() waits for the 'stopped' event before resolving, so these tests
+    // capture the registered handlers and emit 'stopped' the way the real
+    // ProxyManager would (after the core handleStopped listener has already
+    // flipped the session state to PAUSED).
+    let handlers: Record<string, Function[]>;
+
+    const emit = (event: string, ...args: unknown[]) => {
+      (handlers[event] ?? []).forEach(fn => fn(...args));
+    };
+
+    const emitStopped = () => {
+      mockSession.state = SessionState.PAUSED; // core handleStopped runs first
+      emit('stopped', 1, 'pause');
+    };
+
+    beforeEach(() => {
+      handlers = {};
+      mockProxyManager.on.mockImplementation((event: string, handler: Function) => {
+        (handlers[event] ??= []).push(handler);
+        return mockProxyManager;
+      });
+    });
+
     it('should pass specific threadId to DAP request', async () => {
       mockSession.state = SessionState.RUNNING;
       mockProxyManager.sendDapRequest.mockResolvedValue({});
 
-      const result = await operations.pause('test-session', 42);
+      const promise = operations.pause('test-session', 42);
+      await vi.waitFor(() => {
+        expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 42 });
+      });
+      emitStopped();
+      const result = await promise;
 
       expect(result.success).toBe(true);
-      expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 42 });
+      expect(result.state).toBe(SessionState.PAUSED);
     });
 
     it('should auto-discover threadId when not provided', async () => {
@@ -2349,12 +2377,16 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         .mockResolvedValueOnce({ body: { threads: [{ id: 7, name: 'Main' }] } })
         .mockResolvedValueOnce({});
 
-      const result = await operations.pause('test-session');
+      const promise = operations.pause('test-session');
+      await vi.waitFor(() => {
+        expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 7 });
+      });
+      emitStopped();
+      const result = await promise;
 
       expect(result.success).toBe(true);
       // Should have called threads first, then pause with discovered threadId
       expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('threads', {});
-      expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 7 });
     });
 
     it('should fall back to threadId=0 when threads request fails', async () => {
@@ -2364,10 +2396,14 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         .mockRejectedValueOnce(new Error('not connected'))
         .mockResolvedValueOnce({});
 
-      const result = await operations.pause('test-session');
+      const promise = operations.pause('test-session');
+      await vi.waitFor(() => {
+        expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 0 });
+      });
+      emitStopped();
+      const result = await promise;
 
       expect(result.success).toBe(true);
-      expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 0 });
     });
 
     it('should fall back to threadId=0 when threads response has no threads', async () => {
@@ -2377,10 +2413,110 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         .mockResolvedValueOnce({ body: { threads: [] } })
         .mockResolvedValueOnce({});
 
+      const promise = operations.pause('test-session');
+      await vi.waitFor(() => {
+        expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 0 });
+      });
+      emitStopped();
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+    });
+
+    it('reports state PAUSED when stopped arrives after the pause response (the common adapter ordering)', async () => {
+      mockSession.state = SessionState.RUNNING;
+      mockProxyManager.sendDapRequest.mockResolvedValue({});
+
+      const promise = operations.pause('test-session', 1);
+      // Let the pause response resolve first — state must still be RUNNING here
+      await vi.waitFor(() => {
+        expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 1 });
+      });
+      expect(mockSession.state).toBe(SessionState.RUNNING);
+      emitStopped();
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.state).toBe(SessionState.PAUSED);
+    });
+
+    it('reports state PAUSED when stopped arrives before the pause response resolves (netcoredbg ordering)', async () => {
+      mockSession.state = SessionState.RUNNING;
+      // Emit 'stopped' from inside the pause request, before its promise resolves
+      mockProxyManager.sendDapRequest.mockImplementation((command: string) => {
+        if (command === 'pause') {
+          emitStopped();
+        }
+        return Promise.resolve({});
+      });
+
+      const result = await operations.pause('test-session', 1);
+
+      expect(result.success).toBe(true);
+      expect(result.state).toBe(SessionState.PAUSED);
+    });
+
+    it('reports state PAUSED when the stop happened during thread discovery (no further event arrives)', async () => {
+      mockSession.state = SessionState.RUNNING;
+      // The stop lands while awaiting the 'threads' request, before the
+      // stopped listeners are registered — the post-response guard covers it.
+      mockProxyManager.sendDapRequest.mockImplementation((command: string) => {
+        if (command === 'threads') {
+          mockSession.state = SessionState.PAUSED;
+          return Promise.resolve({ body: { threads: [{ id: 3, name: 'Main' }] } });
+        }
+        return Promise.resolve({});
+      });
+
       const result = await operations.pause('test-session');
 
       expect(result.success).toBe(true);
-      expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 0 });
+      expect(result.state).toBe(SessionState.PAUSED);
+    });
+
+    it('returns a pause-timeout error when no stopped event arrives', async () => {
+      vi.useFakeTimers();
+      try {
+        mockSession.state = SessionState.RUNNING;
+        mockProxyManager.sendDapRequest.mockResolvedValue({});
+
+        const promise = operations.pause('test-session', 1);
+        await vi.advanceTimersByTimeAsync(5000);
+        const result = await promise;
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("no 'stopped' event");
+        expect(result.state).toBe(SessionState.RUNNING);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('resolves gracefully when the session terminates while waiting', async () => {
+      mockSession.state = SessionState.RUNNING;
+      mockProxyManager.sendDapRequest.mockResolvedValue({});
+
+      const promise = operations.pause('test-session', 1);
+      await vi.waitFor(() => {
+        expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 1 });
+      });
+      emit('terminated');
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.data?.message).toContain('Session ended');
+    });
+
+    it('rejects when the pause request itself fails', async () => {
+      mockSession.state = SessionState.RUNNING;
+      mockProxyManager.sendDapRequest.mockImplementation((command: string) => {
+        if (command === 'pause') {
+          return Promise.reject(new Error('pause not supported'));
+        }
+        return Promise.resolve({ body: { threads: [{ id: 1, name: 'Main' }] } });
+      });
+
+      await expect(operations.pause('test-session', 1)).rejects.toThrow('pause not supported');
     });
   });
 


### PR DESCRIPTION
## Problem

A testing agent found that `pause_execution` responds with `state: "running"` for Python, JavaScript, Ruby, Go, and Rust even though the program actually paused (subsequent `get_stack_trace` / `get_local_variables` / `list_threads` all return correct paused-state data). Only .NET reported `state: "paused"`.

## Root cause

`SessionManagerOperations.pause()` sent the DAP `pause` request and immediately returned `session.state`. But the state only transitions to `PAUSED` when the asynchronous `stopped` event is handled by the core `handleStopped` listener. Since DAP responses and events flow through the same message stream in `ProxyManager`, the reported state was decided purely by adapter message ordering:

- **netcoredbg (.NET)** emits `stopped` *before* its pause response → state already `PAUSED` when read → looked correct.
- **debugpy, js-debug, rdbg, delve, CodeLLDB** ack the pause request first and emit `stopped` a moment later → stale `RUNNING` was reported.

No .NET-specific code was involved — it was event-ordering luck. No existing test asserted the returned `state` field, which is how this slipped through.

## Fix

Rework `pause()` to follow the existing `_executeStepOperation` pattern:

- Register `stopped`/`terminated`/`exited`/`exit` listeners **before** sending the DAP `pause` request, and resolve only once the stop is observed — the core `handleStopped` listener runs first on the same event, so the state read is reliably `PAUSED`.
- Capture the top stack frame location on stop, for parity with step responses.
- Guard the case where the stop landed during threadId auto-discovery (before listeners were registered).
- Time out after 5s (matching step operations) with a new `ErrorMessages.pauseTimeout` message.

## Tests

- Updated the existing `pause with threadId` unit tests to emit `stopped` and assert `state === "paused"`.
- New unit tests covering: stopped-after-response (the reported bug), stopped-before-response (netcoredbg ordering), stop-during-thread-discovery, timeout with no stopped event, termination while waiting, and request rejection.

## Verification

- Full unit suite: 147 files / 2298 tests passing; lint and strict typecheck clean.
- Live end-to-end via MCP tools: paused a running Python loop and a running Node interval script — both responses now report `state: "paused"` with a `location`, confirmed genuinely stopped via `get_stack_trace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)