### PR TITLE
fix(python): attach-first DAP handshake for debugpy attach (fixes #145)

### DIFF
--- a/examples/python/attach_loop.py
+++ b/examples/python/attach_loop.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Long-running loop target for attach_to_process smoke tests."""
+import time
+
+
+def compute(a, b):
+    result = a + b
+    return result
+
+
+print("ATTACH_LOOP_READY", flush=True)
+while True:
+    total = compute(42, 58)
+    time.sleep(0.5)

--- a/packages/adapter-python/src/python-debug-adapter.ts
+++ b/packages/adapter-python/src/python-debug-adapter.ts
@@ -22,6 +22,8 @@ import {
   AdapterConfig,
   GenericLaunchConfig,
   LanguageSpecificLaunchConfig,
+  GenericAttachConfig,
+  LanguageSpecificAttachConfig,
   DebugFeature,
   FeatureRequirement,
   AdapterCapabilities,
@@ -57,6 +59,21 @@ interface PythonLaunchConfig extends LanguageSpecificLaunchConfig {
   showReturnValue?: boolean;    // Show function return values
   subProcess?: boolean;         // Debug child processes
   [key: string]: unknown;       // Required by LanguageSpecificLaunchConfig
+}
+
+/**
+ * Python-specific attach configuration (debugpy client-connect shape)
+ */
+interface PythonAttachConfig extends LanguageSpecificAttachConfig {
+  type: 'python';
+  request: 'attach';
+  name: string;
+  connect: { host: string; port: number };
+  host: string;
+  port: number;
+  justMyCode: boolean;
+  cwd?: string;
+  env?: Record<string, string>;
 }
 
 /**
@@ -381,7 +398,73 @@ export class PythonDebugAdapter extends EventEmitter implements IDebugAdapter {
       cwd: process.cwd()
     };
   }
-  
+
+  supportsAttach(): boolean {
+    return true;
+  }
+
+  supportsDetach(): boolean {
+    return true;
+  }
+
+  usesDirectConnectForAttach(): boolean {
+    return true;
+  }
+
+  transformAttachConfig(config: GenericAttachConfig): PythonAttachConfig {
+    const host = config.host || '127.0.0.1';
+    const port = config.port;
+
+    if (typeof port !== 'number') {
+      if (config.processId !== undefined || config.processName !== undefined) {
+        throw new AdapterError(
+          'Python attach does not support attaching by process ID or name. ' +
+          'Start the target with: python -m debugpy --listen 127.0.0.1:<port> script.py and attach to that port',
+          AdapterErrorCode.ENVIRONMENT_INVALID
+        );
+      }
+      throw new AdapterError(
+        'Python attach requires the port of a listening debugpy endpoint ' +
+        '(python -m debugpy --listen 127.0.0.1:<port> script.py)',
+        AdapterErrorCode.ENVIRONMENT_INVALID
+      );
+    }
+
+    const attachConfig: PythonAttachConfig = {
+      type: 'python',
+      request: 'attach',
+      name: 'Python: Attach',
+      // Modern debugpy attach convention; host/port are also kept top-level
+      // so the adapter policy's spawn config can read them.
+      connect: { host, port },
+      host,
+      port,
+      justMyCode: config.justMyCode ?? true
+    };
+
+    if (config.stopOnEntry !== undefined) {
+      attachConfig.stopOnEntry = config.stopOnEntry;
+    }
+
+    if (config.cwd) {
+      attachConfig.cwd = config.cwd;
+    }
+
+    if (config.env) {
+      attachConfig.env = config.env;
+    }
+
+    return attachConfig;
+  }
+
+  getDefaultAttachConfig(): Partial<GenericAttachConfig> {
+    return {
+      request: 'attach',
+      host: '127.0.0.1',
+      justMyCode: true
+    };
+  }
+
   // ===== DAP Protocol Operations =====
   
   async sendDapRequest<T extends DebugProtocol.Response>(

--- a/packages/adapter-python/src/python-debug-adapter.ts
+++ b/packages/adapter-python/src/python-debug-adapter.ts
@@ -69,8 +69,6 @@ interface PythonAttachConfig extends LanguageSpecificAttachConfig {
   request: 'attach';
   name: string;
   connect: { host: string; port: number };
-  host: string;
-  port: number;
   justMyCode: boolean;
   cwd?: string;
   env?: Record<string, string>;
@@ -434,11 +432,10 @@ export class PythonDebugAdapter extends EventEmitter implements IDebugAdapter {
       type: 'python',
       request: 'attach',
       name: 'Python: Attach',
-      // Modern debugpy attach convention; host/port are also kept top-level
-      // so the adapter policy's spawn config can read them.
+      // debugpy client-connect convention. Top-level host/port must NOT be
+      // set alongside it — debugpy rejects that combination as mutually
+      // exclusive. The adapter policy's spawn config reads connect.* too.
       connect: { host, port },
-      host,
-      port,
       justMyCode: config.justMyCode ?? true
     };
 

--- a/packages/shared/src/interfaces/adapter-policy-python.ts
+++ b/packages/shared/src/interfaces/adapter-policy-python.ts
@@ -233,10 +233,14 @@ export const PythonAdapterPolicy: AdapterPolicy = {
   },
 
   /**
-   * Python adapter has no special initialization requirements
+   * debugpy emits 'initialized' only AFTER it receives the launch/attach
+   * request. Launch mode already sends launch first; attach must do the
+   * same or the worker deadlocks waiting for 'initialized' (issue #145).
    */
   getInitializationBehavior: () => {
-    return {};  // Python doesn't need any special initialization quirks
+    return {
+      sendAttachBeforeInitialized: true
+    };
   },
 
   /**
@@ -275,6 +279,34 @@ export const PythonAdapterPolicy: AdapterPolicy = {
    * Get the configuration for spawning the Python debug adapter (debugpy)
    */
   getAdapterSpawnConfig: (payload) => {
+    const launchConfig = (payload.launchConfig ?? {}) as Record<string, unknown>;
+
+    // Attach: debugpy is already listening as a DAP server next to the target
+    // (python -m debugpy --listen host:port), so there is no adapter process
+    // to spawn — connect directly.
+    if (launchConfig.request === 'attach') {
+      const connect = launchConfig.connect as { host?: string; port?: number } | undefined;
+      const host = connect?.host
+        ?? (typeof launchConfig.host === 'string' && launchConfig.host.length > 0
+          ? launchConfig.host
+          : '127.0.0.1');
+      const port = connect?.port ?? launchConfig.port;
+
+      if (typeof port !== 'number' || !Number.isInteger(port) || port <= 0 || port > 65535) {
+        throw new Error(
+          `Python attach requires the TCP port of a listening debugpy endpoint (got: ${String(port)}). ` +
+          `Start the target with: python -m debugpy --listen 127.0.0.1:<port> [--wait-for-client] script.py`
+        );
+      }
+
+      return {
+        mode: 'connect',
+        host,
+        port,
+        logDir: payload.logDir
+      };
+    }
+
     // If a custom adapter command was provided, use it directly
     if (payload.adapterCommand) {
       return {

--- a/packages/shared/src/interfaces/adapter-policy-python.ts
+++ b/packages/shared/src/interfaces/adapter-policy-python.ts
@@ -243,6 +243,11 @@ export const PythonAdapterPolicy: AdapterPolicy = {
     };
   },
 
+  // debugpy does not suspend a running target on attach, so an explicit
+  // pause is required for the session to land in a truthful PAUSED state
+  // (same rationale as rdbg re-attach).
+  getAttachBehavior: () => ({ pauseAfterAttach: true }),
+
   /**
    * Python DAP client behaviors - minimal since Python doesn't use child sessions
    */

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -439,20 +439,27 @@ export class DapProxyWorker {
         );
 
         if (isAttachMode && initBehavior.sendAttachBeforeInitialized) {
-          // ATTACH-FIRST MODE: Send attach immediately, then wait for initialized
-          // Some adapters only send 'initialized' AFTER processing the attach request
+          // ATTACH-FIRST MODE: Send attach immediately, then wait for initialized.
+          // Some adapters (debugpy) only send 'initialized' AFTER processing the
+          // attach request — and only respond to attach after configurationDone,
+          // so the attach response must not be awaited before handleInitializedEvent.
           const attachPayload = payload.launchConfig || {};
-          const payloadKeys = Object.keys(attachPayload);
-          const hasSymbolOpts = 'symbolOptions' in (attachPayload as Record<string, unknown>);
-          this.logger!.info(`[Worker] Attach-first mode — sending attach. Keys: ${payloadKeys.join(', ')}, symbolOptions: ${hasSymbolOpts ? JSON.stringify((attachPayload as Record<string, unknown>).symbolOptions) : 'absent'}`);
-          await this.connectionManager!.sendAttachRequest(
+          this.logger!.info(`[Worker] Attach-first mode — sending attach. Keys: ${Object.keys(attachPayload).join(', ')}`);
+          const attachRequest = this.connectionManager!.sendAttachRequest(
             this.dapClient,
             attachPayload
           );
+          // Surface early attach failures (connection refused, bad args) instead
+          // of waiting out the initialized timeout. Promise.race subscribes to
+          // every arm, so this rejection is consumed even when another arm wins.
+          const attachFailure = new Promise<never>((_, reject) => {
+            attachRequest.catch(reject);
+          });
 
           this.logger!.info('[Worker] Attach sent, waiting for "initialized" event');
           await Promise.race([
             this.initializedEventPromise!,
+            attachFailure,
             new Promise((_, reject) =>
               setTimeout(() => reject(new Error('Timeout waiting for initialized event after attach')), 15000)
             )
@@ -460,6 +467,9 @@ export class DapProxyWorker {
 
           this.deferInitializedHandling = false;
           await this.handleInitializedEvent();
+          // Now that configurationDone is sent, the adapter's attach response
+          // can arrive; propagate an attach failure if it rejected instead.
+          await attachRequest;
         } else if (isAttachMode) {
           // STANDARD ATTACH MODE: Wait for "initialized" event BEFORE sending attach
           // Some adapters send "initialized" after initialize response, before attach

--- a/tests/e2e/mcp-server-smoke-python-attach.test.ts
+++ b/tests/e2e/mcp-server-smoke-python-attach.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Python Attach-Mode Smoke Tests via MCP Interface
+ *
+ * Tests Python attach debugging (issue #145): start a script under
+ * `python -m debugpy --listen host:port`, then use attach_to_process to
+ * connect the debugger directly to the listening debugpy endpoint.
+ *
+ * This is the regression test for the attach handshake deadlock: debugpy
+ * emits 'initialized' only after it receives the attach request, and only
+ * responds to attach after configurationDone — attach succeeding at all
+ * proves the attach-first ordering works.
+ *
+ * Hard assertions (every step must succeed):
+ * - Session creation returns valid sessionId
+ * - Breakpoint on line 7 (result = a + b inside compute()) returns success
+ * - Attach succeeds and returns paused state (post-attach pause)
+ * - Continue execution resumes the loop
+ * - Breakpoint fires: non-empty stack frames with top frame in compute()
+ * - Local variables a=42, b=58 with correct values
+ * - Continue after breakpoint hit succeeds
+ * - Closing the session detaches without killing the target
+ *
+ * Prerequisites:
+ * - Python 3.7+ with debugpy installed (pip install debugpy)
+ *
+ * Skips gracefully when python/debugpy is not installed.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import path from 'path';
+import net from 'net';
+import { fileURLToPath } from 'url';
+import { execSync, spawn, ChildProcess } from 'child_process';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { parseSdkToolResult, callToolSafely } from './smoke-test-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../..');
+
+// Windows ships `python`; Linux/macOS use `python3`
+const PYTHON_CMD = process.platform === 'win32' ? 'python' : 'python3';
+
+/**
+ * Find a free TCP port by briefly listening on port 0.
+ */
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (!addr || typeof addr === 'string') {
+        srv.close(() => reject(new Error('Could not determine port')));
+        return;
+      }
+      const port = addr.port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+/**
+ * Poll for non-empty stack frames (breakpoint hit).
+ * Returns the stack response once frames appear, or null after exhausting attempts.
+ */
+async function waitForPausedState(
+  client: Client,
+  sessionId: string,
+  maxAttempts = 20,
+  intervalMs = 500,
+  validate?: (frames: Array<{ file?: string; name?: string; line?: number }>) => boolean
+): Promise<{ stackFrames?: Array<{ file?: string; name?: string; line?: number }> } | null> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const result = await callToolSafely(client, 'get_stack_trace', { sessionId });
+    if (result.stackFrames && (result.stackFrames as any[]).length > 0) {
+      const frames = result.stackFrames as Array<{ file?: string; name?: string; line?: number }>;
+      if (!validate || validate(frames)) {
+        return result as { stackFrames: Array<{ file?: string; name?: string; line?: number }> };
+      }
+    }
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  return null;
+}
+
+describe('MCP Server Python Attach-Mode Smoke Test @requires-python', () => {
+  let mcpClient: Client | null = null;
+  let transport: StdioClientTransport | null = null;
+  let sessionId: string | null = null;
+  let pyProcess: ChildProcess | null = null;
+
+  beforeAll(async () => {
+    console.log('[Python Attach Test] Starting MCP server...');
+
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.join(ROOT, 'dist', 'index.js'), '--log-level', 'info'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'test'
+      }
+    });
+
+    mcpClient = new Client({
+      name: 'python-attach-smoke-test-client',
+      version: '1.0.0'
+    }, {
+      capabilities: {}
+    });
+
+    await mcpClient.connect(transport);
+    console.log('[Python Attach Test] MCP client connected');
+  }, 30000);
+
+  afterAll(async () => {
+    if (sessionId && mcpClient) {
+      try {
+        await callToolSafely(mcpClient, 'close_debug_session', { sessionId });
+      } catch {
+        // Session may already be closed
+      }
+    }
+
+    if (mcpClient) {
+      await mcpClient.close();
+    }
+    if (transport) {
+      await transport.close();
+    }
+
+    if (pyProcess && !pyProcess.killed) {
+      pyProcess.kill('SIGKILL');
+    }
+
+    console.log('[Python Attach Test] Cleanup completed');
+  });
+
+  afterEach(async () => {
+    if (sessionId && mcpClient) {
+      try {
+        await callToolSafely(mcpClient, 'close_debug_session', { sessionId });
+      } catch {
+        // Session may already be closed
+      }
+      sessionId = null;
+    }
+
+    if (pyProcess && !pyProcess.killed) {
+      pyProcess.kill('SIGKILL');
+      pyProcess = null;
+    }
+  });
+
+  it('should attach to a running debugpy target and debug with verified stack and variables', async () => {
+    // Skip if python/debugpy not available
+    try {
+      execSync(`${PYTHON_CMD} -c "import debugpy"`, { stdio: 'ignore' });
+    } catch {
+      console.log('[Python Attach Test] Skipping — python/debugpy not installed');
+      return;
+    }
+
+    const scriptPath = path.resolve(ROOT, 'examples', 'python', 'attach_loop.py');
+
+    try {
+      // Pick a free port for debugpy to listen on
+      const debugPort = await getFreePort();
+      console.log(`[Python Attach Test] Using debugpy port: ${debugPort}`);
+
+      // Start the target under debugpy. debugpy sets up its listener before
+      // running the script, so the READY marker implies the port is open.
+      pyProcess = spawn(PYTHON_CMD, [
+        '-m', 'debugpy',
+        '--listen', `127.0.0.1:${debugPort}`,
+        scriptPath
+      ], {
+        cwd: ROOT,
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Timeout waiting for debugpy target')), 15000);
+        let outputData = '';
+        let resolved = false;
+
+        const checkOutput = (chunk: Buffer, stream: string) => {
+          if (resolved) return;
+          outputData += chunk.toString();
+          console.log(`[Python Attach Test] target ${stream}:`, chunk.toString().trim());
+          if (outputData.includes('ATTACH_LOOP_READY')) {
+            resolved = true;
+            clearTimeout(timeout);
+            resolve();
+          }
+        };
+
+        pyProcess!.stdout!.on('data', (chunk: Buffer) => checkOutput(chunk, 'stdout'));
+        pyProcess!.stderr!.on('data', (chunk: Buffer) => checkOutput(chunk, 'stderr'));
+
+        pyProcess!.on('error', (err) => {
+          if (resolved) return;
+          clearTimeout(timeout);
+          reject(err);
+        });
+
+        pyProcess!.on('exit', (code) => {
+          if (resolved) return;
+          clearTimeout(timeout);
+          reject(new Error(`Target exited with code ${code} before debugpy was ready`));
+        });
+      });
+
+      console.log('[Python Attach Test] Target is running with debugpy listening');
+
+      // 1. Create Python debug session
+      console.log('[Python Attach Test] Creating debug session...');
+      const createResult = await mcpClient!.callTool({
+        name: 'create_debug_session',
+        arguments: {
+          language: 'python',
+          name: 'python-attach-test'
+        }
+      });
+
+      const createResponse = parseSdkToolResult(createResult);
+      expect(createResponse.sessionId).toBeDefined();
+      sessionId = createResponse.sessionId as string;
+      console.log(`[Python Attach Test] Session created: ${sessionId}`);
+
+      // 2. Set breakpoint on line 7 (result = a + b; inside compute())
+      console.log('[Python Attach Test] Setting breakpoint on line 7...');
+      const bpResult = await mcpClient!.callTool({
+        name: 'set_breakpoint',
+        arguments: {
+          sessionId,
+          file: scriptPath,
+          line: 7
+        }
+      });
+
+      const bpResponse = parseSdkToolResult(bpResult);
+      expect(bpResponse.success).toBe(true);
+      console.log('[Python Attach Test] Breakpoint set successfully');
+
+      // 3. Attach to the running target. Success here is the regression test
+      //    for the issue #145 handshake deadlock.
+      console.log(`[Python Attach Test] Attaching to debugpy on port ${debugPort}...`);
+      const attachResult = await mcpClient!.callTool({
+        name: 'attach_to_process',
+        arguments: {
+          sessionId,
+          host: '127.0.0.1',
+          port: debugPort
+        }
+      });
+
+      const attachResponse = parseSdkToolResult(attachResult);
+      console.log('[Python Attach Test] attach response:', JSON.stringify(attachResponse));
+      expect(attachResponse.success).toBe(true);
+      expect(attachResponse.state).toBe('paused');
+      console.log('[Python Attach Test] Attached successfully, state:', attachResponse.state);
+
+      // 4. Continue execution — the post-attach pause left the target stopped.
+      console.log('[Python Attach Test] Continuing execution...');
+      const continueResult = parseSdkToolResult(
+        await mcpClient!.callTool({
+          name: 'continue_execution',
+          arguments: { sessionId }
+        })
+      );
+      expect(continueResult.success).toBe(true);
+
+      // 5. Poll for breakpoint hit — the loop calls compute() every 500ms.
+      console.log('[Python Attach Test] Waiting for breakpoint hit...');
+      const stackResponse = await waitForPausedState(mcpClient!, sessionId, 20, 500,
+        (frames) => frames[0]?.name?.toLowerCase().includes('compute') ?? false
+      );
+
+      // HARD ASSERTION: Breakpoint must fire
+      expect(stackResponse).not.toBeNull();
+      expect(stackResponse!.stackFrames).toBeDefined();
+      const frames = stackResponse!.stackFrames!;
+      expect(frames.length).toBeGreaterThan(0);
+      console.log(`[Python Attach Test] Stack has ${frames.length} frames`);
+
+      // HARD ASSERTION: Top frame is compute() at line 7
+      const topFrame = frames[0];
+      console.log('[Python Attach Test] Top frame:', topFrame.name, 'line:', topFrame.line);
+      expect(topFrame.name?.toLowerCase()).toContain('compute');
+      if (typeof topFrame.line === 'number' && topFrame.line > 0) {
+        expect(topFrame.line).toBe(7);
+      }
+
+      // Get local variables and verify runtime values
+      console.log('[Python Attach Test] Getting local variables...');
+      const localsRaw = await mcpClient!.callTool({
+        name: 'get_local_variables',
+        arguments: { sessionId }
+      });
+      const localsResponse = parseSdkToolResult(localsRaw) as {
+        success?: boolean;
+        variables?: Array<{ name: string; value: string }>;
+        count?: number;
+      };
+
+      expect(localsResponse.success).toBe(true);
+      expect(Array.isArray(localsResponse.variables)).toBe(true);
+      expect(localsResponse.variables!.length).toBeGreaterThan(0);
+
+      const localsByName = new Map(
+        (localsResponse.variables ?? []).map(v => [v.name, v.value])
+      );
+      console.log('[Python Attach Test] Variables:', Object.fromEntries(localsByName));
+
+      // HARD ASSERTION: a=42, b=58 in compute()
+      expect(localsByName.get('a')).toBe('42');
+      expect(localsByName.get('b')).toBe('58');
+
+      // HARD ASSERTION: Continue execution after breakpoint hit
+      console.log('[Python Attach Test] Continuing execution...');
+      const finalContinue = parseSdkToolResult(
+        await mcpClient!.callTool({
+          name: 'continue_execution',
+          arguments: { sessionId }
+        })
+      );
+      expect(finalContinue.success).toBe(true);
+
+      // 6. Close the session — attach mode must detach without killing the
+      //    target (terminateDebuggee=false).
+      console.log('[Python Attach Test] Closing session (detach)...');
+      await callToolSafely(mcpClient!, 'close_debug_session', { sessionId });
+      sessionId = null;
+
+      await new Promise(r => setTimeout(r, 1000));
+      expect(pyProcess!.exitCode).toBeNull();
+      console.log('[Python Attach Test] Target survived detach');
+
+    } finally {
+      // Kill target if still running
+      if (pyProcess && !pyProcess.killed) {
+        pyProcess.kill('SIGKILL');
+        pyProcess = null;
+      }
+    }
+  }, 60000);
+});

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -1773,9 +1773,7 @@ describe('DapProxyWorker', () => {
         launchConfig: {
           type: 'python',
           request: 'attach',
-          connect: { host: '127.0.0.1', port: 5679 },
-          host: '127.0.0.1',
-          port: 5679
+          connect: { host: '127.0.0.1', port: 5679 }
         }
         // No adapterCommand: direct-connect attach — debugpy is already listening
       };
@@ -1846,9 +1844,7 @@ describe('DapProxyWorker', () => {
         launchConfig: {
           type: 'python',
           request: 'attach',
-          connect: { host: '127.0.0.1', port: 5679 },
-          host: '127.0.0.1',
-          port: 5679
+          connect: { host: '127.0.0.1', port: 5679 }
         }
       };
 

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -1755,6 +1755,139 @@ describe('DapProxyWorker', () => {
         expect.stringContaining('Waiting for "initialized" event from adapter')
       );
     });
+
+    // debugpy ordering (issue #145): 'initialized' is only emitted AFTER the
+    // adapter receives the attach request, and the attach *response* only
+    // arrives after configurationDone. The worker must send attach first and
+    // must not block on the attach response before configurationDone.
+    it('python attach: sends attach before initialized and tolerates attach response deferred until configurationDone', async () => {
+      const payload: ProxyInitPayload = {
+        cmd: 'init',
+        sessionId: 'py-attach-session',
+        language: 'python',
+        executablePath: 'python',
+        adapterHost: '127.0.0.1',
+        adapterPort: 40001,
+        logDir: '/logs',
+        scriptPath: 'attach://remote',
+        launchConfig: {
+          type: 'python',
+          request: 'attach',
+          connect: { host: '127.0.0.1', port: 5679 },
+          host: '127.0.0.1',
+          port: 5679
+        }
+        // No adapterCommand: direct-connect attach — debugpy is already listening
+      };
+
+      const processStub = {
+        spawn: vi.fn(),
+        shutdown: vi.fn().mockResolvedValue(undefined)
+      };
+
+      const callOrder: string[] = [];
+      let resolveAttachResponse!: () => void;
+      const attachResponse = new Promise<void>((resolve) => {
+        resolveAttachResponse = resolve;
+      });
+
+      const connectionStub = {
+        connectWithRetry: vi.fn().mockResolvedValue(mockDapClient),
+        setAdapterPolicy: vi.fn(),
+        setupEventHandlers: vi.fn((client: EventEmitter, handlers: Record<string, () => void>) => {
+          if (handlers.onInitialized) client.on('initialized', handlers.onInitialized);
+        }),
+        // debugpy does NOT emit 'initialized' after initialize alone
+        initializeSession: vi.fn().mockResolvedValue(undefined),
+        sendAttachRequest: vi.fn().mockImplementation(() => {
+          callOrder.push('attach');
+          // 'initialized' arrives only after the attach request is received
+          setImmediate(() => (mockDapClient as EventEmitter).emit('initialized'));
+          // the attach response arrives only after configurationDone
+          return attachResponse;
+        }),
+        setBreakpoints: vi.fn().mockResolvedValue(undefined),
+        sendConfigurationDone: vi.fn().mockImplementation(async () => {
+          callOrder.push('configurationDone');
+          resolveAttachResponse();
+        }),
+        disconnect: vi.fn().mockResolvedValue(undefined)
+      };
+
+      (worker as any).logger = mockLogger;
+      (worker as any).processManager = processStub;
+      (worker as any).connectionManager = connectionStub;
+      (worker as any).adapterPolicy = PythonAdapterPolicy;
+      (worker as any).adapterState = PythonAdapterPolicy.createInitialState();
+      (worker as any).currentInitPayload = payload;
+      (worker as any).state = ProxyState.INITIALIZING;
+
+      mockMessageSender.send.mockClear();
+
+      await (worker as any).startAdapterAndConnect(payload);
+
+      // Direct connect: no adapter process spawned, socket opened to the attach port
+      expect(processStub.spawn).not.toHaveBeenCalled();
+      expect(connectionStub.connectWithRetry).toHaveBeenCalledWith('127.0.0.1', 5679);
+      // Attach was sent first; configurationDone followed the initialized event
+      expect(callOrder).toEqual(['attach', 'configurationDone']);
+    }, 20000);
+
+    it('python attach: fails fast when the attach request is rejected', async () => {
+      const payload: ProxyInitPayload = {
+        cmd: 'init',
+        sessionId: 'py-attach-refused',
+        language: 'python',
+        executablePath: 'python',
+        adapterHost: '127.0.0.1',
+        adapterPort: 40002,
+        logDir: '/logs',
+        scriptPath: 'attach://remote',
+        launchConfig: {
+          type: 'python',
+          request: 'attach',
+          connect: { host: '127.0.0.1', port: 5679 },
+          host: '127.0.0.1',
+          port: 5679
+        }
+      };
+
+      const processStub = {
+        spawn: vi.fn(),
+        shutdown: vi.fn().mockResolvedValue(undefined)
+      };
+
+      const connectionStub = {
+        connectWithRetry: vi.fn().mockResolvedValue(mockDapClient),
+        setAdapterPolicy: vi.fn(),
+        setupEventHandlers: vi.fn((client: EventEmitter, handlers: Record<string, () => void>) => {
+          if (handlers.onInitialized) client.on('initialized', handlers.onInitialized);
+        }),
+        initializeSession: vi.fn().mockResolvedValue(undefined),
+        // Attach fails immediately (e.g. debugpy rejects the request) and
+        // 'initialized' never arrives — the worker must not sit out the full
+        // initialized timeout before surfacing the failure.
+        sendAttachRequest: vi.fn().mockRejectedValue(
+          new Error('connect ECONNREFUSED 127.0.0.1:5679')
+        ),
+        setBreakpoints: vi.fn().mockResolvedValue(undefined),
+        sendConfigurationDone: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined)
+      };
+
+      (worker as any).logger = mockLogger;
+      (worker as any).processManager = processStub;
+      (worker as any).connectionManager = connectionStub;
+      (worker as any).adapterPolicy = PythonAdapterPolicy;
+      (worker as any).adapterState = PythonAdapterPolicy.createInitialState();
+      (worker as any).currentInitPayload = payload;
+      (worker as any).state = ProxyState.INITIALIZING;
+
+      const started = Date.now();
+      await expect((worker as any).startAdapterAndConnect(payload)).rejects.toThrow(/ECONNREFUSED/);
+      // Fail-fast: well under the 15s initialized timeout
+      expect(Date.now() - started).toBeLessThan(5000);
+    }, 20000);
   });
 
   describe('Go/Java Launch Sequence', () => {

--- a/tests/unit/adapter-python/python-debug-adapter.test.ts
+++ b/tests/unit/adapter-python/python-debug-adapter.test.ts
@@ -350,12 +350,14 @@ describe('PythonDebugAdapter', () => {
         request: 'attach',
         name: 'Python: Attach',
         connect: { host: '127.0.0.1', port: 5679 },
-        host: '127.0.0.1',
-        port: 5679,
         justMyCode: false,
         cwd: '/work',
         env: { FOO: '1' }
       });
+      // debugpy rejects configs carrying both `connect` and top-level
+      // host/port ("mutually exclusive"), so those must not leak through.
+      expect(config.host).toBeUndefined();
+      expect(config.port).toBeUndefined();
       // No launch-template pollution (second bug in issue #145)
       expect(config.console).toBeUndefined();
       expect(config.__attachMode).toBeUndefined();

--- a/tests/unit/adapter-python/python-debug-adapter.test.ts
+++ b/tests/unit/adapter-python/python-debug-adapter.test.ts
@@ -322,4 +322,78 @@ describe('PythonDebugAdapter', () => {
     expect(defaults.env).toEqual({});
     expect(defaults.cwd).toBe(process.cwd());
   });
+
+  describe('attach support (issue #145)', () => {
+    it('reports attach capabilities', () => {
+      const adapter = new PythonDebugAdapter(createDependencies());
+
+      expect(adapter.supportsAttach?.()).toBe(true);
+      expect(adapter.supportsDetach?.()).toBe(true);
+      expect(adapter.usesDirectConnectForAttach?.()).toBe(true);
+    });
+
+    it('keeps request=attach and emits the debugpy connect shape', () => {
+      const adapter = new PythonDebugAdapter(createDependencies());
+
+      const config = adapter.transformAttachConfig!({
+        request: 'attach',
+        host: '127.0.0.1',
+        port: 5679,
+        justMyCode: false,
+        cwd: '/work',
+        env: { FOO: '1' },
+        __attachMode: true
+      });
+
+      expect(config).toMatchObject({
+        type: 'python',
+        request: 'attach',
+        name: 'Python: Attach',
+        connect: { host: '127.0.0.1', port: 5679 },
+        host: '127.0.0.1',
+        port: 5679,
+        justMyCode: false,
+        cwd: '/work',
+        env: { FOO: '1' }
+      });
+      // No launch-template pollution (second bug in issue #145)
+      expect(config.console).toBeUndefined();
+      expect(config.__attachMode).toBeUndefined();
+    });
+
+    it('defaults attach host to 127.0.0.1 and justMyCode to true', () => {
+      const adapter = new PythonDebugAdapter(createDependencies());
+
+      const config = adapter.transformAttachConfig!({ request: 'attach', port: 5679 });
+
+      expect(config).toMatchObject({
+        connect: { host: '127.0.0.1', port: 5679 },
+        justMyCode: true
+      });
+    });
+
+    it('rejects attach without a port', () => {
+      const adapter = new PythonDebugAdapter(createDependencies());
+
+      expect(() => adapter.transformAttachConfig!({ request: 'attach' }))
+        .toThrow(/port/i);
+    });
+
+    it('rejects PID-based attach with guidance toward debugpy --listen', () => {
+      const adapter = new PythonDebugAdapter(createDependencies());
+
+      expect(() => adapter.transformAttachConfig!({ request: 'attach', processId: 1234 }))
+        .toThrow(/process id/i);
+    });
+
+    it('provides a default attach config', () => {
+      const adapter = new PythonDebugAdapter(createDependencies());
+
+      expect(adapter.getDefaultAttachConfig?.()).toEqual({
+        request: 'attach',
+        host: '127.0.0.1',
+        justMyCode: true
+      });
+    });
+  });
 });

--- a/tests/unit/shared/adapter-policy-python.test.ts
+++ b/tests/unit/shared/adapter-policy-python.test.ts
@@ -95,6 +95,12 @@ describe('PythonAdapterPolicy', () => {
     });
   });
 
+  it('pauses the target after attach', () => {
+    // debugpy does not suspend a running target on attach, so an explicit
+    // pause is required for the session to land in a truthful PAUSED state.
+    expect(PythonAdapterPolicy.getAttachBehavior?.()).toEqual({ pauseAfterAttach: true });
+  });
+
   describe('getAdapterSpawnConfig', () => {
     const basePayload = {
       executablePath: 'python',

--- a/tests/unit/shared/adapter-policy-python.test.ts
+++ b/tests/unit/shared/adapter-policy-python.test.ts
@@ -87,7 +87,79 @@ describe('PythonAdapterPolicy', () => {
     ).toBe(false);
   });
 
-  it('returns empty initialization behavior', () => {
-    expect(PythonAdapterPolicy.getInitializationBehavior()).toEqual({});
+  it('requires attach to be sent before the initialized event (debugpy ordering)', () => {
+    // debugpy only emits 'initialized' AFTER it receives the attach request;
+    // waiting for the event before sending attach deadlocks (issue #145).
+    expect(PythonAdapterPolicy.getInitializationBehavior()).toEqual({
+      sendAttachBeforeInitialized: true
+    });
+  });
+
+  describe('getAdapterSpawnConfig', () => {
+    const basePayload = {
+      executablePath: 'python',
+      adapterHost: '127.0.0.1',
+      adapterPort: 40000,
+      logDir: '/logs'
+    };
+
+    it('returns connect mode for attach using the connect object', () => {
+      const config = PythonAdapterPolicy.getAdapterSpawnConfig!({
+        ...basePayload,
+        launchConfig: { request: 'attach', connect: { host: '10.0.0.5', port: 5679 } }
+      });
+
+      expect(config).toEqual({ mode: 'connect', host: '10.0.0.5', port: 5679, logDir: '/logs' });
+    });
+
+    it('returns connect mode for attach using top-level host/port', () => {
+      const config = PythonAdapterPolicy.getAdapterSpawnConfig!({
+        ...basePayload,
+        launchConfig: { request: 'attach', host: '192.168.1.2', port: 5680 }
+      });
+
+      expect(config).toEqual({ mode: 'connect', host: '192.168.1.2', port: 5680, logDir: '/logs' });
+    });
+
+    it('defaults the attach host to 127.0.0.1', () => {
+      const config = PythonAdapterPolicy.getAdapterSpawnConfig!({
+        ...basePayload,
+        launchConfig: { request: 'attach', port: 5681 }
+      });
+
+      expect(config).toMatchObject({ mode: 'connect', host: '127.0.0.1', port: 5681 });
+    });
+
+    it('rejects attach without a valid port, pointing at debugpy --listen', () => {
+      expect(() =>
+        PythonAdapterPolicy.getAdapterSpawnConfig!({
+          ...basePayload,
+          launchConfig: { request: 'attach' }
+        })
+      ).toThrow(/debugpy --listen/);
+    });
+
+    it('still spawns debugpy.adapter for launch', () => {
+      const config = PythonAdapterPolicy.getAdapterSpawnConfig!({
+        ...basePayload,
+        launchConfig: { request: 'launch' }
+      });
+
+      expect(config.mode).toBe('spawn');
+      expect(config).toMatchObject({
+        command: 'python',
+        args: expect.arrayContaining(['-m', 'debugpy.adapter'])
+      });
+    });
+
+    it('uses a provided adapterCommand verbatim for launch', () => {
+      const config = PythonAdapterPolicy.getAdapterSpawnConfig!({
+        ...basePayload,
+        launchConfig: { request: 'launch' },
+        adapterCommand: { command: 'py', args: ['-m', 'debugpy.adapter'], env: { A: '1' } }
+      });
+
+      expect(config).toMatchObject({ mode: 'spawn', command: 'py' });
+    });
   });
 });


### PR DESCRIPTION
## Problem

`attach_to_process` on a Python session always failed after ~5s with `Failed to attach: Proxy exited during initialization` (#145).

## Root causes (three, all fixed)

1. **Handshake deadlock** — `PythonAdapterPolicy.getInitializationBehavior()` returned `{}`, so the proxy worker waited for the `initialized` event before sending attach. debugpy only emits `initialized` **after** it receives the attach request, so the 5s wait always timed out. The policy now sets `sendAttachBeforeInitialized: true`, routing Python into the worker's attach-first branch.

2. **Latent deadlock in the attach-first branch** — that branch (never exercised until now; no policy set the flag) awaited the attach **response** before `handleInitializedEvent()` sends `configurationDone` — but debugpy only responds to attach after `configurationDone`, which would have traded the 5s deadlock for a 30s one. The branch now fires the attach request, races `initialized` against attach failure and the 15s timeout, completes `configurationDone`, then awaits the attach response. Early attach failures (connection refused) surface immediately instead of waiting out the timeout.

3. **Config pollution** — the Python adapter implemented neither `supportsAttach` nor `transformAttachConfig`, so attach configs fell through to `transformLaunchConfig`, which overwrote `request:'attach'` with the launch template (`request:'launch'`, `name:'Python: Current File'`, `console:'internalConsole'`) — the secondary bug noted in the issue. The adapter now implements the attach surface emitting debugpy's client-connect shape (`connect: {host, port}` only — debugpy rejects configs that also carry top-level host/port as mutually exclusive), and `usesDirectConnectForAttach()` so the proxy connects straight to the listening debugpy endpoint instead of spawning a second `debugpy.adapter`.

Additionally, `getAttachBehavior: { pauseAfterAttach: true }` (separate commit, same machinery as rdbg): debugpy does not suspend a running target on attach, so an explicit pause makes the reported PAUSED state truthful.

## Tests

- Worker unit tests pinning the debugpy ordering: attach sent before `initialized`; attach response deferred until after `configurationDone`; fail-fast on attach rejection. Existing Java-ordering attach tests (standard branch, untouched) stay green.
- Policy tests: `sendAttachBeforeInitialized`, connect-mode spawn config (from `connect` object and top-level fields, host default, invalid-port error), launch path unchanged, `pauseAfterAttach`.
- Adapter tests: attach capability flags, `transformAttachConfig` shape (no top-level host/port, no launch-template pollution), missing-port and PID-attach errors, default attach config.
- New e2e `mcp-server-smoke-python-attach.test.ts`: attach to a live `python -m debugpy --listen` loop, verify paused state, breakpoint hit in `compute()` with locals `a=42`/`b=58`, and the target surviving detach. Skips gracefully without debugpy.

## Verification

- Full unit suite (2402), lint, build all green.
- E2E regressions: python launch smoke, Java attach, Ruby attach all pass.
- Live dogfood via dev proxy: the exact issue repro (attach to running `debugpy --listen` target) now attaches paused, hits breakpoints, inspects locals, and detaches leaving the target running.

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)