### PR TITLE
fix(proxy): remove one-sided bootstrap heartbeat (fixes #123)

### DIFF
--- a/src/proxy/dap-proxy-core.ts
+++ b/src/proxy/dap-proxy-core.ts
@@ -99,7 +99,17 @@ export class ProxyRunner {
               counter: this.heartbeatTickCounter
             });
           } catch (tickError) {
-            this.logger.warn('[ProxyRunner] Failed to send heartbeat tick:', tickError);
+            // process.send throws only when the IPC channel is closed (the
+            // payload is static, so serialization cannot fail) — the parent is
+            // unreachable. Shut down instead of lingering. This replaces the
+            // self-SIGTERM the old proxy-bootstrap heartbeat performed (#123).
+            this.logger.warn(
+              '[ProxyRunner] Failed to send heartbeat tick — parent unreachable, shutting down:',
+              tickError
+            );
+            this.stop().finally(() => {
+              process.exit(1);
+            });
           }
         }, 5000);
       }
@@ -127,6 +137,11 @@ export class ProxyRunner {
     if (!this.isRunning) {
       return;
     }
+
+    // Mark as stopped immediately so channel-close handlers triggered by the
+    // teardown below (e.g. readline 'close' when we close the interface) do
+    // not treat it as a parent death and exit the process.
+    this.isRunning = false;
 
     this.logger.info('[ProxyRunner] Stopping proxy runner...');
 
@@ -162,7 +177,6 @@ export class ProxyRunner {
       this.rl.close();
     }
 
-    this.isRunning = false;
     this.logger.info('[ProxyRunner] Stopped');
   }
 
@@ -312,8 +326,22 @@ export class ProxyRunner {
       output: process.stdout,
       terminal: false
     });
-    
+
     this.rl.on('line', (line: string) => processMessage(line));
