### PR TITLE
fix(js-adapter): establish child session in attach mode (fixes #124)

### DIFF
--- a/examples/javascript/attach_target.js
+++ b/examples/javascript/attach_target.js
@@ -9,7 +9,7 @@ const message = 'tick';
 
 function tick() {
   counter += 1;
-  if (counter % 50 === 0) {
+  if (counter % 10 === 0) {
     console.log(`${message} ${counter}`);
   }
 }

--- a/packages/adapter-javascript/src/javascript-debug-adapter.ts
+++ b/packages/adapter-javascript/src/javascript-debug-adapter.ts
@@ -19,6 +19,8 @@ import {
   type AdapterConfig,
   type GenericLaunchConfig,
   type LanguageSpecificLaunchConfig,
+  type GenericAttachConfig,
+  type LanguageSpecificAttachConfig,
   type FeatureRequirement,
   type AdapterCapabilities,
   type AdapterLaunchBarrier
@@ -554,6 +556,47 @@ export class JavascriptDebugAdapter extends EventEmitter implements IDebugAdapte
       justMyCode: true,
       env: {},
       cwd: process.cwd()
+    };
+  }
+
+  // ===== Attach Support =====
+
+  supportsAttach(): boolean {
+    return true;
+  }
+
+  /**
+   * Build the js-debug (pwa-node) attach configuration. Unlike
+   * transformLaunchConfig — which always produces a launch request — this
+   * preserves the attach request/host/port so the proxy worker detects attach
+   * mode and JsDebugAdapterPolicy.performHandshake sends a real DAP 'attach'.
+   */
+  transformAttachConfig(config: GenericAttachConfig): LanguageSpecificAttachConfig {
+    const attachConfig: LanguageSpecificAttachConfig = {
+      type: 'pwa-node',
+      request: 'attach',
+      name: 'Attach to Node.js process',
+      host: config.host || '127.0.0.1',
+      port: config.port,
+    };
+
+    if (config.stopOnEntry !== undefined) {
+      attachConfig.stopOnEntry = config.stopOnEntry;
+    }
+    if (config.justMyCode !== undefined) {
+      attachConfig.justMyCode = config.justMyCode;
+    }
+    if (config.timeout !== undefined) {
+      attachConfig.timeout = config.timeout;
+    }
+
+    return attachConfig;
+  }
+
+  getDefaultAttachConfig(): Partial<GenericAttachConfig> {
+    return {
+      request: 'attach',
+      host: '127.0.0.1',
     };
   }
 

--- a/packages/shared/src/interfaces/adapter-policy-js.ts
+++ b/packages/shared/src/interfaces/adapter-policy-js.ts
@@ -186,6 +186,13 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
     state === SessionState.PAUSED || (!options.stopOnEntry && state === SessionState.RUNNING),
 
   /**
+   * js-debug attaches with continueOnAttach, so a running target stays
+   * running; the SessionManager must issue an explicit pause for the PAUSED
+   * state it reports after attach to be real (issue #124).
+   */
+  getAttachBehavior: () => ({ pauseAfterAttach: true }),
+
+  /**
    * Perform JavaScript-specific handshake sequence for js-debug/pwa-node.
    * This includes the strict initialization sequence required by js-debug.
    */
@@ -325,18 +332,44 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
       getPortValue(a.port);
 
     if (req === 'attach' && typeof attachPort === 'number' && attachPort > 0) {
-      // Explicit ATTACH flow (single parent session); avoid DI ambiguity
+      // Explicit ATTACH flow (single parent session); avoid DI ambiguity.
+      // Use the caller-provided host — previously hardcoded to 127.0.0.1,
+      // which broke attaching to anything but local loopback (issue #124).
+      const attachHost =
+        typeof baseRecord.host === 'string' && (baseRecord.host as string).length > 0
+          ? (baseRecord.host as string)
+          : typeof a.host === 'string' && (a.host as string).length > 0
+          ? (a.host as string)
+          : '127.0.0.1';
+      // NOTE: do not set attachSimplePort here. Combined with `port` it makes
+      // js-debug attach to the same inspector twice (simple-attach delegate +
+      // regular attach target); with continueOnAttach the two targets then
+      // fight over the process — every pause is immediately resumed by the
+      // other target and stackTrace fails with "Thread is not paused"
+      // (observed empirically while fixing issue #124).
+      const attachArgs: Record<string, unknown> = {
+        type,
+        request: 'attach',
+        address: attachHost,
+        port: attachPort,
+        continueOnAttach: true,
+        attachExistingChildren: true
+      };
+      // Carry the caller's stopOnEntry: js-debug itself ignores it, but
+      // MinimalDapClient records the attach args and threads the intent into
+      // child session creation (issue #124).
+      const stopOnEntryValue =
+        typeof baseRecord.stopOnEntry === 'boolean'
+          ? (baseRecord.stopOnEntry as boolean)
+          : typeof a.stopOnEntry === 'boolean'
+          ? (a.stopOnEntry as boolean)
+          : undefined;
+      if (typeof stopOnEntryValue === 'boolean') {
+        attachArgs.stopOnEntry = stopOnEntryValue;
+      }
       try {
-        console.info(`[JsDebugAdapterPolicy] [JS] Sending 'attach' to ${attachPort} (address=127.0.0.1)`);
-        await pm.sendDapRequest('attach', {
-          type,
-          request: 'attach',
-          address: '127.0.0.1',
-          port: attachPort,
-          continueOnAttach: true,
-          attachExistingChildren: true,
-          attachSimplePort: attachPort
-        });
+        console.info(`[JsDebugAdapterPolicy] [JS] Sending 'attach' to ${attachPort} (address=${attachHost})`);
+        await pm.sendDapRequest('attach', attachArgs);
       } catch (e) {
         console.warn(`[JsDebugAdapterPolicy] [JS] 'attach' failed: ${e instanceof Error ? e.message : String(e)}`);
       }

--- a/packages/shared/src/interfaces/adapter-policy.ts
+++ b/packages/shared/src/interfaces/adapter-policy.ts
@@ -189,7 +189,18 @@ export interface AdapterPolicy {
   /**
    * Perform language-specific handshake after connecting to the debug adapter.
    * Some languages (like JavaScript) require a specific initialization sequence.
-   * 
+   *
+   * Contract: the SessionManager invokes this for BOTH launch
+   * (startDebugging) and attach (attachToProcess), right after
+   * startProxyManager succeeds. A policy that defines this method owns the
+   * full DAP start sequence — initialize, configuration and the
+   * launch/attach request itself; the proxy worker's built-in launch/attach
+   * flow does not run for command-queueing policies. Attach is
+   * distinguished from launch by `dapLaunchArgs.request === 'attach'`
+   * (and/or `__attachMode: true`) and by the transformed
+   * `launchConfig.request`. Policies that do not define this method are
+   * unaffected: the proxy worker drives their launch/attach sequence.
+   *
    * @param context Context object with session details and helper methods
    * @returns Promise that resolves when handshake is complete
    */

--- a/src/proxy/child-session-manager.ts
+++ b/src/proxy/child-session-manager.ts
@@ -235,8 +235,14 @@ export class ChildSessionManager extends EventEmitter {
       // Skip when the user explicitly requested stopOnEntry=false: forcing a
       // pause contradicts intent and the resulting 'pause'-reason stopped
       // event would not be recognized by the auto-continue trigger.
+      // Also skip for attach-mode parents (request === 'attach', threaded in
+      // by MinimalDapClient.enrichChildConfig): attach targets emit no entry
+      // stop, so waiting for one here only stalls adoption, and the
+      // SessionManager already issues and verifies the post-attach pause via
+      // the policy's getAttachBehavior().pauseAfterAttach (issue #124).
       const wantsEntryStop = parentConfig?.stopOnEntry !== false;
-      if (this.dapBehavior.pauseAfterChildAttach && wantsEntryStop) {
+      const attachModeParent = parentConfig?.request === 'attach';
+      if (this.dapBehavior.pauseAfterChildAttach && wantsEntryStop && !attachModeParent) {
         await this.ensureChildStopped(child);
       }
       

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -402,17 +402,22 @@ export class DapProxyWorker {
       // Set up event handlers
       this.setupDapEventHandlers();
 
+      // Detect attach mode from launchConfig. Needed to determine the DAP
+      // sequence below AND the shutdown behavior (attach mode must detach
+      // with terminateDebuggee=false so the target survives) — including for
+      // command-queueing policies (js-debug), whose handshake is driven by
+      // the SessionManager rather than this worker.
+      const isAttachMode = payload.launchConfig?.request === 'attach' ||
+                           payload.launchConfig?.__attachMode === true;
+      this.isAttachMode = isAttachMode;
+
       // Check if adapter requires command queueing
       if (this.adapterPolicy.requiresCommandQueueing()) {
-        this.logger!.info(`[Worker] ${this.adapterPolicy.name} adapter detected; command queueing enabled`);
+        this.logger!.info(`[Worker] ${this.adapterPolicy.name} adapter detected; command queueing enabled (attachMode=${isAttachMode})`);
         this.state = ProxyState.CONNECTED;
         this.sendStatus('adapter_connected');
         await this.drainPreConnectQueue();
       } else {
-        // Detect attach mode from launchConfig - needed to determine DAP sequence
-        const isAttachMode = payload.launchConfig?.request === 'attach' ||
-                             payload.launchConfig?.__attachMode === true;
-        this.isAttachMode = isAttachMode;
         const initBehavior = this.adapterPolicy.getInitializationBehavior();
 
         // For adapters that send 'initialized' before launch/attach (Go/Delve, Java),

--- a/src/proxy/minimal-dap.ts
+++ b/src/proxy/minimal-dap.ts
@@ -49,6 +49,11 @@ export class MinimalDapClient extends EventEmitter {
   private childSessions = new Map<string, MinimalDapClient>();
   private activeChild: MinimalDapClient | null = null;
 
+  // Arguments of the last 'launch'/'attach' request sent through this client.
+  // Used to thread the caller's intent (attach mode, stopOnEntry) into child
+  // session creation — the adapter does not echo these fields (issue #124).
+  private lastStartRequestArgs: Record<string, unknown> | null = null;
+
   // Adapter policy and DAP behavior configuration
   private policy: AdapterPolicy;
   private dapBehavior: DapClientBehavior;
@@ -260,7 +265,7 @@ export class MinimalDapClient extends EventEmitter {
             },
             createChildSession: async (config: ChildSessionConfig) => {
               if (this.childSessionManager) {
-                await this.childSessionManager.createChildSession(config);
+                await this.childSessionManager.createChildSession(this.enrichChildConfig(config));
                 // Update active child reference from manager
                 this.activeChild = this.childSessionManager.getActiveChild();
               }
@@ -277,7 +282,7 @@ export class MinimalDapClient extends EventEmitter {
               // Create child session through the manager
               logger.info(`[MinimalDapClient] Creating child session via ChildSessionManager`);
               try {
-                await this.childSessionManager.createChildSession(result.childConfig);
+                await this.childSessionManager.createChildSession(this.enrichChildConfig(result.childConfig));
                 
                 // Set up deferred config if needed
                 if (this.dapBehavior.deferParentConfigDone) {
@@ -388,6 +393,29 @@ export class MinimalDapClient extends EventEmitter {
     });
   }
 
+  /**
+   * Thread the caller's attach intent into a child session config. js-debug's
+   * reverse startDebugging configuration only carries
+   * {type, name, __pendingTargetId}: without this, ChildSessionManager cannot
+   * distinguish attach-mode children from launch-mode children, nor see
+   * whether the user asked for an entry stop (issue #124). Launch-mode
+   * configs are returned unchanged.
+   */
+  private enrichChildConfig(config: ChildSessionConfig): ChildSessionConfig {
+    const start = this.lastStartRequestArgs;
+    if (!start || start.request !== 'attach') {
+      return config;
+    }
+    const parentConfig: Record<string, unknown> = {
+      ...(config.parentConfig ?? {}),
+      request: 'attach'
+    };
+    if (typeof start.stopOnEntry === 'boolean') {
+      parentConfig.stopOnEntry = start.stopOnEntry;
+    }
+    return { ...config, parentConfig };
+  }
+
   public async sendRequest<T extends DebugProtocol.Response>(
     command: string,
     args?: unknown,
@@ -401,6 +429,16 @@ export class MinimalDapClient extends EventEmitter {
       throw new Error('Client is disconnecting or disconnected');
     }
 
+    // Remember the parent's start request so child session creation can see
+    // the caller's intent: js-debug's reverse startDebugging configuration
+    // only carries {type, name, __pendingTargetId} — request mode and
+    // stopOnEntry never round-trip through the adapter (issue #124).
+    if (command === 'attach' || command === 'launch') {
+      this.lastStartRequestArgs = {
+        ...((args as Record<string, unknown> | undefined) ?? {}),
+        request: command
+      };
+    }
 
     // Defer parent's configurationDone briefly to allow child session to configure,
     // avoiding immediate resume of the target before adoption completes.

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -260,7 +260,17 @@ export abstract class SessionManagerCore {
         'exception'
       ]);
       const isFirstStop = !session.firstStopHandled;
+      // Attach sessions have no launch entry stop to skip: any stop observed
+      // after attach is either the deliberate post-attach pause issued by
+      // attachToProcess (pauseAfterAttach policies) or a real debug event.
+      // Auto-continuing those resumed the target right after we paused it
+      // (issue #124), so auto-continue is launch-only.
+      const launchArgsRecord = effectiveLaunchArgs as Record<string, unknown>;
+      const isAttachSession =
+        launchArgsRecord.request === 'attach' ||
+        launchArgsRecord.__attachMode === true;
       const shouldAutoContinue =
+        !isAttachSession &&
         !effectiveLaunchArgs.stopOnEntry &&
         (reason === 'entry' ||
           (firstStopMayBeNonEntry && isFirstStop && !userBreakReasons.has(reason)));

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -69,6 +69,13 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   protected attachVerifyTimeoutMs = 5000;
   protected attachVerifyIntervalMs = 250;
 
+  /**
+   * How long to wait for the 'stopped' event after a post-attach pause
+   * (policies with getAttachBehavior().pauseAfterAttach) before reporting
+   * PAUSED anyway with a warning. Protected so tests can shrink the window.
+   */
+  protected attachPauseStopTimeoutMs = 5000;
+
   protected async startProxyManager(
     session: ManagedSession,
     scriptPath: string,
@@ -1593,13 +1600,40 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         __attachMode: true  // Internal flag to signal attach mode
       };
 
-      await this.startProxyManager(
+      const attachConfigData = await this.startProxyManager(
         session,
         placeholderPath,
         undefined,
         attachLaunchArgs as Partial<CustomLaunchRequestArguments>,
         false
       );
+
+      // Perform language-specific handshake if required, mirroring
+      // startDebugging. For js-debug the whole DAP sequence — initialize,
+      // configurationDone and the DAP 'attach' request itself — is driven
+      // here because the proxy worker skips its built-in attach flow for
+      // command-queueing policies. Policies without performHandshake are
+      // untouched: their attach is performed by the proxy worker.
+      const policy = this.selectPolicy(session.language);
+      if (policy.performHandshake) {
+        try {
+          await policy.performHandshake({
+            proxyManager: session.proxyManager,
+            sessionId: session.id,
+            dapLaunchArgs: attachLaunchArgs as Partial<CustomLaunchRequestArguments>,
+            scriptPath: placeholderPath,
+            scriptArgs: undefined,
+            breakpoints: session.breakpoints,
+            launchConfig: attachConfigData
+          });
+        } catch (handshakeErr) {
+          this.logger.warn(
+            `[SessionManager] Language handshake for attach returned with warning/error: ${
+              handshakeErr instanceof Error ? handshakeErr.message : String(handshakeErr)
+            }`
+          );
+        }
+      }
 
       // Set session state based on stopOnEntry
       let finalState = session.state;
@@ -1646,27 +1680,6 @@ export abstract class SessionManagerOperations extends SessionManagerData {
           this.logger.warn(`[SessionManager] Initial thread discovery for attach failed: ${lastFailure}`);
         }
 
-        // Some debuggers (rdbg) do not suspend a running target on attach;
-        // issue an explicit pause so the PAUSED state we report is real.
-        // Sent after the first discovery attempt (preserving the previous
-        // ordering) and before any retries so the pause itself can surface
-        // the threads that verification is waiting for.
-        const attachBehavior = this.selectPolicy(session.language).getAttachBehavior?.();
-        if (attachBehavior?.pauseAfterAttach) {
-          const pauseThreadId = threads && threads.length > 0
-            ? (threads.find(t => t.name === 'main') ?? threads[0]).id
-            : 1;
-          try {
-            await proxyManager.sendDapRequest('pause', { threadId: pauseThreadId });
-            this.logger.info(`[SessionManager] Sent post-attach pause (threadId=${pauseThreadId})`);
-          } catch (err) {
-            // Already stopped (e.g. target was started suspended) — fine.
-            this.logger.info(
-              `[SessionManager] Post-attach pause not needed/accepted: ${err instanceof Error ? err.message : String(err)}`
-            );
-          }
-        }
-
         // Retry until the deadline if the debugger has not reported threads yet.
         while (!threads && Date.now() < deadline) {
           const sleepMs = Math.min(pollIntervalMs, Math.max(deadline - Date.now(), 1));
@@ -1707,6 +1720,56 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         this.logger.info(`[SessionManager] Discovered ${threads.length} threads. Using threadId=${discoveredThreadId} (name=${mainThread?.name || threads[0].name})`);
         proxyManager.setCurrentThreadId(discoveredThreadId);
         this.logger.info(`[SessionManager] Set threadId=${discoveredThreadId} for attach mode`);
+
+        // Some debuggers (rdbg; js-debug attaches with continueOnAttach) do
+        // not suspend a running target on attach; issue an explicit pause so
+        // the PAUSED state we report is real, and wait for the stop to be
+        // observed before reporting it. Sent after thread verification so it
+        // reaches the debuggee-owning session (for js-debug the pause is
+        // routed to the child session, which exists once threads are
+        // reported). A rejected pause means the target is already stopped
+        // (e.g. started suspended) — fine, no stop event will follow.
+        const attachBehavior = this.selectPolicy(session.language).getAttachBehavior?.();
+        if (attachBehavior?.pauseAfterAttach) {
+          let stopSettled = false;
+          let stopTimer: ReturnType<typeof setTimeout> | undefined;
+          let onStopped: (() => void) | undefined;
+          const stoppedSeen = new Promise<boolean>((resolve) => {
+            onStopped = () => {
+              if (!stopSettled) {
+                stopSettled = true;
+                if (stopTimer) clearTimeout(stopTimer);
+                resolve(true);
+              }
+            };
+            stopTimer = setTimeout(() => {
+              if (!stopSettled) {
+                stopSettled = true;
+                resolve(false);
+              }
+            }, this.attachPauseStopTimeoutMs);
+            proxyManager.once('stopped', onStopped);
+          });
+          try {
+            await proxyManager.sendDapRequest('pause', { threadId: discoveredThreadId });
+            this.logger.info(`[SessionManager] Sent post-attach pause (threadId=${discoveredThreadId})`);
+            const stopObserved = await stoppedSeen;
+            if (!stopObserved) {
+              this.logger.warn(
+                `[SessionManager] No 'stopped' event within ${this.attachPauseStopTimeoutMs}ms after post-attach pause; reported state may lag the engine`
+              );
+            }
+          } catch (err) {
+            // Already stopped (e.g. target was started suspended) — fine.
+            this.logger.info(
+              `[SessionManager] Post-attach pause not needed/accepted: ${err instanceof Error ? err.message : String(err)}`
+            );
+          } finally {
+            stopSettled = true;
+            if (stopTimer) clearTimeout(stopTimer);
+            if (onStopped) proxyManager.removeListener('stopped', onStopped);
+          }
+        }
 
         this._updateSessionState(session, SessionState.PAUSED);
         finalState = SessionState.PAUSED;

--- a/tests/e2e/mcp-server-smoke-javascript-attach.test.ts
+++ b/tests/e2e/mcp-server-smoke-javascript-attach.test.ts
@@ -1,23 +1,24 @@
 /**
- * JavaScript Attach-Mode Smoke Test via MCP Interface (issue #124)
+ * JavaScript Attach-Mode Smoke Tests via MCP Interface (issue #124)
  *
- * Invariant under test: attach_to_process must not lie.
+ * Test 1 — invariant: attach_to_process must not lie. Attach to a real
+ * `node --inspect=<port>` process and require that EITHER attach reports
+ * success AND the session is actually debuggable (non-empty threads, real
+ * stack frames) OR attach reports a truthful failure. What must never happen
+ * is the original issue #124 behavior: success + "paused" while the js-debug
+ * child session never connected to the inspector and every downstream tool
+ * answered empty-but-successful results.
  *
- * Attach to a real `node --inspect=<port>` process and require that EITHER:
- *   (a) attach reports success AND the session is actually debuggable
- *       (list_threads returns at least one thread, get_stack_trace returns
- *       at least one frame), OR
- *   (b) attach reports a truthful failure (success:false with a real error).
+ * Test 2 — acceptance: full working attach cycle. Attach, set a breakpoint,
+ * continue to hit it, evaluate an expression at the stop, then
+ * detach_from_process must leave the target alive and running.
  *
- * What must never happen is the behavior from issue #124: attach returns
- * success + "paused" while the js-debug child session never connected to the
- * inspector port, list_threads answers an empty-but-successful list and
- * get_stack_trace answers an empty-but-successful stack.
- *
- * In both branches the target process must survive the attach attempt.
+ * Test 3 — stopOnEntry:false: attaching must NOT pause the target (the
+ * js-debug child adoption path must not force an entry stop), and detach
+ * must leave it alive.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import path from 'path';
 import net from 'net';
 import { fileURLToPath } from 'url';
@@ -30,6 +31,8 @@ import { parseSdkToolResult, callToolSafely } from './smoke-test-utils.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT = path.resolve(__dirname, '../..');
+const TARGET_SCRIPT = path.resolve(ROOT, 'examples', 'javascript', 'attach_target.js');
+const BREAKPOINT_LINE = 11; // `counter += 1;` inside tick()
 
 function getFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -47,7 +50,49 @@ function getFreePort(): Promise<number> {
   });
 }
 
-describe('MCP Server JavaScript Attach-Mode Smoke Test', () => {
+interface Target {
+  proc: ChildProcess;
+  port: number;
+  stdout: () => string;
+}
+
+/** Spawn the tick target with an open inspector port and wait until it listens. */
+async function spawnTarget(): Promise<Target> {
+  const port = await getFreePort();
+  const proc = spawn(
+    process.execPath,
+    [`--inspect=127.0.0.1:${port}`, TARGET_SCRIPT],
+    { stdio: ['ignore', 'pipe', 'pipe'] }
+  );
+
+  let stdout = '';
+  proc.stdout!.on('data', (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('node --inspect did not start listening within 30s')),
+      30000
+    );
+    let stderr = '';
+    proc.stderr!.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (stderr.includes('Debugger listening on')) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    proc.on('exit', (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`target exited prematurely (code ${code}): ${stderr}`));
+    });
+  });
+
+  return { proc, port, stdout: () => stdout };
+}
+
+describe('MCP Server JavaScript Attach-Mode Smoke Tests', () => {
   let mcpClient: Client | null = null;
   let transport: StdioClientTransport | null = null;
   let sessionId: string | null = null;
@@ -81,62 +126,35 @@ describe('MCP Server JavaScript Attach-Mode Smoke Test', () => {
     console.log('[JS Attach Test] MCP client connected');
   }, 30000);
 
-  afterAll(async () => {
+  afterEach(async () => {
     if (sessionId && mcpClient) {
       try {
         await callToolSafely(mcpClient, 'close_debug_session', { sessionId });
       } catch {
         // Session may already be closed
       }
+      sessionId = null;
     }
+    if (targetProcess && !targetProcess.killed) {
+      targetProcess.kill('SIGKILL');
+    }
+    targetProcess = null;
+  });
 
+  afterAll(async () => {
     if (mcpClient) {
       await mcpClient.close();
     }
     if (transport) {
       await transport.close();
     }
-
-    if (targetProcess && !targetProcess.killed) {
-      targetProcess.kill('SIGKILL');
-    }
-
     console.log('[JS Attach Test] Cleanup completed');
   });
 
-  it('attach_to_process must either really attach (threads + frames) or fail loudly', async () => {
-    const targetScript = path.resolve(ROOT, 'examples', 'javascript', 'attach_target.js');
-    const inspectPort = await getFreePort();
-
-    // 1. Start a long-running Node target with an open inspector port
-    targetProcess = spawn(
-      process.execPath,
-      [`--inspect=127.0.0.1:${inspectPort}`, targetScript],
-      { stdio: ['ignore', 'pipe', 'pipe'] }
-    );
-
-    // Wait for the inspector to announce it is listening
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error('node --inspect did not start listening within 30s')),
-        30000
-      );
-      let stderr = '';
-      targetProcess!.stderr!.on('data', (chunk: Buffer) => {
-        stderr += chunk.toString();
-        if (stderr.includes('Debugger listening on')) {
-          clearTimeout(timeout);
-          resolve();
-        }
-      });
-      targetProcess!.on('exit', (code) => {
-        clearTimeout(timeout);
-        reject(new Error(`target exited prematurely (code ${code}): ${stderr}`));
-      });
-    });
-    console.log(`[JS Attach Test] Target listening on inspector port ${inspectPort}`);
-
-    // 2. Create session and attach
+  async function createSessionAndAttach(
+    port: number,
+    extraAttachArgs: Record<string, unknown> = {}
+  ) {
     const createResult = await mcpClient!.callTool({
       name: 'create_debug_session',
       arguments: { language: 'javascript', name: 'js-attach-test' }
@@ -146,14 +164,21 @@ describe('MCP Server JavaScript Attach-Mode Smoke Test', () => {
 
     const attachResult = await mcpClient!.callTool({
       name: 'attach_to_process',
-      arguments: { sessionId, host: '127.0.0.1', port: inspectPort }
+      arguments: { sessionId, host: '127.0.0.1', port, ...extraAttachArgs }
     });
-    const attachResponse = parseSdkToolResult(attachResult);
+    return parseSdkToolResult(attachResult);
+  }
+
+  it('attach_to_process must either really attach (threads + frames) or fail loudly', async () => {
+    const target = await spawnTarget();
+    targetProcess = target.proc;
+
+    const attachResponse = await createSessionAndAttach(target.port);
     console.log('[JS Attach Test] attach_to_process response:', JSON.stringify(attachResponse));
 
     if (attachResponse.success === true) {
       // Branch (a): attach claims success — hold it to that claim.
-      const threadsResult = await callToolSafely(mcpClient!, 'list_threads', { sessionId });
+      const threadsResult = await callToolSafely(mcpClient!, 'list_threads', { sessionId: sessionId! });
       const threads = (threadsResult.threads as Array<{ id: number; name: string }> | undefined) ?? [];
       expect(
         threads.length,
@@ -162,7 +187,7 @@ describe('MCP Server JavaScript Attach-Mode Smoke Test', () => {
         `debuggable; the js-debug child session likely never connected to the inspector (issue #124)`
       ).toBeGreaterThan(0);
 
-      const stackResult = await callToolSafely(mcpClient!, 'get_stack_trace', { sessionId });
+      const stackResult = await callToolSafely(mcpClient!, 'get_stack_trace', { sessionId: sessionId! });
       expect(
         stackResult.success,
         `attach_to_process reported success but get_stack_trace failed: ` +
@@ -176,8 +201,7 @@ describe('MCP Server JavaScript Attach-Mode Smoke Test', () => {
         `lying about being debuggable (issue #124)`
       ).toBeGreaterThan(0);
     } else {
-      // Branch (b): a truthful failure is acceptable until JS attach is
-      // implemented (issue #124 PR-b), but it must carry a real error.
+      // Branch (b): a truthful failure must carry a real error.
       const errorText = String(attachResponse.message ?? attachResponse.error ?? '');
       expect(
         errorText.length,
@@ -186,11 +210,96 @@ describe('MCP Server JavaScript Attach-Mode Smoke Test', () => {
       console.log(`[JS Attach Test] Attach failed truthfully: ${errorText}`);
     }
 
-    // 3. In both branches, the attach attempt must not have harmed the target.
+    // In both branches, the attach attempt must not have harmed the target.
     await new Promise(r => setTimeout(r, 500));
     expect(
       targetProcess!.exitCode,
       'the attach attempt must leave the target process running'
     ).toBeNull();
+  }, 120000);
+
+  it('should attach, hit a breakpoint, evaluate, and detach leaving the target running', async () => {
+    const target = await spawnTarget();
+    targetProcess = target.proc;
+
+    // 1. Attach (default stopOnEntry: the target is paused once attached)
+    const attachResponse = await createSessionAndAttach(target.port);
+    expect(attachResponse.success, `attach failed: ${JSON.stringify(attachResponse)}`).toBe(true);
+    expect(attachResponse.state).toBe('paused');
+
+    // 2. Breakpoint inside the tick loop
+    const bpResult = await callToolSafely(mcpClient!, 'set_breakpoint', {
+      sessionId: sessionId!,
+      file: TARGET_SCRIPT,
+      line: BREAKPOINT_LINE
+    });
+    expect(bpResult.success, `set_breakpoint failed: ${JSON.stringify(bpResult)}`).toBe(true);
+
+    // 3. Continue and wait for the breakpoint to fire (tick runs every 100ms)
+    const contResult = await callToolSafely(mcpClient!, 'continue_execution', { sessionId: sessionId! });
+    expect(contResult.success, `continue_execution failed: ${JSON.stringify(contResult)}`).toBe(true);
+
+    let hit: { line?: number } | null = null;
+    for (let i = 0; i < 20; i++) {
+      await new Promise(r => setTimeout(r, 500));
+      const stack = await callToolSafely(mcpClient!, 'get_stack_trace', { sessionId: sessionId! });
+      const frames = (stack.stackFrames as Array<{ file?: string; line?: number }> | undefined) ?? [];
+      if (stack.success && frames.length > 0 && frames[0].line === BREAKPOINT_LINE) {
+        hit = frames[0];
+        break;
+      }
+    }
+    expect(hit, 'breakpoint at tick() was not hit within 10s of continue').not.toBeNull();
+
+    // 4. Evaluate at the stop — counter is live program state
+    const evalResult = await callToolSafely(mcpClient!, 'evaluate_expression', {
+      sessionId: sessionId!,
+      expression: 'counter'
+    });
+    expect(evalResult.success, `evaluate_expression failed: ${JSON.stringify(evalResult)}`).toBe(true);
+    expect(Number(evalResult.result)).toBeGreaterThanOrEqual(1);
+
+    // 5. Detach without terminating; the target must stay alive and resume
+    const outputBeforeDetach = target.stdout().length;
+    const detachResult = await callToolSafely(mcpClient!, 'detach_from_process', {
+      sessionId: sessionId!,
+      terminateProcess: false
+    });
+    expect(detachResult.success, `detach_from_process failed: ${JSON.stringify(detachResult)}`).toBe(true);
+
+    await new Promise(r => setTimeout(r, 2500));
+    expect(targetProcess!.exitCode, 'detach must leave the target process alive').toBeNull();
+    expect(
+      target.stdout().length,
+      'the target must resume ticking after detach (it was left paused or was killed)'
+    ).toBeGreaterThan(outputBeforeDetach);
+  }, 120000);
+
+  it('should not pause the target when attaching with stopOnEntry:false', async () => {
+    const target = await spawnTarget();
+    targetProcess = target.proc;
+
+    const attachResponse = await createSessionAndAttach(target.port, { stopOnEntry: false });
+    expect(attachResponse.success, `attach failed: ${JSON.stringify(attachResponse)}`).toBe(true);
+    expect(attachResponse.state).toBe('running');
+
+    // Give child adoption time to settle, then verify the target kept running:
+    // the tick loop prints every ~1s, so new output must appear.
+    const outputAfterAttach = target.stdout().length;
+    await new Promise(r => setTimeout(r, 3000));
+    expect(
+      target.stdout().length,
+      'attach with stopOnEntry:false must not pause the target (issue #124: the js-debug ' +
+      'child adoption path must not force an entry stop)'
+    ).toBeGreaterThan(outputAfterAttach);
+
+    const detachResult = await callToolSafely(mcpClient!, 'detach_from_process', {
+      sessionId: sessionId!,
+      terminateProcess: false
+    });
+    expect(detachResult.success, `detach_from_process failed: ${JSON.stringify(detachResult)}`).toBe(true);
+
+    await new Promise(r => setTimeout(r, 500));
+    expect(targetProcess!.exitCode, 'detach must leave the target process alive').toBeNull();
   }, 120000);
 });

--- a/tests/proxy/child-session-manager.test.ts
+++ b/tests/proxy/child-session-manager.test.ts
@@ -99,6 +99,40 @@ describe('ChildSessionManager', () => {
       }
     });
     
+    it('skips the entry-stop pause for attach-mode parents (issue #124)', async () => {
+      // MinimalDapClient.enrichChildConfig threads request:'attach' into the
+      // parentConfig of attach-mode children. For those, ensureChildStopped
+      // must be skipped entirely: attach targets emit no entry stop (waiting
+      // stalls adoption for 15s) and the SessionManager owns the post-attach
+      // pause via getAttachBehavior().pauseAfterAttach.
+      vi.useFakeTimers();
+      try {
+        const config = {
+          pendingId: 'test-pending-attach',
+          host: 'localhost',
+          port: 9229,
+          parentConfig: {
+            type: 'pwa-node',
+            request: 'attach'
+          }
+        };
+
+        const createPromise = manager.createChildSession(config);
+        // Only the post-attach initialized wait (3s) should be pending — the
+        // 15s ensureChildStopped stall must not run for attach parents.
+        await vi.advanceTimersByTimeAsync(4000);
+        await createPromise;
+
+        const child = manager.getActiveChild() as unknown as MockMinimalDapClient;
+        expect(child).toBeDefined();
+        const commands = child.requests.map(r => r.command);
+        expect(commands).not.toContain('pause');
+        expect(manager.hasActiveChildren()).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should route commands to child when policy specifies', () => {
       // JavaScript policy routes many commands to child
       expect(manager.shouldRouteToChild('threads')).toBe(true);

--- a/tests/unit/proxy/minimal-dap.test.ts
+++ b/tests/unit/proxy/minimal-dap.test.ts
@@ -1724,4 +1724,50 @@ describe('MinimalDapClient', () => {
     });
   });
 
+  describe('Child config enrichment (attach intent threading, issue #124)', () => {
+    // js-debug's reverse startDebugging configuration only carries
+    // {type, name, __pendingTargetId}; enrichChildConfig threads the caller's
+    // attach intent (request, stopOnEntry) into the child's parentConfig.
+    const baseConfig = {
+      host: 'localhost',
+      port: 1234,
+      pendingId: 'p1',
+      parentConfig: { type: 'pwa-node', name: 'Remote Process [0]' }
+    };
+
+    it('returns the config unchanged when no start request was recorded', () => {
+      const c = new MinimalDapClient('localhost', 1234, JsDebugAdapterPolicy);
+      expect((c as any).enrichChildConfig(baseConfig)).toBe(baseConfig);
+      c.shutdown();
+    });
+
+    it('returns the config unchanged for launch-mode parents', () => {
+      const c = new MinimalDapClient('localhost', 1234, JsDebugAdapterPolicy);
+      (c as any).lastStartRequestArgs = { request: 'launch', stopOnEntry: false };
+      expect((c as any).enrichChildConfig(baseConfig)).toBe(baseConfig);
+      c.shutdown();
+    });
+
+    it('threads request and stopOnEntry into attach-mode child configs', () => {
+      const c = new MinimalDapClient('localhost', 1234, JsDebugAdapterPolicy);
+      (c as any).lastStartRequestArgs = { request: 'attach', stopOnEntry: false };
+      const enriched = (c as any).enrichChildConfig(baseConfig);
+      expect(enriched.parentConfig.request).toBe('attach');
+      expect(enriched.parentConfig.stopOnEntry).toBe(false);
+      expect(enriched.parentConfig.type).toBe('pwa-node');
+      // Original config must not be mutated
+      expect((baseConfig.parentConfig as Record<string, unknown>).request).toBeUndefined();
+      c.shutdown();
+    });
+
+    it('omits stopOnEntry when the attach request did not carry a boolean', () => {
+      const c = new MinimalDapClient('localhost', 1234, JsDebugAdapterPolicy);
+      (c as any).lastStartRequestArgs = { request: 'attach' };
+      const enriched = (c as any).enrichChildConfig(baseConfig);
+      expect(enriched.parentConfig.request).toBe('attach');
+      expect('stopOnEntry' in enriched.parentConfig).toBe(false);
+      c.shutdown();
+    });
+  });
+
 });

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -1307,6 +1307,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       // Shrink the attach verification window so failure-path tests stay fast.
       (operations as unknown as { attachVerifyTimeoutMs: number }).attachVerifyTimeoutMs = 200;
       (operations as unknown as { attachVerifyIntervalMs: number }).attachVerifyIntervalMs = 10;
+      (operations as unknown as { attachPauseStopTimeoutMs: number }).attachPauseStopTimeoutMs = 50;
     });
 
     it('should discover main thread when available', async () => {
@@ -1454,6 +1455,78 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(result.state).toBe(SessionState.ERROR);
       expect(result.error).toContain('Child session not ready');
       expect(mockProxyManager.setCurrentThreadId).not.toHaveBeenCalled();
+    });
+
+    it('should invoke the adapter policy performHandshake for attach when the policy defines it', async () => {
+      // js-debug's DAP attach sequence is driven by performHandshake; before
+      // issue #124 attachToProcess never called it, so no attach request ever
+      // reached the adapter. Policies without performHandshake are no-ops.
+      const handshakeSpy = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(operations as any, 'selectPolicy').mockReturnValue({
+        performHandshake: handshakeSpy,
+        getAttachBehavior: () => undefined
+      });
+
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'threads') {
+          return { body: { threads: [{ id: 1, name: 'main' }] } };
+        }
+        return {};
+      });
+
+      vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+        return { request: 'attach', port: 5005 };
+      });
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 5005,
+        host: 'localhost',
+        stopOnEntry: true
+      });
+
+      expect(result.success).toBe(true);
+      expect(handshakeSpy).toHaveBeenCalledTimes(1);
+      expect(handshakeSpy.mock.calls[0][0]).toMatchObject({
+        sessionId: 'test-session',
+        scriptPath: 'attach://remote',
+        dapLaunchArgs: expect.objectContaining({
+          request: 'attach',
+          __attachMode: true,
+          port: 5005
+        }),
+        launchConfig: { request: 'attach', port: 5005 }
+      });
+    });
+
+    it('should tolerate a performHandshake failure and still verify the attach', async () => {
+      const handshakeSpy = vi.fn().mockRejectedValue(new Error('handshake exploded'));
+      vi.spyOn(operations as any, 'selectPolicy').mockReturnValue({
+        performHandshake: handshakeSpy,
+        getAttachBehavior: () => undefined
+      });
+
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'threads') {
+          return { body: { threads: [{ id: 1, name: 'main' }] } };
+        }
+        return {};
+      });
+
+      vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+      });
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 5005,
+        host: 'localhost',
+        stopOnEntry: true
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Language handshake for attach returned with warning/error')
+      );
     });
 
     it('should succeed when threads appear during the verification window', async () => {


### PR DESCRIPTION
## Summary

PR 2 of 2 for #124 (truthful reporting landed in #129). JS attach never worked because nobody ever sent the DAP `attach` request: JavaScript is the only policy with `requiresCommandQueueing() === true`, which routes it past the worker-driven handshake, and the policy-side `performHandshake` (whose attach branch existed but was dead) was only invoked from `startDebugging`. js-debug's DAP server sat idle; no child session; no connection to the inspector.

## Changes

- `attachToProcess` now invokes `policy.performHandshake` exactly as `startDebugging` does (no-op for the 7 policies that don't define it; contract documented in `adapter-policy.ts`).
- JS adapter gains `supportsAttach`/`transformAttachConfig` (the launch transform hardcoded `request:'launch'` and dropped port/host); the attach branch honors the caller's host instead of hardcoded 127.0.0.1.
- Worker sets `isAttachMode` for queueing policies, so detach uses `terminateDebuggee: false` — detaching no longer kills the user's target.
- Auto-continue is now launch-only: the entry-stop heuristic was treating the deliberate post-attach pause as an entry stop and resuming the target 3 ms after we paused it (DAP-trace verified).
- Child-session attach intent threading: js-debug's reverse `startDebugging` config carries only `{type, name, __pendingTargetId}`, so `MinimalDapClient` records the parent attach args and threads `request` + `stopOnEntry` into the child config; `ChildSessionManager` skips its entry-stop gate for attach parents (it stalled adoption 15 s waiting for an entry stop that never comes, and wrongly paused `stopOnEntry:false` attaches).

## Empirical findings (trace-verified against a live target)

- `attachSimplePort` + `port` together make js-debug attach to the same inspector **twice**; with `continueOnAttach` the two targets fight (every pause immediately `continued`, "Thread is not paused" on stackTrace). `attachSimplePort` dropped — one target, stable pauses.
- The reverse-request config never echoes `stopOnEntry`, so the child gate `parentConfig?.stopOnEntry !== false` always ran — fixed via intent threading.

## Acceptance (live e2e transcript)

Attach to real `node --inspect` → verified `paused` backed by a real stop → `list_threads` 1 thread → real stack frames → breakpoint on `counter += 1` → continue → **breakpoint hit** → `evaluate_expression counter` returns live value → `detach_from_process` → **target alive and ticking again**. Plus `stopOnEntry:false` attach → `state:"running"`, target never stops.

## Gates (all local, all green)

Full unit 2309 (+7 new); lint clean; JS attach e2e 3/3 (the #129 invariant test now takes its success branch); Ruby attach 1/1; Java attach 2/2; JS launch smoke 3/3; integration 21 passed / 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)