### PR TITLE
fix(proxy): thread per-request DAP timeout through parent/worker/socket for evaluate and redefine (fixes #142)

### DIFF
--- a/docs/architecture/component-design.md
+++ b/docs/architecture/component-design.md
@@ -181,7 +181,11 @@ ProxyManager spawns and communicates with a debug proxy worker process over IPC 
 
 ### Request Tracking
 
-ProxyManager tracks pending DAP requests with timeout handling:
+ProxyManager tracks pending DAP requests with timeout handling. The timeout is
+derived, not hardcoded: a per-request `timeoutMs` override (from the `timeout`
+tool argument on `evaluate_expression`/`redefine_classes`, issue #142) or the
+30s default, plus a 5s margin so the worker/socket timeout — which produces the
+actionable error — always fires before this parent backstop:
 
 ```typescript
 private pendingDapRequests = new Map<string, {
@@ -191,12 +195,14 @@ private pendingDapRequests = new Map<string, {
 }>();
 
 // Timeout handler
+const effectiveTimeoutMs =
+  (options?.timeoutMs ?? this.defaultDapRequestTimeoutMs) + this.dapParentMarginMs;
 setTimeout(() => {
   if (this.pendingDapRequests.has(requestId)) {
     this.pendingDapRequests.delete(requestId);
-    reject(new Error(ErrorMessages.dapRequestTimeout(command, 35)));
+    reject(new Error(ErrorMessages.dapRequestTimeout(command, Math.round(effectiveTimeoutMs / 1000))));
   }
-}, 35000);
+}, effectiveTimeoutMs);
 ```
 
 ### Process Management

--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -167,14 +167,34 @@ async startDebugging(
 
 **Example**: ProxyManager DAP request timeout (`src/proxy/proxy-manager.ts`)
 
+A DAP request rides a three-layer timeout stack, ordered so the layer with the
+most actionable error message fires first:
+
+1. **Socket** (`minimal-dap.ts`) — 30s default, per-request `timeoutMs` override
+2. **Worker request tracker** (`dap-proxy-request-tracker.ts`) — 30s default, same override; its
+   `Request '<cmd>' timed out after Ns` failure is what callers normally see
+3. **Parent** (`proxy-manager.ts`) — override (or 30s default) **plus a 5s margin**, a backstop
+   that only fires if the worker never responds at all
+
+`evaluate_expression` and `redefine_classes` expose the override as a `timeout` (ms) tool
+argument (issue #142). `SessionManagerOperations` validates it (positive, finite, clamped to
+600000) and passes `{ timeoutMs }` to `sendDapRequest`, which threads it over IPC
+(`DapCommandPayload.timeoutMs`) to the worker and socket. On a timeout failure those
+operations append `ErrorMessages.dapRequestTimeoutHint()` naming the `timeout` argument.
+The margin invariant (worker fires before parent) must hold for any new override plumbing.
+
 ```typescript
-// Timeout handler
+// Timeout handler. The worker/socket timeout (timeoutMs, default 30s)
+// fires first and produces the actionable error; this parent timer is a
+// backstop that only fires if the worker never responds at all.
+const effectiveTimeoutMs =
+  (options?.timeoutMs ?? this.defaultDapRequestTimeoutMs) + this.dapParentMarginMs;
 setTimeout(() => {
   if (this.pendingDapRequests.has(requestId)) {
     this.pendingDapRequests.delete(requestId);
-    reject(new Error(ErrorMessages.dapRequestTimeout(command, 35)));
+    reject(new Error(ErrorMessages.dapRequestTimeout(command, Math.round(effectiveTimeoutMs / 1000))));
   }
-}, 35000);
+}, effectiveTimeoutMs);
 ```
 
 **Example**: SessionManager step operation grace window (`src/session/session-manager-operations.ts`)

--- a/src/proxy/dap-proxy-interfaces.ts
+++ b/src/proxy/dap-proxy-interfaces.ts
@@ -41,6 +41,11 @@ export interface DapCommandPayload {
   dapCommand: string;
   dapArgs?: unknown;
   sessionId: string;
+  /**
+   * Per-request timeout override (ms) for the worker request tracker and the
+   * DAP socket. Absent = layer defaults (30s). Issue #142.
+   */
+  timeoutMs?: number;
 }
 
 export interface TerminatePayload {
@@ -119,7 +124,7 @@ export interface IProcessSpawner {
  */
 export interface IDapClient {
   connect(): Promise<void>;
-  sendRequest<T = unknown>(command: string, args?: unknown): Promise<T>;
+  sendRequest<T = unknown>(command: string, args?: unknown, timeoutMs?: number): Promise<T>;
   disconnect(): void;
   /**
    * Reject all pending requests, clear timers, dispose resources.
@@ -202,7 +207,7 @@ export interface TrackedRequest {
  * Request tracker interface
  */
 export interface IRequestTracker {
-  track(requestId: string, command: string, timeoutMs: number): void;
+  track(requestId: string, command: string, timeoutMs?: number): void;
   complete(requestId: string): void;
   clear(): void;
   getPending(): Map<string, TrackedRequest>;

--- a/src/proxy/dap-proxy-message-parser.ts
+++ b/src/proxy/dap-proxy-message-parser.ts
@@ -157,6 +157,13 @@ export class MessageParser {
       throw new Error(`DAP payload 'dapArgs' should not be null`);
     }
 
+    // Defensive normalization: a per-request timeout override must be a finite
+    // positive number of milliseconds; anything else falls back to defaults.
+    if (obj.timeoutMs !== undefined &&
+        (typeof obj.timeoutMs !== 'number' || !Number.isFinite(obj.timeoutMs) || obj.timeoutMs <= 0)) {
+      delete obj.timeoutMs;
+    }
+
     // Type assertion via unknown to satisfy TypeScript
     return obj as unknown as DapCommandPayload;
   }

--- a/src/proxy/dap-proxy-request-tracker.ts
+++ b/src/proxy/dap-proxy-request-tracker.ts
@@ -94,10 +94,10 @@ export class RequestTracker implements IRequestTracker {
  * Enhanced request tracker with timeout callbacks
  */
 export class CallbackRequestTracker extends RequestTracker {
-  private onTimeout: (requestId: string, command: string) => void;
+  private onTimeout: (requestId: string, command: string, timeoutMs: number) => void;
 
   constructor(
-    onTimeout: (requestId: string, command: string) => void,
+    onTimeout: (requestId: string, command: string, timeoutMs: number) => void,
     defaultTimeoutMs: number = 30000
   ) {
     super(defaultTimeoutMs);
@@ -114,7 +114,7 @@ export class CallbackRequestTracker extends RequestTracker {
       if (request) {
         this.pendingRequests.delete(requestId);
         // Call the timeout handler
-        this.onTimeout(requestId, command);
+        this.onTimeout(requestId, command, timeout);
       }
     }, timeout);
 

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -86,7 +86,7 @@ export class DapProxyWorker {
     hooks: DapProxyWorkerHooks = {}
   ) {
     this.requestTracker = new CallbackRequestTracker(
-      (requestId, command) => this.handleRequestTimeout(requestId, command)
+      (requestId, command, timeoutMs) => this.handleRequestTimeout(requestId, command, timeoutMs)
     );
     this.adapterState = DefaultAdapterPolicy.createInitialState();
 
@@ -747,8 +747,8 @@ export class DapProxyWorker {
         return;
       }
 
-      // Track request
-      this.requestTracker.track(payload.requestId, payload.dapCommand);
+      // Track request (payload.timeoutMs overrides the tracker default when present)
+      this.requestTracker.track(payload.requestId, payload.dapCommand, payload.timeoutMs);
 
       // Log setBreakpoints for debugging
       if (payload.dapCommand === 'setBreakpoints') {
@@ -769,7 +769,9 @@ export class DapProxyWorker {
 
       // Send request
       this.logger?.info(`[Worker] Sending '${payload.dapCommand}' to adapter`);
-      const response = await this.dapClient.sendRequest(payload.dapCommand, dapArgs);
+      const response = payload.timeoutMs !== undefined
+        ? await this.dapClient.sendRequest(payload.dapCommand, dapArgs, payload.timeoutMs)
+        : await this.dapClient.sendRequest(payload.dapCommand, dapArgs);
       
       // Update adapter state if needed
       if (this.adapterPolicy.updateStateOnCommand) {
@@ -840,8 +842,10 @@ export class DapProxyWorker {
           continue;
         }
 
-        this.requestTracker.track(payload.requestId, payload.dapCommand);
-        const response = await this.dapClient!.sendRequest(payload.dapCommand, payload.dapArgs);
+        this.requestTracker.track(payload.requestId, payload.dapCommand, payload.timeoutMs);
+        const response = payload.timeoutMs !== undefined
+          ? await this.dapClient!.sendRequest(payload.dapCommand, payload.dapArgs, payload.timeoutMs)
+          : await this.dapClient!.sendRequest(payload.dapCommand, payload.dapArgs);
         
         if (this.adapterPolicy.updateStateOnCommand) {
           this.adapterPolicy.updateStateOnCommand(payload.dapCommand, payload.dapArgs || {}, this.adapterState);
@@ -912,9 +916,14 @@ export class DapProxyWorker {
   /**
    * Handle request timeout
    */
-  private handleRequestTimeout(requestId: string, command: string): void {
-    this.logger!.error(`[Worker] DAP request '${command}' (id: ${requestId}) timed out`);
-    this.sendDapResponse(requestId, false, undefined, `Request '${command}' timed out`);
+  private handleRequestTimeout(requestId: string, command: string, timeoutMs: number): void {
+    this.logger!.error(`[Worker] DAP request '${command}' (id: ${requestId}) timed out after ${timeoutMs}ms`);
+    this.sendDapResponse(
+      requestId,
+      false,
+      undefined,
+      `Request '${command}' timed out after ${Math.round(timeoutMs / 1000)}s`
+    );
   }
 
   /**

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -60,8 +60,9 @@ export interface IProxyManager extends EventEmitter {
   start(config: ProxyConfig): Promise<void>;
   stop(): Promise<void>;
   sendDapRequest<T extends DebugProtocol.Response>(
-    command: string, 
-    args?: unknown
+    command: string,
+    args?: unknown,
+    options?: { timeoutMs?: number }
   ): Promise<T>;
   isRunning(): boolean;
   getCurrentThreadId(): number | null;
@@ -107,6 +108,13 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private isStopped = false;
   /** Bounded wait for in-flight DAP requests to settle before stop() cancels them. */
   private stopDrainTimeoutMs = 1000;
+  /** Worker-side DAP request timeout assumed when no per-request override is given. */
+  private defaultDapRequestTimeoutMs = 30000;
+  /**
+   * Extra time the parent waits beyond the worker/socket timeout so the
+   * worker's own timeout (which produces the actionable error) fires first.
+   */
+  private dapParentMarginMs = 5000;
   private isDryRun = false;
   private dryRunCompleteReceived = false;
   private dryRunCommandSnapshot?: string;
@@ -371,8 +379,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   }
 
   async sendDapRequest<T extends DebugProtocol.Response>(
-    command: string, 
-    args?: unknown
+    command: string,
+    args?: unknown,
+    options?: { timeoutMs?: number }
   ): Promise<T> {
     if (!this.proxyProcess || !this.isInitialized) {
       throw new Error('Proxy not initialized');
@@ -385,7 +394,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       sessionId: this.sessionId,
       requestId,
       dapCommand: command,
-      dapArgs: args
+      dapArgs: args,
+      // Conditional so the key is truly absent (not undefined) in IPC payloads
+      ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {})
     };
 
     if (barrier && !barrier.awaitResponse) {
@@ -443,7 +454,11 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         reject(error);
       }
 
-      // Timeout handler
+      // Timeout handler. The worker/socket timeout (timeoutMs, default 30s)
+      // fires first and produces the actionable error; this parent timer is a
+      // backstop that only fires if the worker never responds at all.
+      const effectiveTimeoutMs =
+        (options?.timeoutMs ?? this.defaultDapRequestTimeoutMs) + this.dapParentMarginMs;
       setTimeout(() => {
         if (this.pendingDapRequests.has(requestId)) {
           this.pendingDapRequests.delete(requestId);
@@ -453,9 +468,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           if (this.activeLaunchBarrier && this.activeLaunchBarrierRequestId === requestId) {
             this.clearActiveLaunchBarrier();
           }
-          reject(new Error(ErrorMessages.dapRequestTimeout(command, 35)));
+          reject(new Error(ErrorMessages.dapRequestTimeout(command, Math.round(effectiveTimeoutMs / 1000))));
         }
-      }, 35000);
+      }, effectiveTimeoutMs);
     });
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -624,9 +624,9 @@ export class DebugMcpServer {
           { name: 'get_local_variables', description: 'Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeSpecial: { type: 'boolean', description: 'Include special/internal variables like this, __proto__, __builtins__, etc. Default: false' } }, required: ['sessionId'] } },
           { name: 'get_stack_trace', description: 'Get stack trace', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeInternals: { type: 'boolean', description: 'Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output.' } }, required: ['sessionId'] } },
           { name: 'get_scopes', description: 'Get scopes for a stack frame', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, frameId: { type: 'number', description: "The ID of the stack frame from a stackTrace response" } }, required: ['sessionId', 'frameId'] } },
-          { name: 'evaluate_expression', description: 'Evaluate expression in the current debug context. Expressions can read and modify program state', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, expression: { type: 'string' }, frameId: { type: 'number', description: 'Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically' } }, required: ['sessionId', 'expression'] } },
+          { name: 'evaluate_expression', description: 'Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, expression: { type: 'string' }, frameId: { type: 'number', description: 'Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically' }, timeout: { type: 'number', description: 'Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout' } }, required: ['sessionId', 'expression'] } },
           { name: 'get_source_context', description: 'Get source context around a specific line in a file', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: fileDescription }, line: { type: 'number', description: 'Line number to get context for' }, linesContext: { type: 'number', description: 'Number of lines before and after to include (default: 5)' } }, required: ['sessionId', 'file', 'line'] } },
-          { name: 'redefine_classes', description: 'Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Only works with Java debug sessions.', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, classesDir: { type: 'string', description: 'Absolute path to compiled classes directory (e.g. build/classes/java/main/)' }, sinceTimestamp: { type: 'number', description: 'Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files.' } }, required: ['sessionId', 'classesDir'] } },
+          { name: 'redefine_classes', description: 'Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Only works with Java debug sessions.', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, classesDir: { type: 'string', description: 'Absolute path to compiled classes directory (e.g. build/classes/java/main/)' }, sinceTimestamp: { type: 'number', description: 'Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files.' }, timeout: { type: 'number', description: 'Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once' } }, required: ['sessionId', 'classesDir'] } },
         ],
       };
     });