+
+    // stdin closing (EOF) means the parent is gone — mirror the IPC
+    // 'disconnect' handling so stdin-mode proxies do not linger as orphans.
+    // Guarded by isRunning: a normal stop() closes the interface after
+    // marking the runner stopped, which must not re-enter or exit.
+    this.rl.on('close', () => {
+      if (!this.isRunning) {
+        return;
+      }
+      this.logger.warn('[ProxyRunner] stdin closed — parent process gone, shutting down');
+      this.stop().finally(() => {
+        process.exit(0);
+      });
+    });
   }
 
   /**

--- a/src/proxy/proxy-bootstrap.js
+++ b/src/proxy/proxy-bootstrap.js
@@ -23,11 +23,12 @@ function logBootstrapActivity(message) {
 // Bootstrap handlers would race with worker shutdown and call process.exit()
 // before the async auto-detach could complete.
 
-// Set up heartbeat to detect orphaned state
-let lastHeartbeat = Date.now();
-const HEARTBEAT_TIMEOUT = 30000; // 30 seconds
-
- // Check if we're orphaned every 10 seconds
+// Check if we're orphaned every 10 seconds.
+// NOTE: The old one-sided `{type:'heartbeat'}` ping to the parent was removed
+// (issue #123): the parent rejected it as an invalid message and never replied,
+// so on idle sessions it only produced WARN log noise. Proxy liveness is proven
+// by the ProxyRunner's 5s ipc-heartbeat-tick, and a failing tick send triggers
+// self-shutdown there (see dap-proxy-core.ts).
 setInterval(() => {
   // Use container-safe orphan detection (ppid=1 ignored inside containers)
   // Send SIGTERM (not process.exit) so the worker's signal handler fires
@@ -35,25 +36,8 @@ setInterval(() => {
   if (shouldExitAsOrphanFromEnv(process.ppid, process.env)) {
     logBootstrapActivity('Process orphaned (ppid=1 outside container), sending SIGTERM...');
     process.kill(process.pid, 'SIGTERM');
-    return;
-  }
-
-  // Also check if we haven't received any IPC messages in a while
-  if (Date.now() - lastHeartbeat > HEARTBEAT_TIMEOUT && process.send) {
-    try {
-      // Try to ping parent
-      process.send({ type: 'heartbeat', pid: process.pid });
-    } catch {
-      logBootstrapActivity('Cannot communicate with parent, sending SIGTERM...');
-      process.kill(process.pid, 'SIGTERM');
-    }
   }
 }, 10000);
-
-// Update heartbeat on any message from parent
-process.on('message', () => {
-  lastHeartbeat = Date.now();
-});
 
 logBootstrapActivity(`Bootstrap script started. CWD: ${process.cwd()}`);
 

--- a/tests/unit/proxy/dap-proxy-core.test.ts
+++ b/tests/unit/proxy/dap-proxy-core.test.ts
@@ -394,6 +394,46 @@ describe('ProxyRunner stdin communication', () => {
       expect.stringContaining('stdin/readline')
     );
   });
+
+  it('shuts down and exits when stdin closes while running', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    runner = new ProxyRunner(deps, logger, { useStdin: true, onMessage: vi.fn() });
+    await runner.start();
+    const shutdownSpy = vi.spyOn(runner.getWorker(), 'shutdown');
+
+    // Simulate parent death: stdin EOF closes the readline interface
+    const rl = (runner as unknown as { rl: { emit: (event: string) => void } }).rl;
+    rl.emit('close');
+    // Allow the async stop() chain and .finally() to run
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('stdin closed')
+    );
+    expect(shutdownSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    exitSpy.mockRestore();
+  });
+
+  it('stop() closing the stdin interface does not exit the process', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    runner = new ProxyRunner(deps, logger, { useStdin: true, onMessage: vi.fn() });
+    await runner.start();
+    await runner.stop();
+
+    // Allow any readline 'close' handler triggered by stop() to run
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('stdin closed')
+    );
+
+    exitSpy.mockRestore();
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -449,6 +489,36 @@ describe('ProxyRunner heartbeat and init timeout', () => {
     expect(fakeSend).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'ipc-heartbeat-tick', counter: 2 })
     );
+
+    exitSpy.mockRestore();
+  });
+
+  it('shuts down and exits(1) when heartbeat tick send fails', async () => {
+    const fakeSend = vi.fn(() => {
+      throw new Error('ERR_IPC_CHANNEL_CLOSED: Channel closed');
+    });
+    (process as any).send = fakeSend;
+    Object.defineProperty(process, 'connected', { value: false, configurable: true });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn() });
+    await runner.start();
+    const shutdownSpy = vi.spyOn(runner.getWorker(), 'shutdown');
+
+    // First tick throws -> runner must warn, shut down, and exit(1)
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('parent unreachable'),
+      expect.any(Error)
+    );
+    expect(shutdownSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    // stop() cleared the interval (and init timeout): no further exits
+    exitSpy.mockClear();
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(exitSpy).not.toHaveBeenCalled();
 
     exitSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

Fixes #123. proxy-bootstrap.js sent `{type:'heartbeat', pid}` after 30 s of parent silence — a message with no `sessionId`, absent from the `ProxyMessage` union, that the parent rejected as `Invalid message format` every 10 s forever on idle sessions. Since the parent never replied, the bootstrap's staleness detector could never be satisfied; the mechanism was pure WARN-level log noise.

## Change

- **Delete the bootstrap heartbeat.** Its 10 s interval now only performs the container-safe ppid orphan check. Proxy liveness is already proven by ProxyRunner's 5 s `ipc-heartbeat-tick`, which the parent accepts.
- **Preserve its one unique behavior** — self-terminate when `process.send` throws (parent unreachable) — on the tick's send path in `dap-proxy-core.ts`: warn, graceful `stop()`, `exit(1)`.
- **Close an adjacent gap from the issue:** stdin-mode proxies now shut down when the readline interface closes (parent EOF), mirroring the IPC `disconnect` handling. `stop()` marks the runner stopped before teardown so normal teardown can't self-trigger the exit path (covered by a dedicated test).

Deliberately deferred: the `ppid === 1` orphan check being dead code on Windows — that's parent-death-detection territory owned by #122, and the IPC `disconnect` handler already covers Windows parent death in production (proxies always spawn with an IPC channel).

## Testing

- 3 new unit tests: tick send-failure → warn + worker shutdown + `exit(1)` exactly once; stdin close while running → shutdown + `exit(0)`; plain `stop()` never exits the process.
- Targeted suites 87/87; full unit suite 147 files / 2301 tests passing; lint clean.
- Manual Windows verification: mock session idle 75 s → **zero** `Invalid message format` warns (previously ~4-5); abrupt parent kill → proxy exited within 4 s via IPC disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)