### PR TITLE
fix(proxy): stop leaking adapter env into logs and tool errors (fixes #146)

### DIFF
--- a/docs/logging-format-specification.md
+++ b/docs/logging-format-specification.md
@@ -207,8 +207,11 @@ Truncation is applied in targeted locations rather than as a generic deep traver
 1. **Variable values in `get_variables` logging**: Individual variable `value` strings are truncated at 200 characters, and only the first 10 variables are included in the log entry.
 
 2. **Request/Response objects**: Targeted sanitization via `sanitizePayloadForLogging`:
-   - `adapterCommand.env` is sanitized by `sanitizeEnvForLogging`, which checks each key against a list of sensitive patterns (e.g., `api_key`, `secret`, `token`, `password`, `credential`, `auth`, `session_id`, `access_key`, `signing`, `private_key`). Matching keys have their values replaced with `[REDACTED]`; non-matching keys are passed through unchanged
+   - `adapterCommand.env` is replaced wholesale with a count summary (e.g., `<57 env vars redacted>`) — env values are never logged, since keyword redaction cannot anticipate every secret-bearing key name (issue #146)
+   - `sanitizeEnvForLogging` (for any direct use) redacts values whose key matches a sensitive pattern (e.g., `api_key`, `secret`, `token`, `password`, `credential`, `auth`, `session_id`, `access_key`, `signing`, `private_key`) or contains a sensitive token after splitting on delimiters and camelCase boundaries (`pat`, `key`, `pwd`, `passwd`, `cred`, `bearer`, `oauth`, `jwt` — catches `GITHUB_PAT` without redacting `PATH`)
    - Other request/response fields are not generically scrubbed; sanitization is intentionally targeted
+
+3. **Proxy stderr in errors**: stderr lines are sanitized at capture (`sanitizeStderr` redacts lines with sensitive key names like `GITHUB_PAT=...` or well-known secret value shapes like `ghp_...`, `github_pat_...`, `sk-...`, `AKIA...`, JWTs, PEM headers), the capture buffer is bounded to 100 lines, and the "Proxy exited during initialization" error embeds at most the last 10 lines (max 2000 chars)
 
 There is no generic array truncation (e.g., "show first 5 items") applied across all log entries.
 

--- a/src/proxy/dap-proxy-core.ts
+++ b/src/proxy/dap-proxy-core.ts
@@ -283,7 +283,7 @@ export class ProxyRunner {
             this.logger.debug(`[ProxyRunner] IPC message #${this.ipcMessageCounter} processed successfully (object)`);
           } catch (e) {
             this.logger.error('[ProxyRunner] Could not process object message:', {
-              message,
+              message: sanitizePayloadForLogging(message),
               error: getErrorMessage(e)
             });
             throw e;

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -274,7 +274,17 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         } else {
           let errorMessage = `Proxy exited during initialization. Code: ${code}, Signal: ${signal}`;
           if (this.stderrBuffer.length > 0) {
-            errorMessage += `\nStderr output:\n${this.stderrBuffer.join('\n')}`;
+            // Cap what gets embedded in the user-facing error — the full
+            // buffer is already in the logs (issue #146).
+            const lines = this.stderrBuffer.slice(-10);
+            let text = lines.join('\n');
+            if (text.length > 2000) {
+              text = '…' + text.slice(-2000);
+            }
+            const label = this.stderrBuffer.length > lines.length
+              ? ` (last ${lines.length} of ${this.stderrBuffer.length} lines)`
+              : '';
+            errorMessage += `\nStderr output${label}:\n${text}`;
           }
           reject(new Error(errorMessage));
         }
@@ -742,8 +752,13 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       // Sanitize before logging and storing — stderr may contain env vars
       const sanitizedLines = sanitizeStderr([output]);
       this.logger.error(`[ProxyManager STDERR] ${sanitizedLines[0]}`);
-      // Capture sanitized stderr for error reporting during initialization
+      // Capture sanitized stderr for error reporting during initialization.
+      // Bounded so a chatty proxy cannot grow the buffer (and everything it
+      // gets copied into) without limit.
       if (!this.isInitialized) {
+        if (this.stderrBuffer.length >= 100) {
+          this.stderrBuffer.shift();
+        }
         this.stderrBuffer.push(sanitizedLines[0]);
       }
     });

