### PR TITLE
chore(release): prepare v0.22.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+      uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       ref:
         description: 'Git ref (tag or branch) to release from'
         required: true
-        default: 'refs/tags/v0.21.0'
+        default: 'refs/tags/v0.22.0'
 
 permissions: {}
 
@@ -61,6 +61,14 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '21'
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74  # v1.314.0
+      with:
+        ruby-version: '3.3'
+
+    - name: Verify rdbg (bundled debug gem)
+      run: rdbg --version
 
     - name: Sanity versions
       run: |
@@ -249,6 +257,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '21'
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74  # v1.314.0
+      with:
+        ruby-version: '3.3'
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-06
+
 ### Added
 - **Ruby debugging support** – launch and attach via `rdbg` (debug gem) DAP, including remote attach to containers and Kubernetes pods through port forwarding; conditional breakpoints, locals, repl-context expression evaluation, detach/re-attach (adapted from PR #88, contributed by [@Poyraxx](https://github.com/Poyraxx))
 - **Direct-connect attach** – adapter policies can now return a `connect`-mode spawn config to attach straight to an already-listening DAP server without spawning an adapter process; policy selection is driven by the session language via a single shared `getPolicyForLanguage()` mapping instead of adapter-command sniffing
 - **Ruby documentation** – `docs/ruby/README.md` user guide with verified launch/attach flows and Docker/Kubernetes remote-attach walkthroughs (`examples/ruby/remote-attach/`)
 
 ### Fixed
+- **JavaScript attach mode** – establish the js-debug child session when attaching, so breakpoints, stepping, and inspection work for attached Node.js processes (#131, fixes #124)
+- **Truthful attach failures** – `attach_to_process` now reports adapter/connection errors instead of returning an empty success (#129)
+- **`pause_execution` state** – reports the correct session state instead of a stale one (#119)
+- **Proxy lifecycle** – the per-session proxy process is stopped when a debuggee terminates naturally, eliminating leaked proxy processes (#127)
+- **Server orphan self-defense** – a stdin watchdog shuts the server down when its MCP client disappears, and backend shutdown is graceful across stdio/http/sse commands (#130)
+- **Proxy bootstrap heartbeat** – removed a one-sided heartbeat that could kill healthy proxies during slow startups (#126, fixes #123)
+- **Logging** – per-process log files prevent multi-process rotation races, and a rotation-failure latch stops runaway retry loops (#128, fixes #121)
+- **Python interpreter validation** – a configured `pythonPath` is validated for debugpy availability up front, with a clear error instead of a hang (#107, fixes #106)
+- **Java adapter vendoring** – honors `SKIP_ADAPTER_VENDOR` and skips gracefully on a `javac` older than JDK 21 (#116)
 - Attach sessions no longer apply host-side file existence checks to breakpoint paths — attach targets may run on a remote filesystem (container, pod, other machine)
 - `test:unit` now actually runs the per-adapter unit suites on Windows (the `tests/adapters/*/unit` glob never expanded under cmd.exe)
 - CLI bundle prepare-pack workspace list updated for new adapter packages
+
+### Changed
+- Test suite parallelized and hardened via Vitest projects — unit suite runtime dropped from ~12 minutes to ~10 seconds (#110)
+- README refreshed with current capabilities and language matrix (#87)
+
+### Dependencies
+- Bumped `commander` 14 → 15. The CLI surface is unchanged; `commander` is bundled into the published CLI, so end-user installs are unaffected. (#92)
 
 ## [0.21.0] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through debugging as structured tool calls. It lets AI agents set breakpoints, inspect variables, evaluate expressions, and step through running programs across seven languages — driving real language debuggers through the Debug Adapter Protocol (DAP).
 
-> 🆕 **v0.21.0** — the minimum runtime is now **Node.js 22+** (Node 20 reached end-of-life). See the [CHANGELOG](./CHANGELOG.md) for the full release history.
+> 🆕 **v0.22.0** — **Ruby debugging support** lands (launch + attach via `rdbg`, including remote attach to containers and Kubernetes pods), alongside JavaScript attach-mode fixes and session/proxy lifecycle hardening. See the [CHANGELOG](./CHANGELOG.md) for the full release history.
 
 ## ✨ Key Features
 
@@ -87,7 +87,7 @@ claude mcp list
 docker run -v $(pwd):/workspace debugmcp/mcp-debugger:latest
 ```
 
-> ⚠️ The Docker image ships Python, JavaScript, Go, Java, and .NET adapters. Rust debugging requires the local, SSE, or packed deployments where the adapter runs next to your toolchain. Note: adapters are loaded dynamically at runtime — only those whose toolchain is installed and detected will be reported as available by `list_supported_languages`.
+> ⚠️ The Docker image bundles the toolchains for **Python, JavaScript, and Java** debugging (Rust, Go, and .NET are disabled inside the container image, and the image does not include a Ruby runtime). For those languages, run the server via npm/npx next to your local toolchain — or, for Ruby, use remote attach to a `rdbg --open` process inside the container (see the [Ruby guide](./docs/ruby/README.md)). Adapters load dynamically at runtime — `list_supported_languages` reports only those whose toolchain is detected.
 
 ### Using npm
 
@@ -159,15 +159,13 @@ Version 0.10.0 introduces a clean adapter pattern that separates language-agnost
                     ┌──────────────┐      ┌─────────────────┐
                     │ ProxyManager │◀─────│ Language Adapter│
                     └──────────────┘      └─────────────────┘
-                                                   │
-                          ┌──────────────┴──────────────────────────────────────────┐
-                          │                                                          │
-              ┌───────────┼───────────┬───────────┬───────────┬───────────┐          │
-              │           │           │           │           │           │          │
-        ┌─────▼────┐┌─────▼────┐┌─────▼────┐┌─────▼────┐┌─────▼────┐┌─────▼────┐
-        │Python    ││JavaScript││Rust      ││Go        ││Java      ││Dotnet    ││Mock      │
-        │Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   │
-        └──────────┘└──────────┘└──────────┘└──────────┘└──────────┘└──────────┘└──────���───┘
+                                                  │
+              ┌───────────┬───────────┬───────────┼───────────┬───────────┬───────────┬───────────┐
+              │           │           │           │           │           │           │           │
+        ┌─────▼────┐┌─────▼────┐┌─────▼────┐┌─────▼────┐┌─────▼────┐┌─────▼────┐┌─────▼────┐┌─────▼────┐
+        │Python    ││Ruby      ││JavaScript││Rust      ││Go        ││Java      ││.NET      ││Mock      │
+        │Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   ││Adapter   │
+        └──────────┘└──────────┘└──────────┘└──────────┘└──────────┘└──────────┘└──────────┘└──────────┘
 ```
 
 ### Adding Language Support
@@ -312,6 +310,7 @@ Then get the local variables:
 - 🟨 [JavaScript Debugging Guide](./docs/javascript/README.md) – JavaScript/TypeScript features
 - 🐹 [Go Debugging Guide](./docs/go/README.md) – Go debugging with Delve
 - ☕ [Java Debugging Guide](./docs/java/README.md) – Java debugging with JDI bridge
+- 🔷 [.NET Debugging Guide](./docs/dotnet/README.md) – .NET/C# debugging with netcoredbg
 - [Rust Debugging on Windows](docs/rust-debugging-windows.md) - Toolchain requirements and troubleshooting
 - 🔧 [Troubleshooting](./docs/troubleshooting.md) – Common issues & solutions
 
@@ -379,7 +378,7 @@ See [tests/README.md](./tests/README.md) for detailed testing instructions.
 
 ## 📊 Project Status
 
-- ✅ **Production Ready**: v0.21.0 with seven language adapters and polished multi-language distribution
+- ✅ **Production Ready**: v0.22.0 with seven language adapters and polished multi-language distribution
 - ✅ **Clean architecture** with a dynamic adapter pattern
 - ✅ **Python · Ruby · JavaScript/TypeScript · Go · Java · .NET/C#**: Full step-through debugging
 - 🦀 **Rust**: Full support on Linux/macOS/Windows (Windows requires the GNU toolchain; MSVC is not supported by CodeLLDB)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-debugger-monorepo",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Run-time step-through debugging for LLM agents - Monorepo root",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/adapter-dotnet/package.json
+++ b/packages/adapter-dotnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-dotnet",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": ".NET/C# debug adapter for MCP debugger using netcoredbg",
   "type": "module",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.21.0"
+    "@debugmcp/shared": "0.22.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-go/package.json
+++ b/packages/adapter-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-go",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Go debugging adapter for mcp-debugger using Delve",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-java/package.json
+++ b/packages/adapter-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-java",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Java debug adapter for MCP Debugger using JDI bridge",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-javascript/package.json
+++ b/packages/adapter-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-javascript",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "JavaScript/TypeScript debug adapter for MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -34,7 +34,7 @@
     "@vscode/debugprotocol": "^1.68.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.21.0"
+    "@debugmcp/shared": "0.22.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-mock",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Mock debug adapter for testing MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.21.0"
+    "@debugmcp/shared": "0.22.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-python/package.json
+++ b/packages/adapter-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-python",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Python debug adapter for MCP debugger using debugpy",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.21.0"
+    "@debugmcp/shared": "0.22.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-ruby/package.json
+++ b/packages/adapter-ruby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-ruby",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Ruby debug adapter for MCP debugger using rdbg",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.21.0"
+    "@debugmcp/shared": "0.22.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-rust",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Rust debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-debugger/package.json
+++ b/packages/mcp-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/mcp-debugger",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Step-through debugging MCP server for LLMs",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/shared",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Shared interfaces, types, and utilities for MCP Debugger",
   "homepage": "https://github.com/debugmcp/mcp-debugger/tree/main/packages/shared",
   "repository": {

--- a/scripts/release-dry-run.sh
+++ b/scripts/release-dry-run.sh
@@ -24,6 +24,7 @@ ROOT_VER=$(node -e "console.log(require('./package.json').version)")
 SHARED_VER=$(node -e "console.log(require('./packages/shared/package.json').version)")
 MOCK_VER=$(node -e "console.log(require('./packages/adapter-mock/package.json').version)")
 PYTHON_VER=$(node -e "console.log(require('./packages/adapter-python/package.json').version)")
+RUBY_VER=$(node -e "console.log(require('./packages/adapter-ruby/package.json').version)")
 GO_VER=$(node -e "console.log(require('./packages/adapter-go/package.json').version)")
 JAVA_VER=$(node -e "console.log(require('./packages/adapter-java/package.json').version)")
 JS_VER=$(node -e "console.log(require('./packages/adapter-javascript/package.json').version)")
@@ -35,6 +36,7 @@ echo "  Root:               $ROOT_VER"
 echo "  shared:             $SHARED_VER"
 echo "  adapter-mock:       $MOCK_VER"
 echo "  adapter-python:     $PYTHON_VER"
+echo "  adapter-ruby:       $RUBY_VER"
 echo "  adapter-go:         $GO_VER"
 echo "  adapter-java:       $JAVA_VER"
 echo "  adapter-javascript: $JS_VER"
@@ -42,7 +44,7 @@ echo "  adapter-rust:       $RUST_VER"
 echo "  adapter-dotnet:     $DOTNET_VER"
 echo "  mcp-debugger:       $CLI_VER"
 
-if [[ "$ROOT_VER" == "$SHARED_VER" && "$ROOT_VER" == "$MOCK_VER" && "$ROOT_VER" == "$PYTHON_VER" && "$ROOT_VER" == "$GO_VER" && "$ROOT_VER" == "$JAVA_VER" && "$ROOT_VER" == "$JS_VER" && "$ROOT_VER" == "$RUST_VER" && "$ROOT_VER" == "$DOTNET_VER" && "$ROOT_VER" == "$CLI_VER" ]]; then
+if [[ "$ROOT_VER" == "$SHARED_VER" && "$ROOT_VER" == "$MOCK_VER" && "$ROOT_VER" == "$PYTHON_VER" && "$ROOT_VER" == "$RUBY_VER" && "$ROOT_VER" == "$GO_VER" && "$ROOT_VER" == "$JAVA_VER" && "$ROOT_VER" == "$JS_VER" && "$ROOT_VER" == "$RUST_VER" && "$ROOT_VER" == "$DOTNET_VER" && "$ROOT_VER" == "$CLI_VER" ]]; then
   pass "All package versions match ($ROOT_VER)"
 else
   fail "Package versions are inconsistent"
@@ -84,7 +86,7 @@ fi
 # --- 5. npm pack dry-run and provenance readiness ---
 echo ""
 echo "── npm pack dry-run ──"
-PUBLISHED_PKGS=("shared" "adapter-mock" "adapter-python" "mcp-debugger")
+PUBLISHED_PKGS=("shared" "adapter-mock" "adapter-python" "adapter-ruby" "mcp-debugger")
 for pkg_dir in "${PUBLISHED_PKGS[@]}"; do
   pkg_name=$(node -e "console.log(require('./packages/$pkg_dir/package.json').name)")
   if npm pack --dry-run -w "$pkg_name" > /dev/null 2>&1; then
@@ -156,7 +158,7 @@ else
 fi
 
 # Check if packages already exist at this version (would be skipped during publish)
-for pkg in @debugmcp/shared @debugmcp/adapter-mock @debugmcp/adapter-python @debugmcp/mcp-debugger; do
+for pkg in @debugmcp/shared @debugmcp/adapter-mock @debugmcp/adapter-python @debugmcp/adapter-ruby @debugmcp/mcp-debugger; do
   if npm view "${pkg}@${ROOT_VER}" version > /dev/null 2>&1; then
     warn "${pkg}@${ROOT_VER} already published — will be skipped"
   fi


### PR DESCRIPTION
## Summary

Release prep for **v0.22.0** — the first release since 2026-05-30 (49 commits), headlined by the new Ruby adapter (first-ever publish of `@debugmcp/adapter-ruby`).

- **CHANGELOG**: date the 0.22.0 section and backfill entries that never made it in: JS attach child session (#131), truthful attach failures (#129), pause_execution state (#119), proxy stopped on natural termination (#127), CLI orphan self-defense (#130), bootstrap heartbeat removal (#126), per-process log files (#128), Python interpreter validation (#107), Java vendoring skip (#116), commander 14→15 (#92), test-suite overhaul (#110), README refresh (#87)
- **README**: v0.22.0 callouts; add Ruby to the adapter diagram and repair its corrupted row (3 stray U+FFFD bytes); correct the Docker note (image supports Python/JavaScript/Java — Rust/Go/.NET are disabled in-image and there is no Ruby runtime); link the .NET guide
- **release-dry-run.sh**: cover `adapter-ruby` in version-consistency, npm-pack, and already-published checks (it was publishable in release.yml but invisible to the preflight)
- **release.yml**: add the Ruby toolchain to `build-and-test` and `npm-publish` (per docs/release-checklist.md); bump workflow_dispatch default ref to v0.22.0
- **Versions**: sync all 11 package.jsons to 0.22.0 via `scripts/sync-versions.cjs` (includes adapter-ruby's pinned `@debugmcp/shared` peerDep)

## Test plan
- [x] `npm run build` clean
- [x] `npm run test:unit` — 2353/2353 pass
- [ ] CI green on this PR
- [ ] `npm run release:dry-run` on main after merge, then tag `v0.22.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)