### PR TITLE
fix: report pending success instead of failing when step/pause outlives grace window

### DIFF
--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -28,10 +28,11 @@ export const ErrorMessages = {
     `This may indicate that the debug adapter failed to start or is not properly configured. ` +
     `Check that the required debug adapter is installed and accessible.`,
   
-  stepTimeout: (timeout: number) =>
-    `Step operation did not complete within ${timeout}s. ` +
-    `The debug adapter may have crashed or the program may be stuck. ` +
-    `Try restarting your debug session.`,
+  stepStillRunning: (graceSeconds: number) =>
+    `Step dispatched; the program is still executing after ${graceSeconds}s ` +
+    `(e.g. stepping over a long-running call). The session remains 'running' and will ` +
+    `become 'paused' when the step completes. Check the session state, or call ` +
+    `pause_execution to interrupt.`,
   
   adapterReadyTimeout: (timeout: number) =>
     `Timed out waiting for debug adapter to be ready after ${timeout}s. ` +
@@ -176,18 +177,26 @@ setTimeout(() => {
 }, 35000);
 ```
 
-**Example**: SessionManager step operation timeout (`src/session/session-manager-operations.ts`)
+**Example**: SessionManager step operation grace window (`src/session/session-manager-operations.ts`)
+
+Note: a step that outlives the grace window is *not* an error — the debuggee may
+legitimately run for a long time (e.g. stepping over a slow call). The tool
+returns a truthful `pending` success and the step completes asynchronously via
+the persistent `handleStopped` listener in `session-manager-core.ts`.
 
 ```typescript
 return new Promise((resolve) => {
   const timeout = setTimeout(() => {
-    this.logger.warn(`[SM stepOver ${sessionId}] Timeout waiting for stopped event`);
-    resolve({ 
-      success: false, 
-      error: ErrorMessages.stepTimeout(5), 
-      state: session.state 
+    this.logger.info(`[SM stepOver ${sessionId}] Step still running after grace window; completing asynchronously`);
+    resolve({
+      success: true,
+      state: session.state, // still RUNNING
+      data: {
+        message: ErrorMessages.stepStillRunning(this.stepGraceMs / 1000),
+        pending: true,
+      },
     });
-  }, 5000);
+  }, this.stepGraceMs);
   
   session.proxyManager?.once('stopped', () => {
     clearTimeout(timeout);

--- a/docs/patterns/event-management.md
+++ b/docs/patterns/event-management.md
@@ -314,16 +314,21 @@ const handleExit = (code: number | null, signal?: string) => {
 **Location**: `src/session/session-manager-operations.ts`
 
 ```typescript
-// Wait for stopped event
+// Wait for stopped event, with a grace window rather than a hard deadline:
+// a step that outlives the window returns a truthful `pending` success and
+// completes asynchronously via the persistent handleStopped listener.
 return new Promise((resolve) => {
   const timeout = setTimeout(() => {
-    this.logger.warn(`[SM stepOver ${sessionId}] Timeout waiting for stopped event`);
-    resolve({ 
-      success: false, 
-      error: ErrorMessages.stepTimeout(5), 
-      state: session.state 
+    this.logger.info(`[SM stepOver ${sessionId}] Step still running after grace window; completing asynchronously`);
+    resolve({
+      success: true,
+      state: session.state, // still RUNNING
+      data: {
+        message: ErrorMessages.stepStillRunning(this.stepGraceMs / 1000),
+        pending: true,
+      },
     });
-  }, 5000);
+  }, this.stepGraceMs);
   
   session.proxyManager?.once('stopped', () => {
     clearTimeout(timeout);

--- a/src/server.ts
+++ b/src/server.ts
@@ -614,11 +614,11 @@ export class DebugMcpServer {
             }
           },
           { name: 'close_debug_session', description: 'Close a debugging session', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'step_over', description: 'Step over', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'step_into', description: 'Step into', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'step_out', description: 'Step out', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'continue_execution', description: 'Continue execution', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'pause_execution', description: 'Pause a running program', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, threadId: { type: 'number', description: 'Thread ID to pause. If omitted or 0, pauses all threads.' } }, required: ['sessionId'] } },
+          { name: 'step_over', description: 'Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state "running" and pending:true — the session becomes "paused" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+          { name: 'step_into', description: 'Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state "running" and pending:true — the session becomes "paused" when the step completes', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+          { name: 'step_out', description: 'Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state "running" and pending:true — the session becomes "paused" when the step completes', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+          { name: 'continue_execution', description: 'Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When a breakpoint is hit later the session state becomes "paused" (check list_debug_sessions)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+          { name: 'pause_execution', description: 'Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code), returns success with pending:true and the session reports "paused" once the stop lands', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, threadId: { type: 'number', description: 'Thread ID to pause. If omitted or 0, pauses all threads.' } }, required: ['sessionId'] } },
           { name: 'list_threads', description: 'List all threads in the debugged process', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
           { name: 'get_variables', description: 'Get variables (scope is variablesReference: number)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, scope: { type: 'number', description: "The variablesReference number from a StackFrame or Variable" } }, required: ['sessionId', 'scope'] } },
           { name: 'get_local_variables', description: 'Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeSpecial: { type: 'boolean', description: 'Include special/internal variables like this, __proto__, __builtins__, etc. Default: false' } }, required: ['sessionId'] } },
@@ -1001,14 +1001,23 @@ export class DebugMcpServer {
 
                 // Build response with location and line context if available
                 const stepType = toolName.replace('step_', '').replace('_', ' ');
+                const resultData = stepResult.data as { message?: string; location?: { file: string; line: number; column?: number }; pending?: boolean } | undefined;
                 const response: Record<string, unknown> = {
                   success: stepResult.success,
                   message: `Stepped ${stepType}`,
                   state: stepResult.state
                 };
 
+                // A pending step means the program is still executing (e.g. stepping
+                // over a long-running call); report that truthfully instead of "Stepped".
+                if (resultData?.pending) {
+                  response.pending = true;
+                  if (resultData.message) {
+                    response.message = resultData.message;
+                  }
+                }
+
                 // Extract location from result data
-                const resultData = stepResult.data as { message?: string; location?: { file: string; line: number; column?: number } } | undefined;
                 const location = resultData?.location;
 
                 if (location) {

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -76,6 +76,17 @@ export abstract class SessionManagerOperations extends SessionManagerData {
    */
   protected attachPauseStopTimeoutMs = 5000;
 
+  /**
+   * Grace windows for step and pause operations: how long to wait for the
+   * 'stopped' event before returning a truthful "still running" success
+   * (data.pending = true). These are NOT deadlines on the debuggee — a step
+   * over a long-running call or a pause of a target blocked in native code
+   * completes asynchronously via the core handleStopped listener, which has
+   * no timeout. Protected so tests can shrink the windows.
+   */
+  protected stepGraceMs = 5000;
+  protected pauseGraceMs = 5000;
+
   protected async startProxyManager(
     session: ManagedSession,
     scriptPath: string,
@@ -1100,15 +1111,18 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       const onExit = () => success(exitedMessage);
 
       const timeout = setTimeout(() => {
-        this.logger.warn(
-          `[SM ${options.logTag} ${sessionId}] Timeout waiting for stopped or termination event`
+        this.logger.info(
+          `[SM ${options.logTag} ${sessionId}] Step still running after ${this.stepGraceMs}ms grace window; completing asynchronously`
         );
         settle({
-          success: false,
-          error: ErrorMessages.stepTimeout(5),
+          success: true,
           state: session.state,
+          data: {
+            message: ErrorMessages.stepStillRunning(this.stepGraceMs / 1000),
+            pending: true,
+          },
         });
-      }, 5000);
+      }, this.stepGraceMs);
 
       proxyManager.on('stopped', onStopped);
       proxyManager.on('terminated', onTerminated);
@@ -1292,15 +1306,18 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       });
 
       const timeout = setTimeout(() => {
-        this.logger.warn(
-          `[SessionManager pause] Timeout waiting for stopped event in session ${sessionId}`
+        this.logger.info(
+          `[SessionManager pause] No stopped event within ${this.pauseGraceMs}ms grace window in session ${sessionId}; completing asynchronously`
         );
         settle({
-          success: false,
-          error: ErrorMessages.pauseTimeout(5),
+          success: true,
           state: session.state,
+          data: {
+            message: ErrorMessages.pausePending(this.pauseGraceMs / 1000),
+            pending: true,
+          },
         });
-      }, 5000);
+      }, this.pauseGraceMs);
 
       proxyManager.on('stopped', onStopped);
       proxyManager.on('terminated', onEnded);

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -30,28 +30,31 @@ export const ErrorMessages = {
     `Check that the required debug adapter is installed and accessible.`,
   
   /**
-   * Error message for step operation timeouts
-   * Occurs when: A step operation (stepOver, stepInto, stepOut) doesn't receive a 'stopped' event within the timeout
-   * Used in: src/session/session-manager.ts
-   * Default timeout: 5 seconds
-   * @param timeout - The timeout duration in seconds
+   * Informational message for step operations still executing after the grace window
+   * Occurs when: A step operation (stepOver, stepInto, stepOut) doesn't receive a 'stopped' event
+   * within the grace window — usually because the step runs long-lived user code, which is not an error
+   * Used in: src/session/session-manager-operations.ts
+   * Default grace window: 5 seconds
+   * @param graceSeconds - The grace window duration in seconds
    */
-  stepTimeout: (timeout: number) =>
-    `Step operation did not complete within ${timeout}s. ` +
-    `The debug adapter may have crashed or the program may be stuck. ` +
-    `Try restarting your debug session.`,
+  stepStillRunning: (graceSeconds: number) =>
+    `Step dispatched; the program is still executing after ${graceSeconds}s ` +
+    `(e.g. stepping over a long-running call). The session remains 'running' and will ` +
+    `become 'paused' when the step completes. Check the session state, or call ` +
+    `pause_execution to interrupt.`,
 
   /**
-   * Error message for pause operation timeouts
-   * Occurs when: A pause request doesn't receive a 'stopped' event within the timeout
+   * Informational message for pause requests not yet honored within the grace window
+   * Occurs when: A pause request is acknowledged but no 'stopped' event arrives within the grace
+   * window — the target may be blocked in native code or a syscall, which is not an error
    * Used in: src/session/session-manager-operations.ts
-   * Default timeout: 5 seconds
-   * @param timeout - The timeout duration in seconds
+   * Default grace window: 5 seconds
+   * @param graceSeconds - The grace window duration in seconds
    */
-  pauseTimeout: (timeout: number) =>
-    `Pause request was accepted but no 'stopped' event arrived within ${timeout}s. ` +
-    `The program may not be pausable right now (e.g. blocked in native code). ` +
-    `Check the session state or try again.`,
+  pausePending: (graceSeconds: number) =>
+    `Pause requested; no 'stopped' event within ${graceSeconds}s ` +
+    `(the program may be blocked in native code or a syscall). The session will report ` +
+    `'paused' once the stop lands. Check the session state to confirm.`,
 
 
   /**

--- a/tests/core/unit/server/server-control-tools.test.ts
+++ b/tests/core/unit/server/server-control-tools.test.ts
@@ -8,6 +8,7 @@ import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { DebugMcpServer } from '../../../../src/server.js';
 import { SessionManager } from '../../../../src/session/session-manager.js';
 import { Breakpoint } from '@debugmcp/shared';
+import { ErrorMessages } from '../../../../src/utils/error-messages.js';
 import { createProductionDependencies } from '../../../../src/container/dependencies.js';
 import {
   createMockDependencies,
@@ -341,6 +342,42 @@ describe('Server Control Tools Tests', () => {
       const content = JSON.parse(result.content[0].text);
       expect(content.success).toBe(false);
       expect(content.error).toContain('Session not found: test-session');
+    });
+
+    it.each([
+      ['step_over', 'stepOver'],
+      ['step_into', 'stepInto'],
+      ['step_out', 'stepOut']
+    ])('should surface a pending %s truthfully while the program is still running', async (toolName, methodName) => {
+      // Mock session validation
+      mockSessionManager.getSession.mockReturnValue({
+        id: 'test-session',
+        sessionLifecycle: 'ACTIVE' // Not terminated
+      });
+      // A step that outlives the grace window resolves with a pending marker
+      const stepResult = {
+        success: true,
+        state: 'running',
+        data: { message: ErrorMessages.stepStillRunning(5), pending: true }
+      };
+      mockSessionManager[methodName].mockResolvedValue(stepResult);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: toolName,
+          arguments: { sessionId: 'test-session' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.state).toBe('running');
+      expect(content.pending).toBe(true);
+      // The truthful still-running message must replace the default "Stepped X"
+      expect(content.message).toBe(ErrorMessages.stepStillRunning(5));
+      // No stop yet, so there is no location to report
+      expect(content.location).toBeUndefined();
     });
 
     it.each([

--- a/tests/core/unit/session/session-manager-dap.test.ts
+++ b/tests/core/unit/session/session-manager-dap.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SessionManager, SessionManagerConfig } from '../../../../src/session/session-manager.js';
-import { DebugLanguage } from '@debugmcp/shared';
+import { DebugLanguage, SessionState } from '@debugmcp/shared';
 import { createMockDependencies } from './session-manager-test-utils.js';
 import { ErrorMessages } from '../../../../src/utils/error-messages.js';
 import { ProxyNotRunningError } from '../../../../src/errors/debug-errors.js';
@@ -181,20 +181,29 @@ describe('SessionManager - DAP Operations', () => {
       expect(result.error).toBe('Not paused');
     });
 
-    it('should handle step timeout', async () => {
+    it('should report a pending step when the grace window elapses', async () => {
       const session = await createPausedSession();
-      
+
       // Configure mock to not emit stopped event after step
       dependencies.mockProxyManager.sendDapRequest = vi.fn().mockResolvedValue({ success: true });
-      
+
       const stepPromise = sessionManager.stepOver(session.id);
-      
-      // Fast forward past timeout
+
+      // Fast forward past the grace window
       await vi.advanceTimersByTimeAsync(6000);
-      
+
       const result = await stepPromise;
-      expect(result.success).toBe(false);
-      expect(result.error).toBe(ErrorMessages.stepTimeout(5));
+      expect(result.success).toBe(true);
+      const data = result.data as { message?: string; pending?: boolean };
+      expect(data.pending).toBe(true);
+      expect(data.message).toBe(ErrorMessages.stepStillRunning(5));
+
+      // The pending step completes asynchronously: when the stop finally
+      // lands, the persistent core listener flips the session to PAUSED.
+      expect(sessionManager.getSession(session.id)?.state).toBe(SessionState.RUNNING);
+      dependencies.mockProxyManager.simulateStopped(1, 'step');
+      await vi.runAllTimersAsync();
+      expect(sessionManager.getSession(session.id)?.state).toBe(SessionState.PAUSED);
     });
 
     it('should treat termination during step as a successful completion', async () => {

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -365,26 +365,31 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(result.error).toContain('DAP protocol error');
     });
 
-    it('should handle stepOut failure with timeout', async () => {
+    it('should report a pending step when no stopped event arrives within the grace window', async () => {
       vi.useFakeTimers();
-      
+
       mockSession.state = SessionState.PAUSED;
-      // Simulate timeout by not calling the 'stopped' event
+      // Simulate a long-running step by not emitting the 'stopped' event
       mockProxyManager.sendDapRequest.mockResolvedValue({});
-      
+
       // Setup once to do nothing (no stopped event will fire)
       mockProxyManager.once.mockImplementation(() => {});
 
       const stepOutPromise = operations.stepOut('test-session');
-      
-      // Fast-forward past the timeout (5 seconds)
+
+      // Fast-forward past the grace window (5 seconds)
       await vi.advanceTimersByTimeAsync(5100);
-      
+
       const result = await stepOutPromise;
-      
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('did not complete within 5s');
-      
+
+      // A slow step is not a failure: the tool reports success with a pending
+      // marker and the session completes the step asynchronously.
+      expect(result.success).toBe(true);
+      expect(result.state).toBe(SessionState.RUNNING);
+      const data = result.data as { message?: string; pending?: boolean };
+      expect(data.pending).toBe(true);
+      expect(data.message).toContain('still executing');
+
       vi.useRealTimers();
     });
 
@@ -2612,7 +2617,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(result.state).toBe(SessionState.PAUSED);
     });
 
-    it('returns a pause-timeout error when no stopped event arrives', async () => {
+    it('reports a pending pause when no stopped event arrives within the grace window', async () => {
       vi.useFakeTimers();
       try {
         mockSession.state = SessionState.RUNNING;
@@ -2622,9 +2627,14 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         await vi.advanceTimersByTimeAsync(5000);
         const result = await promise;
 
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("no 'stopped' event");
+        // A slow pause (e.g. target blocked in native code) is not a failure:
+        // the tool reports success with a pending marker; the session flips to
+        // PAUSED asynchronously when the stop lands.
+        expect(result.success).toBe(true);
         expect(result.state).toBe(SessionState.RUNNING);
+        const data = result.data as { message?: string; pending?: boolean };
+        expect(data.pending).toBe(true);
+        expect(data.message).toContain("no 'stopped' event");
       } finally {
         vi.useRealTimers();
       }

--- a/tests/unit/utils/error-messages.test.ts
+++ b/tests/unit/utils/error-messages.test.ts
@@ -15,10 +15,16 @@ describe('ErrorMessages', () => {
     expect(message).toMatch(/debug proxy/i);
   });
 
-  it('builds step timeout message', () => {
-    const message = ErrorMessages.stepTimeout(5);
+  it('builds step still-running message', () => {
+    const message = ErrorMessages.stepStillRunning(5);
     expect(message).toContain('5s');
-    expect(message).toContain('Step operation');
+    expect(message).toContain('still executing');
+  });
+
+  it('builds pause pending message', () => {
+    const message = ErrorMessages.pausePending(5);
+    expect(message).toContain('5s');
+    expect(message).toContain("no 'stopped' event");
   });
 
   it('builds adapter ready timeout message', () => {


### PR DESCRIPTION
## Problem

`step_over`/`step_into`/`step_out` and `pause_execution` blocked on the `stopped` DAP event with a hardcoded 5s deadline and returned a spurious `success:false` ("Step operation did not complete within 5s") when the debuggee was simply still executing — e.g. stepping over a long-running call, or pausing a target blocked in native code. The eventual stop was then absorbed silently by the background listener, so the user was told the step failed and the session later flipped to `paused` with no report. This was previously observed in real use (`docs/archive/MCP_DEBUGGER_COMPREHENSIVE_TEST_RESULTS.md`).

These timeouts imposed a fixed requirement on debuggee runtime behavior; they existed to keep the wait finite, not because a slow step is an error.

## Fix — truthful async semantics

Mirror how `continue_execution` already works (ack now, stop reported asynchronously):

- Keep a short grace wait (fast steps still return the new location synchronously). On expiry, return `success:true`, `state:"running"`, `pending:true` with a message explaining the session becomes `paused` when the operation completes — the persistent `handleStopped` listener (which has no timeout) already handles that transition.
- Extract the `5000` literals into protected `stepGraceMs`/`pauseGraceMs` fields (test-shrinkable), matching the existing `attach*` field pattern.
- Replace `ErrorMessages.stepTimeout`/`pauseTimeout` with informational `stepStillRunning`/`pausePending` factories.
- Surface `pending:true` and the truthful message in the step tool response instead of an unconditional "Stepped over".
- Document the blocking contract in the `step_*`/`continue_execution`/`pause_execution` tool descriptions so LLM clients know a pending step is not a failure.
- Update the pattern docs (`docs/patterns/error-handling.md`, `event-management.md`) to show the grace-window pattern.

## Testing

- Updated the tests that pinned the old failure behavior; added a test pinning the async completion path (late `stopped` → `PAUSED`).
- Full unit suite (2354) + integration pass; lint clean.
- Verified live end-to-end: stepping over a `time.sleep(15)` in a Python session returns the pending success after ~5s (previously a spurious failure), the session flips to `paused` at the post-sleep line when the sleep ends, and a trivial step still returns immediately with location/context.

## Follow-ups filed from the same audit

- #142 — `evaluate_expression` can spuriously time out on long-running expressions (uniform 35s/30s/30s request timeouts across three layers)
- #143 — attach thread-verification window (5s) hard-fails slow targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)