--- a/src/utils/env-sanitizer.ts
+++ b/src/utils/env-sanitizer.ts
@@ -19,12 +19,29 @@ const SENSITIVE_PATTERNS = [
 ];
 
 /**
+ * Short sensitive words matched as whole tokens (after splitting keys on
+ * non-alphanumerics and camelCase boundaries). Token matching catches
+ * GITHUB_PAT, SSH_KEY, MY_PWD, githubPat without the substring false
+ * positives a plain pattern would hit (PATH, PATTERN, MONKEY).
+ */
+const SENSITIVE_TOKENS = new Set([
+  'pat', 'key', 'keys', 'pwd', 'passwd', 'cred', 'creds', 'bearer', 'oauth', 'jwt'
+]);
+
+function hasSensitiveToken(key: string): boolean {
+  return key
+    .split(/[^a-zA-Z0-9]+/)
+    .flatMap(part => part.split(/(?<=[a-z0-9])(?=[A-Z])/))
+    .some(token => SENSITIVE_TOKENS.has(token.toLowerCase()));
+}
+
+/**
  * Redact sensitive environment variable values for safe logging.
  */
 export function sanitizeEnvForLogging(env: Record<string, string>): Record<string, string> {
   const sanitized: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
-    if (SENSITIVE_PATTERNS.some(p => p.test(key))) {
+    if (SENSITIVE_PATTERNS.some(p => p.test(key)) || hasSensitiveToken(key)) {
       sanitized[key] = '[REDACTED]';
     } else {
       sanitized[key] = value;
@@ -36,17 +53,20 @@ export function sanitizeEnvForLogging(env: Record<string, string>): Record<strin
 /**
  * Shallow-sanitize a proxy init payload or command object before logging.
  * Specifically targets the `adapterCommand.env` field which contains process.env.
+ *
+ * The env body is replaced with a count summary rather than a per-key
+ * redacted copy: logs never need the values, and keyword redaction cannot
+ * anticipate every secret-bearing key name (issue #146).
  */
 export function sanitizePayloadForLogging(payload: unknown): unknown {
   if (!payload || typeof payload !== 'object') return payload;
 
   const obj = { ...(payload as Record<string, unknown>) };
 
-  // Sanitize adapterCommand.env
   if (obj.adapterCommand && typeof obj.adapterCommand === 'object') {
     const cmd = { ...(obj.adapterCommand as Record<string, unknown>) };
     if (cmd.env && typeof cmd.env === 'object') {
-      cmd.env = sanitizeEnvForLogging(cmd.env as Record<string, string>);
+      cmd.env = `<${Object.keys(cmd.env as Record<string, string>).length} env vars redacted>`;
     }
     obj.adapterCommand = cmd;
   }
@@ -55,17 +75,26 @@ export function sanitizePayloadForLogging(payload: unknown): unknown {
 }
 
 /**
- * Pattern matching sensitive values that may appear in stderr output.
- * Matches lines like `ANTHROPIC_API_KEY=sk-ant-...` or JSON `"OPENAI_API_KEY": "sk-..."`.
+ * Pattern matching sensitive key names that may appear in stderr output.
+ * Matches lines like `ANTHROPIC_API_KEY=sk-ant-...`, `GITHUB_PAT=...`,
+ * or JSON `"OPENAI_API_KEY": "sk-..."`. The short words (pat, key, pwd, ...)
+ * require an immediately following `=`, `:` or `"`, so PATH=/usr/bin stays.
  */
-const STDERR_SENSITIVE_LINE = /(?:api[_-]?key|secret|token|password|credential|private[_-]?key|auth)[=:"]\s*/i;
+const STDERR_SENSITIVE_LINE = /(?:api[_-]?key|secret|token|password|passwd|pwd|credential|private[_-]?key|auth|pat|key|bearer|jwt|oauth)[=:"]\s*/i;
+
+/**
+ * Well-known secret value shapes, for secrets whose key name never appears
+ * on the line: GitHub tokens (ghp_/gho_/... and github_pat_), sk- API keys,
+ * Slack xox tokens, AWS access key ids, JWTs, PEM private key headers.
+ */
+const STDERR_SENSITIVE_VALUE = /\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{10,}\.eyJ)|-----BEGIN[A-Z ]*PRIVATE KEY-----/;
 
 /**
  * Sanitize stderr lines to redact any that appear to contain sensitive env var assignments.
  */
 export function sanitizeStderr(lines: string[]): string[] {
   return lines.map(line => {
-    if (STDERR_SENSITIVE_LINE.test(line)) {
+    if (STDERR_SENSITIVE_LINE.test(line) || STDERR_SENSITIVE_VALUE.test(line)) {
       return '[REDACTED — line contained sensitive data]';
     }
     return line;

--- a/tests/unit/proxy/dap-proxy-core.test.ts
+++ b/tests/unit/proxy/dap-proxy-core.test.ts
@@ -282,6 +282,68 @@ describe('ProxyRunner IPC communication', () => {
     expect(onMessage).toHaveBeenCalledWith(JSON.stringify({ cmd: 'init', sessionId: 'test-2' }));
   });
 
+  it('never logs adapter env values from IPC messages (issue #146)', async () => {
+    (process as any).send = vi.fn();
+    Object.defineProperty(process, 'connected', { value: true, configurable: true });
+    const onMessage = vi.fn().mockResolvedValue(undefined);
+
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage });
+    await runner.start();
+
+    const messageListeners = process.listeners('message');
+    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
+
+    await ipcHandler({
+      cmd: 'init',
+      sessionId: 'env-leak',
+      adapterCommand: {
+        command: 'python',
+        args: ['-m', 'debugpy.adapter'],
+        env: { GITHUB_PAT: 'github_pat_SENTINEL', HOME: '/home/user-sentinel' }
+      }
+    });
+
+    const allLogged = JSON.stringify([
+      (logger.debug as any).mock.calls,
+      (logger.info as any).mock.calls,
+      (logger.warn as any).mock.calls,
+      (logger.error as any).mock.calls
+    ]);
+    expect(allLogged).not.toContain('github_pat_SENTINEL');
+    expect(allLogged).not.toContain('/home/user-sentinel');
+  });
+
+  it('never logs adapter env values when message processing fails (issue #146)', async () => {
+    (process as any).send = vi.fn();
+    Object.defineProperty(process, 'connected', { value: true, configurable: true });
+    const onMessage = vi.fn().mockRejectedValue(new Error('processing failed'));
+
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage });
+    await runner.start();
+
+    const messageListeners = process.listeners('message');
+    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
+
+    await ipcHandler({
+      cmd: 'init',
+      sessionId: 'env-leak-error',
+      adapterCommand: {
+        command: 'python',
+        args: ['-m', 'debugpy.adapter'],
+        env: { GITHUB_PAT: 'github_pat_SENTINEL', HOME: '/home/user-sentinel' }
+      }
+    });
+
+    const allLogged = JSON.stringify([
+      (logger.debug as any).mock.calls,
+      (logger.info as any).mock.calls,
+      (logger.warn as any).mock.calls,
+      (logger.error as any).mock.calls
+    ]);
+    expect(allLogged).not.toContain('github_pat_SENTINEL');
+    expect(allLogged).not.toContain('/home/user-sentinel');
+  });
+
   it('IPC message handler warns on unexpected message type', async () => {
     (process as any).send = vi.fn();
     Object.defineProperty(process, 'connected', { value: true, configurable: true });

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -462,6 +462,43 @@ describe('ProxyManager.start', () => {
     }
   });
 
+  it('caps stderr embedded in init-exit errors and never leaks secrets (issue #146)', async () => {
+    const stderrEmitter = fakeProcess.stderr as unknown as EventEmitter;
+    fakeProcess.sendCommand.mockImplementation((cmd: any) => {
+      if (cmd.cmd === 'init') {
+        setTimeout(() => {
+          // Acknowledge init so start() reaches the wait-for-initialized phase,
+          // then dump 15 stderr lines (one secret-bearing) and exit.
+          fakeProcess.emit('message', {
+            type: 'status',
+            status: 'init_received',
+            sessionId: cmd.sessionId
+          });
+          setTimeout(() => {
+            for (let i = 1; i <= 14; i++) {
+              stderrEmitter.emit('data', Buffer.from(`stderr-line-${String(i).padStart(2, '0')}`));
+            }
+            stderrEmitter.emit('data', Buffer.from('GITHUB_PAT=github_pat_supersecret1234567890'));
+            fakeProcess.emit('exit', 1, null);
+          }, 0);
+        }, 0);
+      }
+    });
+
+    const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+    await expect(startPromise).rejects.toThrow(/Proxy exited during initialization\. Code: 1/);
+    const err = await startPromise.catch((e: Error) => e);
+
+    // Capped to the last 10 of 15 lines, labelled as such
+    expect(err.message).toContain('(last 10 of 15 lines)');
+    expect(err.message).toContain('stderr-line-06');
+    expect(err.message).toContain('stderr-line-14');
+    expect(err.message).not.toContain('stderr-line-05');
+    expect(err.message).not.toContain('stderr-line-01');
+    // The secret never reaches the user-facing error
+    expect(err.message).not.toContain('github_pat_supersecret');
+  });
+
   it('fails to start when bootstrap worker script is missing', async () => {
     (fileSystem.pathExists as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(false);
 

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -499,6 +499,73 @@ describe('ProxyManager.start', () => {
     expect(err.message).not.toContain('github_pat_supersecret');
   });
 
+  it('truncates an oversized stderr tail embedded in the init-exit error (issue #146)', async () => {
+    const stderrEmitter = fakeProcess.stderr as unknown as EventEmitter;
+    fakeProcess.sendCommand.mockImplementation((cmd: any) => {
+      if (cmd.cmd === 'init') {
+        setTimeout(() => {
+          fakeProcess.emit('message', {
+            type: 'status',
+            status: 'init_received',
+            sessionId: cmd.sessionId
+          });
+          setTimeout(() => {
+            // 12 lines of ~300 chars each; the last 10 joined exceed the 2000-char cap.
+            for (let i = 1; i <= 12; i++) {
+              const marker = `MARKER-${String(i).padStart(2, '0')}`;
+              stderrEmitter.emit('data', Buffer.from(marker + 'x'.repeat(300 - marker.length)));
+            }
+            fakeProcess.emit('exit', 1, null);
+          }, 0);
+        }, 0);
+      }
+    });
+
+    const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+    await expect(startPromise).rejects.toThrow(/Proxy exited during initialization/);
+    const err = await startPromise.catch((e: Error) => e);
+
+    // Truncation marker present; the stderr tail is bounded near the 2000-char cap.
+    expect(err.message).toContain('…');
+    const stderrPortion = err.message.slice(err.message.indexOf('\nStderr output'));
+    expect(stderrPortion.length).toBeLessThan(2200);
+    // The newest line survives; the front of the last-10 block was sliced off.
+    expect(err.message).toContain('MARKER-12');
+    expect(err.message).not.toContain('MARKER-03');
+  });
+
+  it('bounds the stderr capture buffer to 100 lines (issue #146)', async () => {
+    const stderrEmitter = fakeProcess.stderr as unknown as EventEmitter;
+    fakeProcess.sendCommand.mockImplementation((cmd: any) => {
+      if (cmd.cmd === 'init') {
+        setTimeout(() => {
+          fakeProcess.emit('message', {
+            type: 'status',
+            status: 'init_received',
+            sessionId: cmd.sessionId
+          });
+          setTimeout(() => {
+            // 150 lines — the buffer must retain only the most recent 100.
+            for (let i = 1; i <= 150; i++) {
+              stderrEmitter.emit('data', Buffer.from(`line-${String(i).padStart(3, '0')}`));
+            }
+            fakeProcess.emit('exit', 1, null);
+          }, 0);
+        }, 0);
+      }
+    });
+
+    const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+    await expect(startPromise).rejects.toThrow(/Proxy exited during initialization/);
+    const err = await startPromise.catch((e: Error) => e);
+
+    // Buffer bounded at 100 (not 150), so the label reports 100 and the newest line survives.
+    expect(err.message).toContain('(last 10 of 100 lines)');
+    expect(err.message).toContain('line-150');
+    expect(err.message).toContain('line-141');
+    expect(err.message).not.toContain('line-140');
+  });
+
   it('fails to start when bootstrap worker script is missing', async () => {
     (fileSystem.pathExists as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(false);
 

--- a/tests/unit/utils/env-sanitizer.test.ts
+++ b/tests/unit/utils/env-sanitizer.test.ts
@@ -61,6 +61,28 @@ describe('sanitizeEnvForLogging', () => {
     expect(result.Api_Key).toBe('[REDACTED]');
     expect(result.apiKey).toBe('[REDACTED]');
   });
+
+  it('redacts token-delimited sensitive keys like GITHUB_PAT (issue #146)', () => {
+    const env = {
+      GITHUB_PAT: 'github_pat_abc123',
+      MY_PWD: 'x',
+      SSH_KEY: 'y',
+      AWS_ACCESS_KEY_ID: 'z',
+      githubPat: 'camel'
+    };
+    const result = sanitizeEnvForLogging(env);
+    expect(result.GITHUB_PAT).toBe('[REDACTED]');
+    expect(result.MY_PWD).toBe('[REDACTED]');
+    expect(result.SSH_KEY).toBe('[REDACTED]');
+    expect(result.AWS_ACCESS_KEY_ID).toBe('[REDACTED]');
+    expect(result.githubPat).toBe('[REDACTED]');
+  });
+
+  it('does not over-redact keys where a token is a mere substring', () => {
+    const env = { PATH: '/usr/bin', PATTERN: '*.ts', KEYBOARD: 'us', MONKEY: 'banana' };
+    const result = sanitizeEnvForLogging(env);
+    expect(result).toEqual(env);
+  });
 });
 
 describe('sanitizePayloadForLogging', () => {
@@ -78,18 +100,21 @@ describe('sanitizePayloadForLogging', () => {
     expect(result.language).toBe('python');
   });
 
-  it('sanitizes adapterCommand.env', () => {
+  it('replaces adapterCommand.env with a count summary — no values logged (issue #146)', () => {
     const payload = {
       sessionId: 'abc',
       adapterCommand: {
         command: 'python',
         args: ['-m', 'debugpy'],
-        env: { HOME: '/home/user', API_KEY: 'secret-value' }
+        env: { HOME: '/home/user', API_KEY: 'secret-value', GITHUB_PAT: 'github_pat_XYZ' }
       }
     };
     const result = sanitizePayloadForLogging(payload) as any;
-    expect(result.adapterCommand.env.HOME).toBe('/home/user');
-    expect(result.adapterCommand.env.API_KEY).toBe('[REDACTED]');
+    expect(result.adapterCommand.env).toBe('<3 env vars redacted>');
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('/home/user');
+    expect(serialized).not.toContain('secret-value');
+    expect(serialized).not.toContain('github_pat_XYZ');
   });
 
   it('handles adapterCommand without env', () => {
@@ -138,6 +163,30 @@ describe('sanitizeStderr', () => {
   it('passes through clean lines', () => {
     const lines = ['Loading module...', 'Server started on port 3000', ''];
     expect(sanitizeStderr(lines)).toEqual(lines);
+  });
+
+  it('redacts lines with extended key patterns like GITHUB_PAT= without touching PATH=', () => {
+    const result = sanitizeStderr(['GITHUB_PAT=github_pat_abc', 'PATH=/usr/bin']);
+    expect(result[0]).toBe('[REDACTED — line contained sensitive data]');
+    expect(result[1]).toBe('PATH=/usr/bin');
+  });
+
+  it('redacts lines containing bare secret-shaped values (issue #146)', () => {
+    const lines = [
+      "env dump: { FOO: 'ghp_0123456789abcdefghij0123456789' }",
+      'github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+      'aws AKIAIOSFODNN7EXAMPLE',
+      'Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.sig',
+      '-----BEGIN RSA PRIVATE KEY-----',
+      'plain informational line'
+    ];
+    const result = sanitizeStderr(lines);
+    expect(result[0]).toBe('[REDACTED — line contained sensitive data]');
+    expect(result[1]).toBe('[REDACTED — line contained sensitive data]');
+    expect(result[2]).toBe('[REDACTED — line contained sensitive data]');
+    expect(result[3]).toBe('[REDACTED — line contained sensitive data]');
+    expect(result[4]).toBe('[REDACTED — line contained sensitive data]');
+    expect(result[5]).toBe('plain informational line');
   });
 
   it('handles empty array', () => {


### PR DESCRIPTION
## Problem

When the proxy worker died during initialization (e.g. the python attach deadlock in #145, or attaching to a dead port), the `Failed to attach: Proxy exited during initialization` error embedded the proxy's entire stderr — which included the ProxyRunner debug log of the full adapter environment. The existing `env-sanitizer` redacted by keyword, so any secret under an unanticipated key name (e.g. `GITHUB_PAT`) leaked verbatim into the MCP tool response (#146).

## Fix (three layers)

1. **Never log env bodies** — `sanitizePayloadForLogging` now replaces `adapterCommand.env` with a count summary (`<N env vars redacted>`) instead of a per-key redacted copy. Logs never need env values, and keyword lists cannot anticipate every secret-bearing key name. This covers the "Raw message snapshot" / IPC-received logs and command-send logging in one place, plus a previously **unsanitized** raw-message log in ProxyRunner's message-processing failure path found during implementation.

2. **Harden the sanitizer (defense-in-depth)** —
   - `sanitizeEnvForLogging`: token-aware key matching (split on delimiters + camelCase boundaries) so `GITHUB_PAT`, `SSH_KEY`, `MY_PWD`, `githubPat` redact without touching `PATH`/`PATTERN`/`KEYBOARD`.
   - `sanitizeStderr`: extended key patterns (`pat=`, `pwd=`, `bearer:` ...) plus a value-shape pattern for secrets whose key name never appears on the line (`ghp_...`/`github_pat_...` GitHub tokens, `sk-...` API keys, `xox...` Slack tokens, `AKIA...` AWS key ids, JWTs, PEM private key headers).

3. **Cap stderr in the user-facing error** — the init-exit error now embeds at most the last 10 stderr lines (max 2000 chars, labelled `(last N of M lines)`), matching the existing cap on the init-retry path, and the stderr capture buffer is bounded to 100 lines so nothing downstream grows without limit.

`docs/logging-format-specification.md` updated to describe the new behavior.

## Tests

- Sanitizer: `GITHUB_PAT`/camelCase token redaction, `PATH`/`PATTERN` non-redaction, env-summary behavior with a no-value-survives assertion, extended stderr key patterns, bare secret-shaped value redaction.
- ProxyManager: init-exit error contains only the last 10 of 15 stderr lines with the truncation label and never the secret (exact repro of the issue's error path).
- ProxyRunner: sentinel env values never reach any logger call, on both the happy path and the processing-failure path.

## Verification

- Full unit suite (2394), lint, build all green.
- Live dogfood via dev proxy: `attach_to_process` against a dead port now returns an error showing `env: '<62 env vars redacted>'` with capped stderr, instead of the full 62-variable environment dump.

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)