### PR TITLE
fix(dev-proxy): exit and kill backend when MCP client disconnects (part of #122)

### DIFF
--- a/tests/manual/dev-proxy-orphan-check.mjs
+++ b/tests/manual/dev-proxy-orphan-check.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Manual verification for issue #122 (PR-1): dev-proxy must exit — and kill its
+ * backend child — when its MCP client disappears (stdin EOF).
+ *
+ * For each backend transport mode this script:
+ *   1. Spawns tools/dev-proxy/dev-proxy.mjs with piped stdio (like Claude Code does)
+ *   2. Waits for "Backend running (PID=...)" on the proxy's stderr
+ *   3. Closes the proxy's stdin — simulating the MCP client dying
+ *   4. Asserts the proxy exits (code 0) within PROXY_EXIT_BUDGET_MS
+ *   5. Asserts the backend PID is gone within BACKEND_EXIT_BUDGET_MS
+ *
+ * Usage (requires a built dist/ — run `npm run build` first):
+ *   node tests/manual/dev-proxy-orphan-check.mjs           # both modes
+ *   node tests/manual/dev-proxy-orphan-check.mjs http
+ *   node tests/manual/dev-proxy-orphan-check.mjs stdio
+ *
+ * Uses port 3947 (not the default 3001) so a developer's real dev-proxy backend
+ * is never touched — dev-proxy's _ensurePortFree() kills whatever node process
+ * holds its configured port.
+ */
+
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+const DEV_PROXY = path.join(ROOT, 'tools', 'dev-proxy', 'dev-proxy.mjs');
+
+const TEST_PORT = '3947';
+const STARTUP_BUDGET_MS = 60000;
+const PROXY_EXIT_BUDGET_MS = 15000;
+const BACKEND_EXIT_BUDGET_MS = 15000;
+const POLL_INTERVAL_MS = 100;
+
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function runMode(mode) {
+  console.log(`\n=== Mode: ${mode} ===`);
+
+  const child = spawn(process.execPath, [DEV_PROXY], {
+    cwd: ROOT,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      DEV_PROXY_BACKEND_TRANSPORT: mode,
+      DEV_PROXY_PORT: TEST_PORT,
+      DEV_PROXY_ROOT: ROOT,
+    },
+  });
+
+  let stderrBuf = '';
+  child.stderr.on('data', (d) => {
+    stderrBuf += d.toString();
+  });
+  child.stdout.on('data', () => {}); // drain; MCP JSON-RPC channel is unused here
+
+  const exitInfo = new Promise((resolve) => {
+    child.on('exit', (code, signal) => resolve({ code, signal, at: Date.now() }));
+  });
+
+  // 1. Wait for the backend to come up and capture its PID
+  let backendPid = null;
+  const startupDeadline = Date.now() + STARTUP_BUDGET_MS;
+  while (Date.now() < startupDeadline) {
+    const match = stderrBuf.match(/Backend running \(PID=(\d+)/);
+    if (match) {
+      backendPid = parseInt(match[1], 10);
+      break;
+    }
+    if (child.exitCode !== null) break;
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  if (!backendPid) {
+    console.error(`FAIL(${mode}): backend never came up. Proxy stderr:\n${stderrBuf}`);
+    try {
+      child.kill();
+    } catch {
+      /* already gone */
+    }
+    return false;
+  }
+  console.log(`Backend up (PID=${backendPid}); proxy PID=${child.pid}`);
+
+  // 2. Simulate the MCP client (Claude Code) dying: close the proxy's stdin
+  const t0 = Date.now();
+  child.stdin.end();
+
+  // 3. Proxy must exit within budget
+  const proxyResult = await Promise.race([
+    exitInfo,
+    sleep(PROXY_EXIT_BUDGET_MS).then(() => null),
+  ]);
+  if (!proxyResult) {
+    console.error(`FAIL(${mode}): proxy still alive ${PROXY_EXIT_BUDGET_MS}ms after stdin close`);
+    console.error(`Proxy stderr:\n${stderrBuf}`);
+    try {
+      child.kill();
+    } catch {
+      /* already gone */
+    }
+    if (pidAlive(backendPid)) process.kill(backendPid);
+    return false;
+  }
+  const proxyExitMs = proxyResult.at - t0;
+  console.log(
+    `Proxy exited in ${proxyExitMs}ms (code=${proxyResult.code}, signal=${proxyResult.signal})`
+  );
+
+  // 4. Backend must be gone within budget
+  let backendExitMs = null;
+  const backendDeadline = t0 + BACKEND_EXIT_BUDGET_MS;
+  while (Date.now() < backendDeadline) {
+    if (!pidAlive(backendPid)) {
+      backendExitMs = Date.now() - t0;
+      break;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  if (backendExitMs === null) {
+    console.error(
+      `FAIL(${mode}): backend PID ${backendPid} still alive ${BACKEND_EXIT_BUDGET_MS}ms after stdin close`
+    );
+    process.kill(backendPid);
+    return false;
+  }
+  console.log(`Backend gone within ${backendExitMs}ms of stdin close`);
+
+  const codeOk = proxyResult.code === 0;
+  if (!codeOk) {
+    console.error(`FAIL(${mode}): proxy exit code was ${proxyResult.code}, expected 0`);
+    return false;
+  }
+
+  console.log(`PASS(${mode}): proxy exit ${proxyExitMs}ms, backend reaped ${backendExitMs}ms`);
+  return true;
+}
+
+const arg = process.argv[2];
+const modes = arg ? [arg] : ['http', 'stdio'];
+let allPassed = true;
+for (const mode of modes) {
+  if (!(await runMode(mode))) allPassed = false;
+}
+console.log(allPassed ? '\nALL PASSED' : '\nFAILURES — see above');
+process.exit(allPassed ? 0 : 1);

--- a/tests/unit/dev-proxy/dev-proxy-shutdown.test.ts
+++ b/tests/unit/dev-proxy/dev-proxy-shutdown.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the dev-proxy shutdown wiring (issue #122, PR-1).
+ *
+ * The helper lives in tools/dev-proxy/shutdown.mjs (separate from dev-proxy.mjs,
+ * which runs main() at module top level and therefore cannot be imported safely).
+ *
+ * These tests verify that when the MCP client (Claude Code) goes away — stdin
+ * EOF/close/error, protocol-level server close, or signals — the proxy stops its
+ * backend child exactly once and then exits, even if backend.stop() hangs or throws.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'events';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- plain-JS module without type declarations
+import { installShutdownHandlers } from '../../../tools/dev-proxy/shutdown.mjs';
+
+interface FakeProc extends EventEmitter {
+  exit: ReturnType<typeof vi.fn>;
+}
+
+function makeDeps() {
+  const stdin = new EventEmitter();
+  const proc = new EventEmitter() as FakeProc;
+  proc.exit = vi.fn();
+  const backend = { stop: vi.fn().mockResolvedValue(undefined) };
+  const log = vi.fn();
+  return { stdin, proc, backend, log };
+}
+
+describe('dev-proxy installShutdownHandlers', () => {
+  it('stops the backend then exits 0 when stdin ends (client died)', async () => {
+    const { stdin, proc, backend, log } = makeDeps();
+    installShutdownHandlers({ stdin, backend, log, proc });
+
+    stdin.emit('end');
+
+    await vi.waitFor(() => expect(proc.exit).toHaveBeenCalledWith(0));
+    expect(backend.stop).toHaveBeenCalledTimes(1);
+    // stop must be initiated before exit
+    expect(backend.stop.mock.invocationCallOrder[0]).toBeLessThan(
+      proc.exit.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('shuts down on stdin close', async () => {
+    const { stdin, proc, backend, log } = makeDeps();
+    installShutdownHandlers({ stdin, backend, log, proc });
+
+    stdin.emit('close');
+
+    await vi.waitFor(() => expect(proc.exit).toHaveBeenCalledWith(0));
+    expect(backend.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats stdin error as client disconnect (Windows broken pipe)', async () => {
+    const { stdin, proc, backend, log } = makeDeps();
+    installShutdownHandlers({ stdin, backend, log, proc });
+
+    stdin.emit('error', new Error('EPIPE: broken pipe'));
+
+    await vi.waitFor(() => expect(proc.exit).toHaveBeenCalledWith(0));
+    expect(backend.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('shuts down on SIGINT and SIGTERM', async () => {
+    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+      const { stdin, proc, backend, log } = makeDeps();
+      installShutdownHandlers({ stdin, backend, log, proc });
+
+      proc.emit(signal);
+
+      await vi.waitFor(() => expect(proc.exit).toHaveBeenCalledWith(0));
+      expect(backend.stop).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('is idempotent: multiple triggers stop the backend and exit only once', async () => {
+    const { stdin, proc, backend, log } = makeDeps();
+    installShutdownHandlers({ stdin, backend, log, proc });
+
+    // Realistic Windows sequence: 'end' then 'close', plus stray signals
+    stdin.emit('end');
+    stdin.emit('close');
+    proc.emit('SIGINT');
+    proc.emit('SIGTERM');
+
+    await vi.waitFor(() => expect(proc.exit).toHaveBeenCalled());
+    // Allow any queued microtasks/macrotasks from the extra triggers to flush
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(backend.stop).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledTimes(1);
+  });
+
+  it('still exits if backend.stop() hangs (stop timeout)', async () => {
+    const { stdin, proc, log } = makeDeps();
+    const backend = { stop: vi.fn().mockReturnValue(new Promise<void>(() => {})) };
+    installShutdownHandlers({
+      stdin,
+      backend,
+      log,
+      proc,
+      stopTimeoutMs: 25,
+      forceExitDelayMs: 5000,
+    });
+
+    stdin.emit('end');
+
+    await vi.waitFor(() => expect(proc.exit).toHaveBeenCalledWith(0), { timeout: 2000 });
+    expect(backend.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('still exits 0 if backend.stop() rejects', async () => {
+    const { stdin, proc, log } = makeDeps();
+    const backend = { stop: vi.fn().mockRejectedValue(new Error('kill failed')) };
+    installShutdownHandlers({ stdin, backend, log, proc });
+
+    stdin.emit('end');
+
+    await vi.waitFor(() => expect(proc.exit).toHaveBeenCalledWith(0));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('kill failed'));
+  });
+
+  it('chains server.onclose instead of replacing it, and shuts down on server close', async () => {
+    const { stdin, proc, backend, log } = makeDeps();
+    const previousOnClose = vi.fn();
+    const server: { onclose?: () => void } = { onclose: previousOnClose };
+    installShutdownHandlers({ stdin, backend, server, log, proc });
+
+    expect(server.onclose).not.toBe(previousOnClose);
+    server.onclose!();
+
+    await vi.waitFor(() => expect(proc.exit).toHaveBeenCalledWith(0));
+    expect(previousOnClose).toHaveBeenCalledTimes(1);
+    expect(backend.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an idempotent shutdown function usable directly', async () => {
+    const { stdin, proc, backend, log } = makeDeps();
+    const shutdown = installShutdownHandlers({ stdin, backend, log, proc });
+
+    await shutdown('test reason');
+    await shutdown('second call is a no-op');
+
+    expect(backend.stop).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledWith(0);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('test reason'));
+  });
+});

--- a/tools/dev-proxy/dev-proxy.mjs
+++ b/tools/dev-proxy/dev-proxy.mjs
@@ -29,6 +29,7 @@ import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprot
 import { spawn, execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
+import { installShutdownHandlers } from './shutdown.mjs';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -760,6 +761,14 @@ async function main() {
 
   log(`Proxy server connected to stdio (backend transport: ${BACKEND_TRANSPORT})`);
 
+  // Exit when the MCP client goes away — stdin EOF/close/error, protocol-level
+  // server close, or SIGINT/SIGTERM — stopping the backend child on the way out.
+  // Installed before backend.start() so a client that dies during a slow backend
+  // startup still triggers shutdown (backend.stop() handles the 'starting' state).
+  // Without this, on Windows both the proxy and its backend outlive a dead
+  // Claude Code forever (issue #122).
+  installShutdownHandlers({ stdin: process.stdin, backend, server, log });
+
   // Start the backend automatically
   try {
     await backend.start();
@@ -769,19 +778,6 @@ async function main() {
     log(`Initial backend start failed: ${err.message}`);
     log('Dev tools are still available — use dev_restart_debugger to retry');
   }
-
-  // Handle graceful shutdown
-  process.on('SIGINT', async () => {
-    log('SIGINT received, shutting down...');
-    await backend.stop();
-    process.exit(0);
-  });
-
-  process.on('SIGTERM', async () => {
-    log('SIGTERM received, shutting down...');
-    await backend.stop();
-    process.exit(0);
-  });
 }
 
 main().catch((err) => {

--- a/tools/dev-proxy/shutdown.mjs
+++ b/tools/dev-proxy/shutdown.mjs
@@ -1,0 +1,115 @@
+/**
+ * Shutdown wiring for dev-proxy — exit when the MCP client (Claude Code) goes away.
+ *
+ * Why this exists (issue #122): on Windows, a dying parent process never delivers
+ * SIGINT/SIGTERM to its children, and the MCP SDK's StdioServerTransport only
+ * attaches 'data'/'error' listeners to stdin — it never notices EOF, and its
+ * onclose fires only on programmatic close(). So a dev-proxy whose client died
+ * kept the event loop alive forever, and its backend child along with it.
+ *
+ * The reliable cross-platform signal is the proxy's own stdin: when the client
+ * process dies, the OS closes the pipe and stdin emits 'end' (or 'error' for a
+ * broken pipe) followed by 'close'. Any of those — plus protocol-level server
+ * close and SIGINT/SIGTERM — means "client is gone": stop the backend child,
+ * then exit.
+ *
+ * Kept in its own module so unit tests can import it without executing the
+ * dev-proxy entry point (dev-proxy.mjs runs main() at module top level).
+ */
+
+/** Max time to wait for backend.stop() before exiting anyway. */
+export const STOP_TIMEOUT_MS = 8000;
+
+/** Hard-exit backstop in case the shutdown sequence itself stalls. */
+export const FORCE_EXIT_DELAY_MS = 10000;
+
+/**
+ * Install handlers that shut the proxy down when the MCP client disconnects.
+ *
+ * @param {object} deps
+ * @param {NodeJS.ReadableStream} deps.stdin
+ *   The proxy's inbound stdin from the MCP client. Safe to listen on: the SDK's
+ *   StdioServerTransport only attaches 'data'/'error' listeners, and its 'data'
+ *   listener keeps the stream flowing so 'end' fires at EOF.
+ * @param {{ stop(): Promise<void> }} deps.backend
+ *   Backend manager to stop before exit. stop() handles all three transport
+ *   modes (http/sse/stdio) including a backend that is still starting.
+ * @param {{ onclose?: (() => void) | undefined }} [deps.server]
+ *   MCP Server whose onclose is chained (not replaced). Note: hook the SERVER,
+ *   never transport.onclose — Protocol.connect() owns transport.onclose and
+ *   overwriting it breaks the SDK's close chain.
+ * @param {(msg: string) => void} [deps.log]
+ * @param {Pick<NodeJS.Process, 'on' | 'exit'>} [deps.proc] Injectable for tests.
+ * @param {number} [deps.stopTimeoutMs]
+ * @param {number} [deps.forceExitDelayMs]
+ * @returns {(reason: string) => Promise<void>} The idempotent shutdown function.
+ */
+export function installShutdownHandlers({
+  stdin,
+  backend,
+  server,
+  log = () => {},
+  proc = process,
+  stopTimeoutMs = STOP_TIMEOUT_MS,
+  forceExitDelayMs = FORCE_EXIT_DELAY_MS,
+}) {
+  let shuttingDown = false;
+
+  const shutdown = async (reason) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log(`Shutting down: ${reason}`);
+
+    // Backstop: never let a hung stop sequence keep an orphaned supervisor alive.
+    const forceExitTimer = setTimeout(() => {
+      log(`Shutdown did not complete within ${forceExitDelayMs}ms — forcing exit`);
+      proc.exit(1);
+    }, forceExitDelayMs);
+    forceExitTimer.unref?.();
+
+    let stopTimer;
+    try {
+      await Promise.race([
+        backend.stop(),
+        new Promise((resolve) => {
+          stopTimer = setTimeout(resolve, stopTimeoutMs);
+          stopTimer.unref?.();
+        }),
+      ]);
+    } catch (err) {
+      log(`Ignoring backend stop error during shutdown: ${err?.message ?? err}`);
+    } finally {
+      clearTimeout(stopTimer);
+    }
+
+    clearTimeout(forceExitTimer);
+    log('Shutdown complete');
+    proc.exit(0);
+  };
+
+  // Primary trigger: client death closes our stdin pipe.
+  stdin.on('end', () => void shutdown('stdin ended (MCP client disconnected)'));
+  stdin.on('close', () => void shutdown('stdin closed (MCP client disconnected)'));
+  stdin.on('error', (err) =>
+    void shutdown(`stdin error (${err?.message ?? err}) — treating as client disconnect`)
+  );
+
+  // Secondary trigger: protocol-level close (client sent a proper shutdown).
+  if (server) {
+    const previousOnClose = server.onclose;
+    server.onclose = () => {
+      try {
+        previousOnClose?.();
+      } catch (err) {
+        log(`Ignoring server onclose handler error: ${err?.message ?? err}`);
+      }
+      void shutdown('MCP server connection closed');
+    };
+  }
+
+  // Signals route through the same idempotent path (parity with prior behavior).
+  proc.on('SIGINT', () => void shutdown('SIGINT received'));
+  proc.on('SIGTERM', () => void shutdown('SIGTERM received'));
+
+  return shutdown;
+}


### PR DESCRIPTION
## Summary

PR 1 of 3 for #122 — stops the dev-proxy supervisor pile-up (45 supervisors + 9 backends observed accumulated across 3 Claude Code sessions on Windows).

On Windows, a dying MCP client (Claude Code) never delivers SIGINT/SIGTERM to dev-proxy, and the MCP SDK's `StdioServerTransport` attaches only `data`/`error` listeners to stdin — it never notices EOF, and its `onclose` fires only on programmatic `close()`. So dev-proxy had literally no code path that reacts to client death, and it (plus its backend child) lived forever.

## Change

- New `tools/dev-proxy/shutdown.mjs`: idempotent shutdown triggered by stdin `end`/`close`/`error` (the OS closes the pipe when the client dies), protocol-level server close (chained via `server.onclose` — never `transport.onclose`, which `Protocol.connect()` owns), and SIGINT/SIGTERM (previous handlers now route through the same path). Stops the backend child (8 s stop timeout, 10 s unref'd hard-exit backstop), then exits 0.
- Handlers install before `backend.start()`, so a client that dies during slow backend startup is still handled; `backend.stop()` covers all three transport modes including the `starting` state.
- Helper lives in its own module because dev-proxy.mjs runs `main()` at module top level and can't be imported by tests without side effects.

## Testing

- 9 new unit tests (`tests/unit/dev-proxy/dev-proxy-shutdown.test.ts`): each trigger, stop-before-exit ordering, idempotency, hung/rejecting `backend.stop()`, onclose chaining.
- Full unit suite: 148 files / 2307 tests passing.
- Manual Windows verification (`tests/manual/dev-proxy-orphan-check.mjs`, uses port 3947 to avoid touching live backends): stdin closed → http mode: proxy exit + backend reaped in **861 ms**; stdio mode: **3062 ms**. Note: `tests/manual/` is gitignored, script was force-added alongside existing tracked precedents there.

Remaining parts of #122 (separate PRs): SessionManager reaps proxies on natural termination; backend orphan self-defense + graceful-then-force kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)