@@ -1187,7 +1187,7 @@ export class DebugMcpServer {
               break;
             }
             case 'evaluate_expression': {
-              result = await this.handleEvaluateExpression(args as { sessionId: string; expression: string; frameId?: number });
+              result = await this.handleEvaluateExpression(args as { sessionId: string; expression: string; frameId?: number; timeout?: number });
               break;
             }
             case 'get_source_context': {
@@ -1206,7 +1206,8 @@ export class DebugMcpServer {
               const redefineResult = await this.sessionManager.redefineClasses(
                 args.sessionId as string,
                 args.classesDir as string,
-                (args.sinceTimestamp as number) || 0
+                (args.sinceTimestamp as number) || 0,
+                args.timeout
               );
               result = {
                 content: [{ type: 'text' as const, text: JSON.stringify(redefineResult, null, 2) }],
@@ -1298,22 +1299,23 @@ export class DebugMcpServer {
     }
   }
 
-  private async handleEvaluateExpression(args: { sessionId: string, expression: string, frameId?: number }): Promise<ServerResult> {
+  private async handleEvaluateExpression(args: { sessionId: string, expression: string, frameId?: number, timeout?: number }): Promise<ServerResult> {
     try {
       // Validate session
       this.validateSession(args.sessionId);
-      
+
       // Check expression length (sanity check)
       if (args.expression.length > 10240) {
         throw new McpError(McpErrorCode.InvalidParams, 'Expression too long (max 10KB)');
       }
-      
+
       // Call SessionManager's evaluateExpression method (uses 'watch' context by default for variable access)
       const result = await this.sessionManager.evaluateExpression(
         args.sessionId,
         args.expression,
-        args.frameId
+        args.frameId,
         // Let SessionManager use its default context ('watch') for proper variable access
+        args.timeout
       );
       
       // Log for audit trail

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -1379,6 +1379,44 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     return value.length > maxLength ? value.substring(0, maxLength) + '... (truncated)' : value;
   }
 
+  /** Upper bound for caller-supplied per-request DAP timeouts (10 minutes). */
+  private static readonly MAX_DAP_TIMEOUT_MS = 600000;
+
+  /**
+   * Validate and clamp a caller-supplied per-request DAP timeout override (ms).
+   * Returns { error } for invalid values, { timeoutMs } with the (possibly
+   * clamped) override, or {} when no override was given.
+   */
+  private resolveDapTimeoutOverride(
+    timeoutMs: number | undefined,
+    logContext: string
+  ): { error?: string; timeoutMs?: number } {
+    if (timeoutMs === undefined) {
+      return {};
+    }
+    if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return {
+        error: `Invalid 'timeout': must be a positive number of milliseconds (got ${timeoutMs})`
+      };
+    }
+    if (timeoutMs > SessionManagerOperations.MAX_DAP_TIMEOUT_MS) {
+      this.logger.warn(
+        `[${logContext}] 'timeout' ${timeoutMs}ms exceeds the maximum; clamping to ${SessionManagerOperations.MAX_DAP_TIMEOUT_MS}ms`
+      );
+      return { timeoutMs: SessionManagerOperations.MAX_DAP_TIMEOUT_MS };
+    }
+    return { timeoutMs };
+  }
+
+  /** Append the 'timeout' tool-arg hint to DAP timeout failures. */
+  private withTimeoutHint(errorMessage: string): string {
+    if (!/timed out|did not respond/i.test(errorMessage)) {
+      return errorMessage;
+    }
+    const separator = errorMessage.trimEnd().endsWith('.') ? ' ' : '. ';
+    return `${errorMessage}${separator}${ErrorMessages.dapRequestTimeoutHint()}`;
+  }
+
   /**
    * Evaluate an expression in the context of the current debug session.
    * The debugger must be paused for evaluation to work.
@@ -1387,12 +1425,15 @@ export abstract class SessionManagerOperations extends SessionManagerData {
    * @param sessionId - The session ID
    * @param expression - The expression to evaluate
    * @param frameId - Optional stack frame ID for context (defaults to current frame)
+   * @param timeoutMs - Optional per-request timeout override (ms) for the DAP
+   *   evaluate request (default 30s, max 600000). Issue #142.
    * @returns Evaluation result with value, type, and optional variable reference
    */
   async evaluateExpression(
     sessionId: string,
     expression: string,
-    frameId?: number
+    frameId?: number,
+    timeoutMs?: number
   ): Promise<EvaluateResult> {
     const session = this._getSessionById(sessionId);
     // Some debuggers (rdbg) reject the default 'variables' context; let the
@@ -1409,6 +1450,15 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     if (!expression || expression.trim().length === 0) {
       this.logger.warn(`[SM evaluateExpression ${sessionId}] Empty expression provided`);
       return { success: false, error: 'Expression cannot be empty' };
+    }
+
+    const timeoutOverride = this.resolveDapTimeoutOverride(
+      timeoutMs,
+      `SM evaluateExpression ${sessionId}`
+    );
+    if (timeoutOverride.error) {
+      this.logger.warn(`[SM evaluateExpression ${sessionId}] ${timeoutOverride.error}`);
+      return { success: false, error: timeoutOverride.error };
     }
 
     // Validate session state
@@ -1484,12 +1534,14 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         )}", frameId: ${frameId}, context: ${context}`
       );
 
-      const response =
-        await session.proxyManager.sendDapRequest<DebugProtocol.EvaluateResponse>('evaluate', {
-          expression,
-          frameId,
-          context,
-        });
+      // Conditional 3-arg call: only pass options when an override is present,
+      // so the default path keeps its exact 2-arg contract.
+      const evaluateArgs = { expression, frameId, context };
+      const response = timeoutOverride.timeoutMs !== undefined
+        ? await session.proxyManager.sendDapRequest<DebugProtocol.EvaluateResponse>(
+            'evaluate', evaluateArgs, { timeoutMs: timeoutOverride.timeoutMs })
+        : await session.proxyManager.sendDapRequest<DebugProtocol.EvaluateResponse>(
+            'evaluate', evaluateArgs);
 
       // Log raw response in debug mode
       this.logger.debug(`[SM evaluateExpression ${sessionId}] DAP evaluate raw response:`, response);
@@ -1566,7 +1618,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         userError = `Invalid frame context: ${errorMessage}`;
       }
 
