### PR TITLE
fix(session): make attach thread-verification window caller-configurable (fixes #143)

### DIFF
--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -206,6 +206,25 @@ return new Promise((resolve) => {
 });
 ```
 
+**Example**: SessionManager attach verification window (`src/session/session-manager-operations.ts`)
+
+After an attach handshake, DAP `threads` is polled until the debugger reports at
+least one thread. If the window elapses without threads, the attach is reported
+as a failure and the proxy is torn down (issue #124 — a debugger with no
+threads is not usable, and reporting "paused" would be a lie). Because a slow
+target (e.g. a busy or warming JVM) can legitimately need longer than the
+default window, the window is caller-configurable (issue #143):
+
+- The default lives in the protected, test-shrinkable field
+  `attachVerifyTimeoutMs` (5s), following the `stepGraceMs`/`pauseGraceMs`
+  field pattern.
+- Callers override it per attach via the `verifyTimeout` (ms) argument on
+  `attach_to_process` / `create_debug_session`; the value is validated
+  (positive finite number) and clamped to 10 minutes.
+- The failure text comes from `ErrorMessages.attachVerifyFailed(timeoutMs,
+  lastFailure)`, which names the `verifyTimeout` knob so a caller that hit the
+  window on a slow target knows how to retry.
+
 ## Error Response Patterns
 
 ### DebugResult Pattern

--- a/src/server.ts
+++ b/src/server.ts
@@ -94,6 +94,7 @@ interface ToolArguments {
   host?: string;
   processId?: number | string;
   timeout?: number;
+  verifyTimeout?: number;
   sourcePaths?: string[];
   stopOnEntry?: boolean;
   justMyCode?: boolean;
@@ -117,6 +118,7 @@ const TOOL_ARG_EXPECTED_TYPES: Record<string, 'number' | 'boolean' | 'object' | 
   // numbers
   line: 'number', linesContext: 'number', scope: 'number',
   frameId: 'number', port: 'number', timeout: 'number', threadId: 'number',
+  verifyTimeout: 'number',
   // booleans
   includeInternals: 'boolean', includeSpecial: 'boolean',
   stopOnEntry: 'boolean', justMyCode: 'boolean',
@@ -561,7 +563,7 @@ export class DebugMcpServer {
       
       return {
         tools: [
-          { name: 'create_debug_session', description: 'Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode', inputSchema: { type: 'object', properties: { language: { type: 'string', enum: supportedLanguages, description: 'Programming language for debugging' }, name: { type: 'string', description: 'Optional session name' }, executablePath: {type: 'string', description: 'Path to language executable (optional, will auto-detect if not provided)'}, host: { type: 'string', description: 'Host to attach to for remote debugging (optional, triggers attach mode)' }, port: { type: 'number', description: 'Debug port to attach to for remote debugging (optional, triggers attach mode)' }, timeout: { type: 'number', description: 'Connection timeout in milliseconds for attach mode (default: 30000)' } }, required: ['language'] } },
+          { name: 'create_debug_session', description: 'Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode', inputSchema: { type: 'object', properties: { language: { type: 'string', enum: supportedLanguages, description: 'Programming language for debugging' }, name: { type: 'string', description: 'Optional session name' }, executablePath: {type: 'string', description: 'Path to language executable (optional, will auto-detect if not provided)'}, host: { type: 'string', description: 'Host to attach to for remote debugging (optional, triggers attach mode)' }, port: { type: 'number', description: 'Debug port to attach to for remote debugging (optional, triggers attach mode)' }, timeout: { type: 'number', description: 'Connection timeout in milliseconds for attach mode (default: 30000)' }, verifyTimeout: { type: 'number', description: 'Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 5000, max: 600000)' } }, required: ['language'] } },
           { name: 'list_supported_languages', description: 'List all supported debugging languages with metadata', inputSchema: { type: 'object', properties: {} } },
           { name: 'list_debug_sessions', description: 'List all active debugging sessions', inputSchema: { type: 'object', properties: {} } },
           { name: 'set_breakpoint', description: 'Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. "com.example.MyClass" or "com.example.Outer$Inner") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths.' }, line: { type: 'number', description: 'Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior' }, condition: { type: 'string' }, suspendPolicy: { type: 'string', enum: ['all', 'thread'], description: 'Suspend policy when breakpoint is hit: "all" suspends all threads (default), "thread" only suspends the event thread. Only supported by the Java/JDI adapter.' } }, required: ['sessionId', 'file', 'line'] } },
@@ -589,7 +591,7 @@ export class DebugMcpServer {
               required: ['sessionId', 'scriptPath'] 
             } 
           },
-          { name: 'attach_to_process', description: 'Attach to a running process for debugging', inputSchema: {
+          { name: 'attach_to_process', description: 'Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~5s default) the attach fails and the debug proxy is torn down', inputSchema: {
               type: 'object',
               properties: {
                 sessionId: { type: 'string', description: 'Debug session ID' },
@@ -597,6 +599,7 @@ export class DebugMcpServer {
                 host: { type: 'string', description: 'Host to attach to (default: localhost)' },
                 processId: { type: ['number', 'string'], description: 'Process ID (for local attach, language-specific)' },
                 timeout: { type: 'number', description: 'Connection timeout in milliseconds (default: 30000)' },
+                verifyTimeout: { type: 'number', description: 'How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 5000, max: 600000). Increase for targets that are slow to become debuggable, e.g. a busy or warming JVM' },
                 sourcePaths: { type: 'array', items: { type: 'string' }, description: 'Source paths for code mapping' },
                 stopOnEntry: { type: 'boolean', description: 'Stop on entry after attaching' },
                 justMyCode: { type: 'boolean', description: 'Only debug user code (skip library code)' }
@@ -694,6 +697,7 @@ export class DebugMcpServer {
                     host: (args.host as string) || 'localhost',
                     timeout: (args.timeout as number) || 30000,
                     stopOnEntry: args.stopOnEntry,
+                    verifyTimeout: args.verifyTimeout,
                   });
 
                   result = { content: [{ type: 'text', text: JSON.stringify({
@@ -881,6 +885,7 @@ export class DebugMcpServer {
                   host: args.host,
                   processId: args.processId,
                   timeout: args.timeout,
+                  verifyTimeout: args.verifyTimeout,
                   sourcePaths: args.sourcePaths,
                   stopOnEntry: args.stopOnEntry,
                   justMyCode: args.justMyCode

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -64,6 +64,8 @@ export abstract class SessionManagerOperations extends SessionManagerData {
    * 'threads' is polled until the debugger reports at least one thread.
    * If the window elapses without any threads, the attach is reported as a
    * failure instead of a false "paused" success (issue #124).
+   * Callers can widen the window per attach via the 'verifyTimeout' tool
+   * argument for targets that are slow to become debuggable (issue #143).
    * Protected so tests can shrink the window.
    */
   protected attachVerifyTimeoutMs = 5000;
@@ -1583,6 +1585,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       sourcePaths?: string[];
       stopOnEntry?: boolean;
       justMyCode?: boolean;
+      verifyTimeout?: number;
     }
   ): Promise<DebugResult> {
     const session = this._getSessionById(sessionId);
@@ -1590,6 +1593,32 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       `[SessionManager] Attempting to attach to process for session ${sessionId}`,
       attachConfig
     );
+
+    // The verification-window override is consumed by the thread-discovery
+    // loop below, not by the adapter — strip it from the config that becomes
+    // the DAP attach arguments. Validate before any state mutation.
+    const { verifyTimeout, ...adapterAttachConfig } = attachConfig;
+    let verifyTimeoutOverride = verifyTimeout;
+    if (verifyTimeoutOverride !== undefined) {
+      if (
+        typeof verifyTimeoutOverride !== 'number' ||
+        !Number.isFinite(verifyTimeoutOverride) ||
+        verifyTimeoutOverride <= 0
+      ) {
+        return {
+          success: false,
+          state: session.state,
+          error: `'verifyTimeout' must be a positive number of milliseconds, got: ${String(verifyTimeoutOverride)}`
+        };
+      }
+      const maxVerifyTimeoutMs = 600000;
+      if (verifyTimeoutOverride > maxVerifyTimeoutMs) {
+        this.logger.warn(
+          `[SessionManager] verifyTimeout ${verifyTimeoutOverride}ms exceeds the maximum; clamping to ${maxVerifyTimeoutMs}ms`
+        );
+        verifyTimeoutOverride = maxVerifyTimeoutMs;
+      }
+    }
 
     if (session.proxyManager) {
       this.logger.warn(
@@ -1612,7 +1641,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
 
       // Pass attach config through dapLaunchArgs with special request type
       const attachLaunchArgs = {
-        ...attachConfig,
+        ...adapterAttachConfig,
         request: 'attach',
         __attachMode: true  // Internal flag to signal attach mode
       };
@@ -1667,7 +1696,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         }
         const proxyManager = session.proxyManager;
 
-        const verifyTimeoutMs = this.attachVerifyTimeoutMs;
+        const verifyTimeoutMs = verifyTimeoutOverride ?? this.attachVerifyTimeoutMs;
         const pollIntervalMs = this.attachVerifyIntervalMs;
         const deadline = Date.now() + verifyTimeoutMs;
 
@@ -1712,7 +1741,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         }
 
         if (!threads) {
-          const reason = `Attach did not become debuggable: no threads reported within ${verifyTimeoutMs}ms (last failure: ${lastFailure})`;
+          const reason = ErrorMessages.attachVerifyFailed(verifyTimeoutMs, lastFailure);
           this.logger.error(`[SessionManager] ${reason} — tearing down proxy for session ${sessionId}`);
           // Tear down the proxy using the same mechanics as closeSession, but
           // keep the session record so the failure is inspectable as ERROR.

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -58,6 +58,21 @@ export const ErrorMessages = {
 
 
   /**
+   * Error message for attach verification failures
+   * Occurs when: After an attach handshake, the debugger does not report any
+   * threads within the verification window — either the attach is dead
+   * (issue #124) or the target is slow to become debuggable (issue #143)
+   * Used in: src/session/session-manager-operations.ts
+   * Default window: 5 seconds, overridable per call via 'verifyTimeout'
+   * @param timeoutMs - The verification window in milliseconds
+   * @param lastFailure - The last observed failure while polling 'threads'
+   */
+  attachVerifyFailed: (timeoutMs: number, lastFailure: string) =>
+    `Attach did not become debuggable: no threads reported within ${timeoutMs}ms ` +
+    `(last failure: ${lastFailure}). If the target is just slow to become debuggable ` +
+    `(e.g. a busy or warming JVM), retry with a larger 'verifyTimeout' (ms) on attach_to_process.`,
+
+  /**
    * Error message for adapter ready timeouts
    * Occurs when: Waiting for the debug adapter to be configured times out
    * Used in: src/session/session-manager.ts (logged as warning)

--- a/tests/core/unit/server/server-redefine-and-attach.test.ts
+++ b/tests/core/unit/server/server-redefine-and-attach.test.ts
@@ -249,6 +249,32 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
         })
       );
     });
+
+    it('should forward verifyTimeout to the session manager (issue #143)', async () => {
+      mockSessionManager.attachToProcess.mockResolvedValue({
+        success: true,
+        state: 'paused',
+      });
+
+      await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'create_debug_session',
+          arguments: {
+            language: 'python',
+            port: 5009,
+            verifyTimeout: 12000,
+          },
+        },
+      });
+
+      expect(mockSessionManager.attachToProcess).toHaveBeenCalledWith(
+        'attach-session-1',
+        expect.objectContaining({
+          verifyTimeout: 12000,
+        })
+      );
+    });
   });
 
   describe('attach_to_process stopOnEntry', () => {
@@ -299,6 +325,32 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
         'test-session',
         expect.objectContaining({
           stopOnEntry: true,
+        })
+      );
+    });
+
+    it('should forward verifyTimeout to the session manager (issue #143)', async () => {
+      mockSessionManager.attachToProcess.mockResolvedValue({
+        success: true,
+        state: 'paused',
+      });
+
+      await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'attach_to_process',
+          arguments: {
+            sessionId: 'test-session',
+            port: 5006,
+            verifyTimeout: 12000,
+          },
+        },
+      });
+
+      expect(mockSessionManager.attachToProcess).toHaveBeenCalledWith(
+        'test-session',
+        expect.objectContaining({
+          verifyTimeout: 12000,
         })
       );
     });

--- a/tests/unit/server-coverage.test.ts
+++ b/tests/unit/server-coverage.test.ts
@@ -1344,6 +1344,12 @@ describe('coerceToolArguments', () => {
     expect(args.linesContext).toBe(5);
   });
 
+  it('converts verifyTimeout string to number', () => {
+    const args = { verifyTimeout: '9000' };
+    coerceToolArguments(args);
+    expect(args.verifyTimeout).toBe(9000);
+  });
+
   it('leaves empty string as-is for number fields', () => {
     const args = { line: '' };
     coerceToolArguments(args);

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -1404,6 +1404,8 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(result.state).toBe(SessionState.ERROR);
       expect(result.error).toContain('no threads reported');
       expect(result.error).toContain('zero threads');
+      // The failure must tell the caller which knob raises the window (#143).
+      expect(result.error).toContain('verifyTimeout');
       expect(mockProxyManager.setCurrentThreadId).not.toHaveBeenCalled();
       // The proxy must be torn down so the session is not left half-attached.
       expect(mockProxyManager.stop).toHaveBeenCalled();
@@ -1563,6 +1565,116 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(result.state).toBe(SessionState.PAUSED);
       expect(threadCalls).toBeGreaterThanOrEqual(3);
       expect(mockProxyManager.setCurrentThreadId).toHaveBeenCalledWith(7);
+    });
+
+    it('should honor a caller-provided verifyTimeout over the default window', async () => {
+      // Issue #143: the window must be adjustable per call. A shorter
+      // override proves the caller's value is the one actually applied —
+      // if the default (raised to 5s here) were used instead, the failure
+      // message would name 5000ms and the test would take seconds.
+      (operations as unknown as { attachVerifyTimeoutMs: number }).attachVerifyTimeoutMs = 5000;
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'threads') {
+          return { body: { threads: [] } };
+        }
+        return {};
+      });
+
+      vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+      });
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 5005,
+        host: 'localhost',
+        stopOnEntry: true,
+        verifyTimeout: 200
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('200ms');
+    });
+
+    it('should succeed when a larger verifyTimeout lets a slow target report threads', async () => {
+      // Models the #143 rescue: a target that only becomes debuggable after
+      // the default window (200ms via beforeEach) has elapsed succeeds when
+      // the caller extends the window.
+      (operations as unknown as { attachVerifyIntervalMs: number }).attachVerifyIntervalMs = 25;
+      const attachStartedAt = Date.now();
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'threads') {
+          if (Date.now() - attachStartedAt < 400) {
+            return { body: { threads: [] } };
+          }
+          return { body: { threads: [{ id: 9, name: 'main' }] } };
+        }
+        return {};
+      });
+
+      vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+      });
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 5005,
+        host: 'localhost',
+        stopOnEntry: true,
+        verifyTimeout: 2000
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.state).toBe(SessionState.PAUSED);
+      expect(mockProxyManager.setCurrentThreadId).toHaveBeenCalledWith(9);
+    });
+
+    it('should reject a non-positive verifyTimeout without starting a proxy', async () => {
+      const startSpy = vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+      });
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'threads') {
+          return { body: { threads: [{ id: 1, name: 'main' }] } };
+        }
+        return {};
+      });
+
+      for (const bad of [0, -5, Number.NaN]) {
+        const result = await operations.attachToProcess('test-session', {
+          port: 5005,
+          host: 'localhost',
+          stopOnEntry: true,
+          verifyTimeout: bad
+        });
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('verifyTimeout');
+      }
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not leak verifyTimeout into the adapter attach arguments', async () => {
+      // verifyTimeout is consumed by the session manager's verification loop;
+      // it must not ride the config spread into the DAP attach arguments.
+      const startSpy = vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+      });
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'threads') {
+          return { body: { threads: [{ id: 1, name: 'main' }] } };
+        }
+        return {};
+      });
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 5005,
+        host: 'localhost',
+        stopOnEntry: true,
+        verifyTimeout: 3000
+      });
+
+      expect(result.success).toBe(true);
+      const attachLaunchArgs = startSpy.mock.calls[0][3] as Record<string, unknown>;
+      expect(attachLaunchArgs).not.toHaveProperty('verifyTimeout');
+      expect(attachLaunchArgs).toMatchObject({ request: 'attach', __attachMode: true, port: 5005 });
     });
 
     it('should skip thread discovery when stopOnEntry is false', async () => {

--- a/tests/unit/utils/error-messages.test.ts
+++ b/tests/unit/utils/error-messages.test.ts
@@ -27,6 +27,14 @@ describe('ErrorMessages', () => {
     expect(message).toContain("no 'stopped' event");
   });
 
+  it('builds attach verify failed message naming the verifyTimeout knob', () => {
+    const message = ErrorMessages.attachVerifyFailed(5000, 'debugger reported zero threads');
+    expect(message).toContain('no threads reported');
+    expect(message).toContain('5000ms');
+    expect(message).toContain('debugger reported zero threads');
+    expect(message).toContain('verifyTimeout');
+  });
+
   it('builds adapter ready timeout message', () => {
     const message = ErrorMessages.adapterReadyTimeout(15);
     expect(message).toContain('15s');


### PR DESCRIPTION
## Problem

After an attach handshake, `attachToProcess` polls DAP `threads` for at most `attachVerifyTimeoutMs` (5s) and hard-fails the attach — tearing down the proxy — if no thread appears. The check is deliberate (#124: it prevents a false "paused" success on a dead attach), but the window was a hardcoded protected field, so a target that is merely slow to become debuggable (busy host, warming JVM) failed with no caller recourse.

## Change

- New optional **`verifyTimeout`** (ms) argument on `attach_to_process` and `create_debug_session` (attach mode). Validated (positive finite number, else the attach fails fast without starting a proxy) and clamped to 10 minutes with a warning. The 5s default is unchanged.
- `attachToProcess` destructures `verifyTimeout` out of the config before the spread into the DAP attach arguments, so adapters never see it, and applies it as `verifyTimeout ?? this.attachVerifyTimeoutMs` in the verification loop.
- The failure message moves to `ErrorMessages.attachVerifyFailed`, keeping the pinned `no threads reported` wording and now **naming the `verifyTimeout` knob** so a caller that hit the window on a slow target knows how to retry (per discussion on #143: keep 5s, make the failure self-explanatory).
- `verifyTimeout` registered in `TOOL_ARG_EXPECTED_TYPES` (SSE/HTTP string coercion); tool descriptions document the post-attach verification contract.
- The existing `timeout` argument is untouched — it is a connection hint copied into adapter attach configs, semantically distinct.

## Tests

TDD (all watched failing first): override honored over the default window; slow target rescued by a larger window; non-positive values rejected before proxy start; no leak into adapter attach args; failure message names the knob; both tool handlers forward the arg; SSE coercion; message factory. Full unit suite green (149 files / 2365 tests), lint clean.

## E2E verification

Via the dev proxy against a live JDWP JVM: default attach succeeds; `verifyTimeout: 30000` succeeds (override doesn't break the Java adapter path); `verifyTimeout: 0` fails fast with `'verifyTimeout' must be a positive number of milliseconds`; `verifyTimeout: 99999999` clamps and succeeds. Two pre-existing bugs found while verifying were filed separately: #145 (python attach handshake deadlock), #146 (proxy init failure leaks env/secrets into the tool response).

## Out of scope

The proxy worker's separate `ensureInitialStop(12000)` thread wait is a second timeout slow targets can hit; left as-is (noted on #143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)