-      return { success: false, error: userError };
+      return { success: false, error: this.withTimeoutHint(userError) };
   }
 }
 
@@ -1918,22 +1970,36 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   async redefineClasses(
     sessionId: string,
     classesDir: string,
-    sinceTimestamp: number = 0
+    sinceTimestamp: number = 0,
+    timeoutMs?: number
   ): Promise<RedefineClassesResult> {
     const session = this._getSessionById(sessionId);
     this.logger.info(
       `[SM redefineClasses ${sessionId}] classesDir: "${classesDir}", since: ${sinceTimestamp}`
     );
 
+    const timeoutOverride = this.resolveDapTimeoutOverride(
+      timeoutMs,
+      `SM redefineClasses ${sessionId}`
+    );
+    if (timeoutOverride.error) {
+      this.logger.warn(`[SM redefineClasses ${sessionId}] ${timeoutOverride.error}`);
+      return { success: false, error: timeoutOverride.error };
+    }
+
     if (!session.proxyManager || !session.proxyManager.isRunning()) {
       return { success: false, error: 'No active debug session' };
     }
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = await session.proxyManager.sendDapRequest<any>(
-        'redefineClasses', { classesDir, sinceTimestamp }
-      );
+      const redefineArgs = { classesDir, sinceTimestamp };
+      const response = timeoutOverride.timeoutMs !== undefined
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ? await session.proxyManager.sendDapRequest<any>(
+            'redefineClasses', redefineArgs, { timeoutMs: timeoutOverride.timeoutMs })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        : await session.proxyManager.sendDapRequest<any>(
+            'redefineClasses', redefineArgs);
 
       const body = response?.body;
       if (!body) {
@@ -1954,7 +2020,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       this.logger.error(`[SM redefineClasses ${sessionId}] Error: ${error}`);
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: this.withTimeoutHint(error instanceof Error ? error.message : String(error)),
       };
     }
   }

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -12,11 +12,22 @@ export const ErrorMessages = {
    * @param command - The DAP command that timed out (e.g., 'stackTrace', 'variables')
    * @param timeout - The timeout duration in seconds
    */
-  dapRequestTimeout: (command: string, timeout: number) => 
+  dapRequestTimeout: (command: string, timeout: number) =>
     `Debug adapter did not respond to '${command}' request within ${timeout}s. ` +
     `This typically means the debug adapter has crashed or lost connection. ` +
     `Try restarting your debug session. If the problem persists, check the debug adapter logs.`,
-  
+
+  /**
+   * Hint appended to timeout failures on operations that accept a per-request
+   * 'timeout' tool argument (evaluate_expression, redefine_classes)
+   * Occurs when: A DAP request times out but the operation may simply need more time than the default allows
+   * Used in: src/session/session-manager-operations.ts
+   * Note: DAP has no cancel — the debuggee keeps executing the operation after the timeout fires
+   */
+  dapRequestTimeoutHint: () =>
+    `If the operation is expected to take this long, retry with a larger 'timeout' (ms) argument. ` +
+    `Note the operation may still be running in the debuggee.`,
+
   /**
    * Error message for proxy initialization timeouts
    * Occurs when: The debug proxy process fails to initialize within the timeout period

--- a/tests/core/unit/server/server-redefine-and-attach.test.ts
+++ b/tests/core/unit/server/server-redefine-and-attach.test.ts
@@ -98,6 +98,14 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
       expect(tool.inputSchema.required).toContain('sessionId');
       expect(tool.inputSchema.required).toContain('classesDir');
       expect(tool.inputSchema.properties.sinceTimestamp).toBeDefined();
+      expect(tool.inputSchema.properties.timeout).toBeDefined();
+    });
+
+    it('evaluate_expression schema should expose a timeout property', async () => {
+      const result = await listToolsHandler({ method: 'tools/list', params: {} });
+      const tool = result.tools.find((t: any) => t.name === 'evaluate_expression');
+      expect(tool).toBeDefined();
+      expect(tool.inputSchema.properties.timeout).toBeDefined();
     });
   });
 
@@ -128,7 +136,8 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
       expect(mockSessionManager.redefineClasses).toHaveBeenCalledWith(
         'test-session',
         '/path/to/classes',
-        1000000
+        1000000,
+        undefined
       );
 
       const content = JSON.parse(result.content[0].text);
@@ -163,7 +172,70 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
       expect(mockSessionManager.redefineClasses).toHaveBeenCalledWith(
         'test-session',
         '/path/to/classes',
-        0
+        0,
+        undefined
+      );
+    });
+
+    it('forwards args.timeout to sessionManager.redefineClasses (issue #142)', async () => {
+      mockSessionManager.redefineClasses.mockResolvedValue({
+        success: true,
+        redefined: [],
+        redefinedCount: 0,
+        skippedNotLoaded: 0,
+        failedCount: 0,
+        scannedFiles: 0,
+        newestTimestamp: 0,
+      });
+
+      await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'redefine_classes',
+          arguments: {
+            sessionId: 'test-session',
+            classesDir: '/path/to/classes',
+            sinceTimestamp: 1000000,
+            timeout: 90000,
+          },
+        },
+      });
+
+      expect(mockSessionManager.redefineClasses).toHaveBeenCalledWith(
+        'test-session',
+        '/path/to/classes',
+        1000000,
+        90000
+      );
+    });
+
+    it('forwards args.timeout to sessionManager.evaluateExpression (issue #142)', async () => {
+      mockSessionManager.getSession.mockReturnValue({
+        id: 'test-session',
+        sessionLifecycle: 'active'
+      });
+      mockSessionManager.evaluateExpression.mockResolvedValue({
+        success: true,
+        result: '42'
+      });
+
+      await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'evaluate_expression',
+          arguments: {
+            sessionId: 'test-session',
+            expression: '6*7',
+            timeout: 120000,
+          },
+        },
+      });
+
+      expect(mockSessionManager.evaluateExpression).toHaveBeenCalledWith(
+        'test-session',
+        '6*7',
+        undefined,
+        120000
       );
     });
 

--- a/tests/core/unit/session/session-manager-redefine-classes.test.ts
+++ b/tests/core/unit/session/session-manager-redefine-classes.test.ts
@@ -197,4 +197,60 @@ describe('SessionManager - redefineClasses', () => {
       sessionManager.redefineClasses('nonexistent', '/path/to/classes')
     ).rejects.toThrow();
   });
+
+  it('forwards a timeout override to the DAP request (issue #142)', async () => {
+    const session = await createRunningSession();
+
+    dependencies.mockProxyManager.setDapRequestHandler(async (command: string) => {
+      if (command === 'redefineClasses') {
+        return {
+          success: true,
+          body: {
+            redefined: [],
+            redefinedCount: 0,
+            skippedNotLoaded: 0,
+            failedCount: 0,
+            scannedFiles: 0,
+            newestTimestamp: 0,
+          }
+        };
+      }
+      return { success: true };
+    });
+
+    await sessionManager.redefineClasses(session.id, '/path/to/classes', 0, 120000);
+
+    const dapCall = dependencies.mockProxyManager.dapRequestCalls.find(
+      c => c.command === 'redefineClasses'
+    );
+    expect(dapCall).toBeDefined();
+    expect(dapCall!.options).toEqual({ timeoutMs: 120000 });
+  });
+
+  it('rejects a non-positive timeout override', async () => {
+    const session = await createRunningSession();
+
+    const result = await sessionManager.redefineClasses(session.id, '/path/to/classes', 0, -5);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('timeout');
+    expect(dependencies.mockProxyManager.dapRequestCalls).toHaveLength(0);
+  });
+
+  it('appends a hint naming the timeout arg when the request times out', async () => {
+    const session = await createRunningSession();
+
+    dependencies.mockProxyManager.setDapRequestHandler(async (command: string) => {
+      if (command === 'redefineClasses') {
+        throw new Error("Request 'redefineClasses' timed out after 30s");
+      }
+      return { success: true };
+    });
+
+    const result = await sessionManager.redefineClasses(session.id, '/path/to/classes');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('timed out');
+    expect(result.error).toContain("larger 'timeout'");
+  });
 });

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -1110,6 +1110,60 @@ describe('DapProxyWorker', () => {
 
       mockDapClient.sendRequest = vi.fn().mockResolvedValue({ body: {} });
     });
+
+    it('forwards payload timeoutMs to the request tracker and DAP client (issue #142)', async () => {
+      mockMessageSender.send.mockClear();
+      (worker as any).dapClient = mockDapClient;
+      (worker as any).state = ProxyState.CONNECTED;
+      (worker as any).adapterPolicy = DefaultAdapterPolicy;
+      (worker as any).adapterState = DefaultAdapterPolicy.createInitialState();
+      (worker as any).logger = mockLogger;
+
+      mockDapClient.sendRequest = vi.fn().mockResolvedValue({ body: {} });
+      const trackSpy = vi.spyOn((worker as any).requestTracker, 'track');
+
+      const payload: DapCommandPayload = {
+        cmd: 'dap',
+        sessionId: 'test-session',
+        requestId: 'req-timeout-fwd',
+        dapCommand: 'evaluate',
+        dapArgs: { expression: 'x' },
+        timeoutMs: 60000
+      };
+
+      await worker.handleCommand(payload);
+
+      expect(trackSpy).toHaveBeenCalledWith('req-timeout-fwd', 'evaluate', 60000);
+      expect(mockDapClient.sendRequest).toHaveBeenCalledWith('evaluate', { expression: 'x' }, 60000);
+
+      trackSpy.mockRestore();
+      mockDapClient.sendRequest = vi.fn().mockResolvedValue({ body: {} });
+    });
+
+    it('omits the timeout argument to the DAP client when payload has no timeoutMs', async () => {
+      mockMessageSender.send.mockClear();
+      (worker as any).dapClient = mockDapClient;
+      (worker as any).state = ProxyState.CONNECTED;
+      (worker as any).adapterPolicy = DefaultAdapterPolicy;
+      (worker as any).adapterState = DefaultAdapterPolicy.createInitialState();
+      (worker as any).logger = mockLogger;
+
+      mockDapClient.sendRequest = vi.fn().mockResolvedValue({ body: {} });
+
+      const payload: DapCommandPayload = {
+        cmd: 'dap',
+        sessionId: 'test-session',
+        requestId: 'req-no-timeout',
+        dapCommand: 'threads',
+        dapArgs: {}
+      };
+
+      await worker.handleCommand(payload);
+
+      expect(mockDapClient.sendRequest).toHaveBeenCalledWith('threads', {});
+
+      mockDapClient.sendRequest = vi.fn().mockResolvedValue({ body: {} });
+    });
   });
 
   describe('JavaScript Adapter Command Queueing', () => {
@@ -1218,6 +1272,46 @@ describe('DapProxyWorker', () => {
       expect(responses).toHaveLength(1);
       expect(responses[0][0].success).toBe(true);
     });
+
+    it('retains payload timeoutMs on queued commands (issue #142)', async () => {
+      (worker as any).dapClient = mockDapClient;
+      (worker as any).logger = mockLogger;
+      (worker as any).state = ProxyState.CONNECTED;
+
+      const queuePolicy = {
+        ...DefaultAdapterPolicy,
+        shouldQueueCommand: vi.fn(() => ({
+          shouldQueue: true,
+          shouldDefer: false,
+          reason: 'Queue for test'
+        })),
+        requiresCommandQueueing: vi.fn(() => true)
+      };
+
+      (worker as any).adapterPolicy = queuePolicy;
+      (worker as any).adapterState = queuePolicy.createInitialState();
+
+      mockDapClient.sendRequest = vi.fn().mockResolvedValue({ body: {} });
+      mockMessageSender.send.mockClear();
+      const trackSpy = vi.spyOn((worker as any).requestTracker, 'track');
+
+      const payload: DapCommandPayload = {
+        cmd: 'dap',
+        sessionId: 'queue-session',
+        requestId: 'req-queue-timeout',
+        dapCommand: 'evaluate',
+        dapArgs: { expression: 'x' },
+        timeoutMs: 45000
+      };
+
+      await worker.handleCommand(payload);
+
+      expect(trackSpy).toHaveBeenCalledWith('req-queue-timeout', 'evaluate', 45000);
+      expect(mockDapClient.sendRequest).toHaveBeenCalledWith('evaluate', { expression: 'x' }, 45000);
+
+      trackSpy.mockRestore();
+      mockDapClient.sendRequest = vi.fn().mockResolvedValue({ body: {} });
+    });
   });
 
   describe('Pre-connect queue handling', () => {
@@ -1256,20 +1350,20 @@ describe('DapProxyWorker', () => {
       mockMessageSender.send.mockClear();
 
       const tracker = (worker as any).requestTracker;
-      tracker.track('timeout-req', 'threads', 50);
+      tracker.track('timeout-req', 'threads', 2000);
 
-      await vi.advanceTimersByTimeAsync(60);
+      await vi.advanceTimersByTimeAsync(2001);
       await Promise.resolve();
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        "[Worker] DAP request 'threads' (id: timeout-req) timed out"
+        "[Worker] DAP request 'threads' (id: timeout-req) timed out after 2000ms"
       );
       expect(mockMessageSender.send).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'dapResponse',
           requestId: 'timeout-req',
           success: false,
-          error: "Request 'threads' timed out"
+          error: "Request 'threads' timed out after 2s"
         })
       );
 

--- a/tests/test-utils/mocks/mock-proxy-manager.ts
+++ b/tests/test-utils/mocks/mock-proxy-manager.ts
@@ -20,7 +20,7 @@ export class MockProxyManager extends EventEmitter implements IProxyManager {
   // Track calls for testing
   public startCalls: ProxyConfig[] = [];
   public stopCalls: number = 0;
-  public dapRequestCalls: Array<{ command: string; args?: any }> = [];
+  public dapRequestCalls: Array<{ command: string; args?: any; options?: { timeoutMs?: number } }> = [];
 
   // Control behavior for testing
   public shouldFailStart = false;
@@ -84,10 +84,11 @@ export class MockProxyManager extends EventEmitter implements IProxyManager {
   }
 
   async sendDapRequest<T extends DebugProtocol.Response>(
-    command: string, 
-    args?: any
+    command: string,
+    args?: any,
+    options?: { timeoutMs?: number }
   ): Promise<T> {
-    this.dapRequestCalls.push({ command, args });
+    this.dapRequestCalls.push({ command, args, ...(options !== undefined ? { options } : {}) });
 
     if (!this._isRunning) {
       throw new Error('Proxy not running');

--- a/tests/unit/proxy/dap-proxy-message-parser.test.ts
+++ b/tests/unit/proxy/dap-proxy-message-parser.test.ts
@@ -369,6 +369,34 @@ describe('MessageParser', () => {
       expect(() => MessageParser.validateDapPayload(payload))
         .toThrow("DAP payload 'dapArgs' should not be null");
     });
+
+    it('should keep a valid timeoutMs (issue #142)', () => {
+      const payload = {
+        cmd: 'dap',
+        sessionId: 'test-session',
+        requestId: 'req-123',
+        dapCommand: 'evaluate',
+        timeoutMs: 60000
+      };
+
+      const result = MessageParser.validateDapPayload(payload);
+      expect(result.timeoutMs).toBe(60000);
+    });
+
+    it('should drop non-finite or non-positive timeoutMs', () => {
+      for (const bad of [0, -5, NaN, Infinity, '5000', {}]) {
+        const payload = {
+          cmd: 'dap',
+          sessionId: 'test-session',
+          requestId: 'req-123',
+          dapCommand: 'evaluate',
+          timeoutMs: bad
+        };
+
+        const result = MessageParser.validateDapPayload(payload);
+        expect(result.timeoutMs, `timeoutMs=${String(bad)}`).toBeUndefined();
+      }
+    });
   });
 
   describe('validateTerminatePayload', () => {

--- a/tests/unit/proxy/dap-proxy-request-tracker.test.ts
+++ b/tests/unit/proxy/dap-proxy-request-tracker.test.ts
@@ -185,7 +185,7 @@ describe('CallbackRequestTracker', () => {
     // Advance time past timeout
     vi.advanceTimersByTime(1001);
 
-    expect(timeoutCallback).toHaveBeenCalledWith('req-1', 'continue');
+    expect(timeoutCallback).toHaveBeenCalledWith('req-1', 'continue', 1000);
     expect(timeoutCallback).toHaveBeenCalledTimes(1);
     expect(tracker.isPending('req-1')).toBe(false);
   });
@@ -200,6 +200,22 @@ describe('CallbackRequestTracker', () => {
     expect(timeoutCallback).not.toHaveBeenCalled();
   });
 
+  it('should pass the effective timeout to the callback for an explicit per-request timeout', () => {
+    tracker.track('req-1', 'evaluate', 60000);
+
+    vi.advanceTimersByTime(60001);
+
+    expect(timeoutCallback).toHaveBeenCalledWith('req-1', 'evaluate', 60000);
+  });
+
+  it('should pass the default timeout to the callback when none is provided', () => {
+    tracker.track('req-1', 'evaluate');
+
+    vi.advanceTimersByTime(1001);
+
+    expect(timeoutCallback).toHaveBeenCalledWith('req-1', 'evaluate', 1000);
+  });
+
   it('should handle multiple timeouts', () => {
     tracker.track('req-1', 'continue', 500);
     tracker.track('req-2', 'evaluate', 1000);
@@ -207,12 +223,12 @@ describe('CallbackRequestTracker', () => {
 
     // Advance to trigger first timeout
     vi.advanceTimersByTime(501);
-    expect(timeoutCallback).toHaveBeenCalledWith('req-1', 'continue');
+    expect(timeoutCallback).toHaveBeenCalledWith('req-1', 'continue', 500);
     expect(timeoutCallback).toHaveBeenCalledTimes(1);
 
     // Advance to trigger second timeout
     vi.advanceTimersByTime(500);
-    expect(timeoutCallback).toHaveBeenCalledWith('req-2', 'evaluate');
+    expect(timeoutCallback).toHaveBeenCalledWith('req-2', 'evaluate', 1000);
     expect(timeoutCallback).toHaveBeenCalledTimes(2);
 
     // Complete third request before timeout

--- a/tests/unit/proxy/minimal-dap.test.ts
+++ b/tests/unit/proxy/minimal-dap.test.ts
@@ -489,6 +489,34 @@ describe('MinimalDapClient', () => {
       mockSocket.emit('data', createDapMessage(lateResponse));
     });
 
+    it('should honor an explicit per-request timeoutMs (issue #142)', async () => {
+      // Recreate client with deterministic timers: only a 60s timer (the
+      // override) fires immediately; the 30s default would never fire here.
+      client.shutdown();
+      const scheduledDelays: number[] = [];
+      const fakeTimers = {
+        setTimeout: ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
+          scheduledDelays.push(delay ?? 0);
+          if (delay === 60000) {
+            return setTimeout(() => callback(...args), 0);
+          }
+          return setTimeout(callback, delay, ...args);
+        }) as typeof setTimeout,
+        clearTimeout: ((timer: NodeJS.Timeout) => {
+          clearTimeout(timer);
+        }) as typeof clearTimeout
+      };
+      client = new MinimalDapClient('localhost', 5678, undefined, { timers: fakeTimers });
+
+      await client.connect();
+
+      await expect(
+        client.sendRequest('evaluate', { expression: 'test' }, 60000)
+      ).rejects.toThrow("DAP request 'evaluate' (seq 1) timed out");
+
+      expect(scheduledDelays).toContain(60000);
+    });
+
     it('should handle unknown response sequences', async () => {
       await client.connect();
 

--- a/tests/unit/proxy/proxy-manager-message-handling.test.ts
+++ b/tests/unit/proxy/proxy-manager-message-handling.test.ts
@@ -640,6 +640,82 @@ describe('ProxyManager Message Handling', () => {
       expect(pending.size).toBe(0);
     });
 
+    function makeInitializedProxyManager() {
+      const logger = createMockLogger();
+      const fileSystem = createMockFileSystem();
+      const proxyManager = new ProxyManager(
+        null,
+        { launchProxy: vi.fn() } as never,
+        fileSystem as never,
+        logger
+      );
+      const sendCommand = vi.fn();
+
+      (proxyManager as unknown as { sessionId: string }).sessionId = 'timeout-session';
+      (proxyManager as unknown as { isInitialized: boolean }).isInitialized = true;
+      (proxyManager as unknown as { proxyProcess: unknown }).proxyProcess = {
+        sendCommand,
+        killed: false
+      };
+
+      return { proxyManager, sendCommand };
+    }
+
+    it('honors a per-request timeoutMs override, rejecting after override + parent margin (issue #142)', async () => {
+      const { proxyManager } = makeInitializedProxyManager();
+
+      vi.useFakeTimers();
+
+      const request = proxyManager.sendDapRequest('evaluate', { expression: 'slow()' }, { timeoutMs: 60000 });
+      let settled = false;
+      request.catch(() => { settled = true; });
+
+      // The old hardcoded 35s deadline must NOT fire...
+      await vi.advanceTimersByTimeAsync(35_000);
+      expect(settled).toBe(false);
+
+      // ...but 60s override + 5s parent margin = 65s does, reporting the actual deadline.
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(request).rejects.toThrow(/within 65s/);
+    });
+
+    it('applies the parent margin to short timeoutMs overrides', async () => {
+      const { proxyManager } = makeInitializedProxyManager();
+
+      vi.useFakeTimers();
+
+      const request = proxyManager.sendDapRequest('evaluate', { expression: 'x' }, { timeoutMs: 1000 });
+      let settled = false;
+      request.catch(() => { settled = true; });
+
+      await vi.advanceTimersByTimeAsync(5_999);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(request).rejects.toThrow(/within 6s/);
+    });
+
+    it('includes timeoutMs in the IPC payload when set and omits it otherwise', async () => {
+      const { proxyManager, sendCommand } = makeInitializedProxyManager();
+
+      vi.useFakeTimers();
+
+      const withOverride = proxyManager.sendDapRequest('evaluate', { expression: 'x' }, { timeoutMs: 60000 });
+      const withoutOverride = proxyManager.sendDapRequest('threads');
+      withOverride.catch(() => {});
+      withoutOverride.catch(() => {});
+
+      const firstPayload = sendCommand.mock.calls[0][0] as Record<string, unknown>;
+      const secondPayload = sendCommand.mock.calls[1][0] as Record<string, unknown>;
+      expect(firstPayload).toMatchObject({ dapCommand: 'evaluate', timeoutMs: 60000 });
+      // Assert the key is absent, not merely undefined: IPC serialization drops
+      // undefined, so presence here would still leak into JSON payloads.
+      expect('timeoutMs' in secondPayload).toBe(false);
+
+      // Flush both pending timers so nothing dangles across tests.
+      await vi.advanceTimersByTimeAsync(65_000);
+    });
+
     it('throws helpful error when proxy bootstrap is missing', async () => {
       const logger = createMockLogger();
       const fileSystem = createMockFileSystem();

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -728,6 +728,71 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     });
   });
 
+  describe('Evaluate Expression timeout override (issue #142)', () => {
+    beforeEach(() => {
+      mockSession.state = SessionState.PAUSED;
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'stackTrace') {
+          return { body: { stackFrames: [{ id: 123 }] } };
+        }
+        if (command === 'evaluate') {
+          return { body: { result: '42', variablesReference: 0 } };
+        }
+        return {};
+      });
+    });
+
+    it('forwards the override to the evaluate request but not the stackTrace pre-request', async () => {
+      const result = await operations.evaluateExpression('test-session', '6*7', undefined, 120000);
+
+      expect(result.success).toBe(true);
+      // The internal stackTrace pre-request keeps the default timeout (2-arg call)
+      expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith(
+        'stackTrace',
+        expect.objectContaining({ threadId: 1 })
+      );
+      expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith(
+        'evaluate',
+        expect.objectContaining({ expression: '6*7', frameId: 123 }),
+        { timeoutMs: 120000 }
+      );
+    });
+
+    it('rejects a non-positive or non-finite timeout without sending any DAP request', async () => {
+      for (const bad of [0, -5, NaN]) {
+        const result = await operations.evaluateExpression('test-session', 'x', undefined, bad);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('timeout');
+      }
+      expect(mockProxyManager.sendDapRequest).not.toHaveBeenCalled();
+    });
+
+    it('clamps the override to 600000ms with a warning', async () => {
+      const result = await operations.evaluateExpression('test-session', 'x', 123, 900000);
+
+      expect(result.success).toBe(true);
+      expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith(
+        'evaluate',
+        expect.objectContaining({ expression: 'x', frameId: 123 }),
+        { timeoutMs: 600000 }
+      );
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('600000'));
+    });
+
+    it('appends a hint naming the timeout arg when the evaluate request times out', async () => {
+      mockProxyManager.sendDapRequest
+        .mockResolvedValueOnce({ body: { stackFrames: [{ id: 1 }] } })
+        .mockRejectedValueOnce(new Error("Request 'evaluate' timed out after 30s"));
+
+      const result = await operations.evaluateExpression('test-session', 'slow()');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('timed out');
+      expect(result.error).toContain("larger 'timeout'");
+    });
+  });
+
   describe('Start Debugging Error Scenarios', () => {
     it('should return timeout result when dry run never completes', async () => {
       vi.stubEnv('CI', 'true');

--- a/tests/unit/test-utils/test-proxy-manager.ts
+++ b/tests/unit/test-utils/test-proxy-manager.ts
@@ -65,8 +65,8 @@ export class TestProxyManager extends ProxyManager {
   /**
    * Override sendDapRequest to return mock responses
    */
-  async sendDapRequest(command: string, args?: any): Promise<DebugProtocol.Response> {
-    this.lastSentCommand = { command, args };
+  async sendDapRequest(command: string, args?: any, options?: { timeoutMs?: number }): Promise<DebugProtocol.Response> {
+    this.lastSentCommand = { command, args, ...(options !== undefined ? { options } : {}) };
 
     // Check if proxy is running
     if (!this.isRunning()) {

--- a/tests/unit/utils/error-messages.test.ts
+++ b/tests/unit/utils/error-messages.test.ts
@@ -9,6 +9,12 @@ describe('ErrorMessages', () => {
     expect(message).toContain('10s');
   });
 
+  it('builds dap request timeout hint naming the timeout tool arg', () => {
+    const message = ErrorMessages.dapRequestTimeoutHint();
+    expect(message).toContain("'timeout'");
+    expect(message).toContain('ms');
+  });
+
   it('builds proxy initialization timeout message', () => {
     const message = ErrorMessages.proxyInitTimeout(30);
     expect(message).toContain('30s');


### PR DESCRIPTION
Fixes #142.

## Problem

`evaluate_expression` (and `redefine_classes`) rode three stacked hard timeouts — parent 35s, worker request-tracker 30s, socket 30s — so a long-running expression spuriously failed even though nothing was wrong. Unlike the step/pause case (#144) there is **no async completion path**: the DAP response *is* the result, so this needs a real threaded timeout override, not a "pending" marker.

## Change

Thread a per-request `timeoutMs` end to end, preserving layer ordering (worker/socket fire first, parent last):

```
tool arg `timeout` (ms, evaluate_expression + redefine_classes)
  → SessionManagerOperations.evaluateExpression / redefineClasses   [validate >0 finite, clamp 600000]
  → proxyManager.sendDapRequest(cmd, args, { timeoutMs })           [parent timer = (timeoutMs ?? 30000) + 5000 margin]
  → IPC DapCommandPayload.timeoutMs                                 [parser drops non-finite/non-positive values]
  → worker: requestTracker.track(..., timeoutMs) + dapClient.sendRequest(..., timeoutMs)
  → MinimalDapClient (already supported per-request timeouts; now actually receives them)
```

- **Defaults unchanged when `timeout` is omitted** (30s worker/socket, 35s parent) — the parent timer is now derived instead of the hardcoded `35000`, and its error reports the actual deadline.
- Worker timeout failures now report the effective deadline: `Request 'evaluate' timed out after 30s`.
- Timeout failures on these two tools append a hint naming the `timeout` argument (`ErrorMessages.dapRequestTimeoutHint`).
- Fixed a pre-existing interface/impl mismatch: `IRequestTracker.track`'s `timeoutMs` is now optional, matching both implementations.

## Verification

- Unit: 149 files / 2379 tests green (includes new tests at every layer: tracker callback receives effective timeout; parent honors override + margin and keeps `timeoutMs` out of the IPC payload when unset; worker forwards to tracker + socket incl. queued js-debug commands; parser normalization; session-manager validation/clamp/hint and stackTrace pre-request keeping the default; server schema + forwarding for both tools).
- Integration: green. Lint + tsc clean.
- E2E (Python via dev-proxy): `evaluate_expression` of a 45s-sleeping expression with `timeout: 120000` → succeeds with the correct result where the old stack failed at 30s; the same expression with defaults still fails truthfully at 30s, now with the hint: `Request 'evaluate' timed out after 30s. If the operation is expected to take this long, retry with a larger 'timeout' (ms) argument. Note the operation may still be running in the debuggee.`

## Out of scope (noting on #142)

- Launch-request slowness: the js-debug launch barrier path is fire-and-forget and other adapters' launch keeps the default.
- DAP has no `cancel` support — an expired evaluate keeps running in the debuggee after the timeout fires.

## Note for merging

PR #147 (#143, attach `verifyTimeout`) is still open and also touches `src/utils/error-messages.ts`, `src/server.ts`, and `src/session/session-manager-operations.ts` in different regions — whichever merges second may need a trivial conflict resolution (both append new `ErrorMessages` factories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
