### PR TITLE
fix(proxy): line-buffer proxy stderr before sanitization (fixes #151)

### DIFF
--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -28,6 +28,7 @@ import type {
 } from '../dap-core/types.js';
 import { ErrorMessages } from '../utils/error-messages.js';
 import { sanitizePayloadForLogging, sanitizeStderr } from '../utils/env-sanitizer.js';
+import { LineBuffer } from '../utils/line-buffer.js';
 import { ProxyConfig } from './proxy-config.js';
 import { IDebugAdapter, AdapterLaunchBarrier } from '@debugmcp/shared';
 
@@ -746,22 +747,22 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       );
     });
 
-    // Handle stderr
+    // Handle stderr. Chunks arrive at arbitrary byte boundaries, so they are
+    // line-buffered before sanitization — a secret assignment split across
+    // two chunks would otherwise leak its tail past the key/value redaction
+    // patterns (issue #151). Scoped to this process's handlers so a pending
+    // partial line survives until this stream's own 'end'/'close', and never
+    // bleeds into a later process's stderr.
+    const stderrLineBuffer = new LineBuffer();
     this.proxyProcess.stderr?.on('data', (data: Buffer | string) => {
-      const output = data.toString().trim();
-      // Sanitize before logging and storing — stderr may contain env vars
-      const sanitizedLines = sanitizeStderr([output]);
-      this.logger.error(`[ProxyManager STDERR] ${sanitizedLines[0]}`);
-      // Capture sanitized stderr for error reporting during initialization.
-      // Bounded so a chatty proxy cannot grow the buffer (and everything it
-      // gets copied into) without limit.
-      if (!this.isInitialized) {
-        if (this.stderrBuffer.length >= 100) {
-          this.stderrBuffer.shift();
-        }
-        this.stderrBuffer.push(sanitizedLines[0]);
-      }
+      this.recordStderrLines(stderrLineBuffer.append(data.toString()));
     });
+    // Flush the trailing partial line only once the stream itself is done.
+    // Flushing on process 'exit' would be wrong: the pipe can still deliver
+    // the rest of a split line afterwards, re-creating the straddle leak.
+    const flushStderr = () => this.recordStderrLines(stderrLineBuffer.flush());
+    this.proxyProcess.stderr?.on('end', flushStderr);
+    this.proxyProcess.stderr?.on('close', flushStderr);
 
     // Handle exit
     this.proxyProcess.on('exit', (code: number | null, signal: string | null) => {
@@ -790,6 +791,33 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       this.emit('error', err);
       this.cleanup();
     });
+  }
+
+  /**
+   * Log and capture complete stderr lines, sanitized. Lines can arrive after
+   * the process 'exit' event snapshotted the buffer (the pipe drains last),
+   * so late lines are also appended to the captured exit details.
+   */
+  private recordStderrLines(lines: string[]): void {
+    const sanitized = sanitizeStderr(lines.filter(line => line.trim().length > 0));
+    for (const line of sanitized) {
+      this.logger.error(`[ProxyManager STDERR] ${line}`);
+      // Capture sanitized stderr for error reporting during initialization.
+      // Bounded so a chatty proxy cannot grow the buffer (and everything it
+      // gets copied into) without limit.
+      if (!this.isInitialized) {
+        if (this.stderrBuffer.length >= 100) {
+          this.stderrBuffer.shift();
+        }
+        this.stderrBuffer.push(line);
+      }
+      if (this.lastExitDetails) {
+        if (this.lastExitDetails.capturedStderr.length >= 100) {
+          this.lastExitDetails.capturedStderr.shift();
+        }
+        this.lastExitDetails.capturedStderr.push(line);
+      }
+    }
   }
 
   private handleProxyMessage(rawMessage: unknown): void {

--- a/src/utils/line-buffer.ts
+++ b/src/utils/line-buffer.ts
@@ -1,0 +1,43 @@
+/**
+ * Incremental newline splitter for streamed output.
+ *
+ * Stream 'data' events are chunked at arbitrary byte boundaries, so
+ * content-based filters (e.g. stderr secret redaction) must only ever see
+ * whole lines — a pattern split across two chunks would slip past them
+ * (issue #151). Append chunks as they arrive: complete lines come back
+ * immediately, the trailing partial line is held until the next append or
+ * flush().
+ */
+export class LineBuffer {
+  private pending = '';
+
+  /**
+   * @param maxPendingLength Bound on the held partial line so a newline-free
+   * stream cannot grow memory without limit; once exceeded, the pending data
+   * is emitted as if it were a complete line.
+   */
+  constructor(private readonly maxPendingLength = 8192) {}
+
+  /** Add a chunk; returns the complete lines it produced (CR stripped). */
+  append(chunk: string): string[] {
+    this.pending += chunk;
+    const parts = this.pending.split('\n');
+    this.pending = parts.pop() ?? '';
+    const lines = parts.map(line => (line.endsWith('\r') ? line.slice(0, -1) : line));
+    if (this.pending.length > this.maxPendingLength) {
+      lines.push(this.pending);
+      this.pending = '';
+    }
+    return lines;
+  }
+
+  /** Emit any held partial line; call when the stream ends. */
+  flush(): string[] {
+    if (this.pending === '') {
+      return [];
+    }
+    const line = this.pending;
+    this.pending = '';
+    return [line];
+  }
+}

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -445,7 +445,7 @@ describe('ProxyManager.start', () => {
       fakeProcess.sendCommand.mockImplementation((cmd: any) => {
         if (cmd.cmd === 'init') {
           setTimeout(() => {
-            stderrEmitter.emit('data', Buffer.from('boot failure'));
+            stderrEmitter.emit('data', Buffer.from('boot failure\n'));
             fakeProcess.emit('exit', 2, 'SIGTERM');
           }, 0);
         }
@@ -476,9 +476,9 @@ describe('ProxyManager.start', () => {
           });
           setTimeout(() => {
             for (let i = 1; i <= 14; i++) {
-              stderrEmitter.emit('data', Buffer.from(`stderr-line-${String(i).padStart(2, '0')}`));
+              stderrEmitter.emit('data', Buffer.from(`stderr-line-${String(i).padStart(2, '0')}\n`));
             }
-            stderrEmitter.emit('data', Buffer.from('GITHUB_PAT=github_pat_supersecret1234567890'));
+            stderrEmitter.emit('data', Buffer.from('GITHUB_PAT=github_pat_supersecret1234567890\n'));
             fakeProcess.emit('exit', 1, null);
           }, 0);
         }, 0);
@@ -513,7 +513,7 @@ describe('ProxyManager.start', () => {
             // 12 lines of ~300 chars each; the last 10 joined exceed the 2000-char cap.
             for (let i = 1; i <= 12; i++) {
               const marker = `MARKER-${String(i).padStart(2, '0')}`;
-              stderrEmitter.emit('data', Buffer.from(marker + 'x'.repeat(300 - marker.length)));
+              stderrEmitter.emit('data', Buffer.from(marker + 'x'.repeat(300 - marker.length) + '\n'));
             }
             fakeProcess.emit('exit', 1, null);
           }, 0);
@@ -547,7 +547,7 @@ describe('ProxyManager.start', () => {
           setTimeout(() => {
             // 150 lines — the buffer must retain only the most recent 100.
             for (let i = 1; i <= 150; i++) {
-              stderrEmitter.emit('data', Buffer.from(`line-${String(i).padStart(3, '0')}`));
+              stderrEmitter.emit('data', Buffer.from(`line-${String(i).padStart(3, '0')}\n`));
             }
             fakeProcess.emit('exit', 1, null);
           }, 0);
@@ -564,6 +564,124 @@ describe('ProxyManager.start', () => {
     expect(err.message).toContain('line-150');
     expect(err.message).toContain('line-141');
     expect(err.message).not.toContain('line-140');
+  });
+
+  it('redacts a secret that straddles a stderr chunk boundary (issue #151)', async () => {
+    const stderrEmitter = fakeProcess.stderr as unknown as EventEmitter;
+    fakeProcess.sendCommand.mockImplementation((cmd: any) => {
+      if (cmd.cmd === 'init') {
+        setTimeout(() => {
+          fakeProcess.emit('message', {
+            type: 'status',
+            status: 'init_received',
+            sessionId: cmd.sessionId
+          });
+          setTimeout(() => {
+            // One secret assignment split mid-value across two stream chunks.
+            stderrEmitter.emit('data', Buffer.from('GITHUB_PAT=github_pat_supersecret'));
+            stderrEmitter.emit('data', Buffer.from('tail1234567890\n'));
+            fakeProcess.emit('exit', 1, null);
+          }, 0);
+        }, 0);
+      }
+    });
+
+    const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+    await expect(startPromise).rejects.toThrow(/Proxy exited during initialization/);
+    const err = await startPromise.catch((e: Error) => e);
+
+    // Neither half of the split secret may surface anywhere.
+    expect(err.message).not.toContain('supersecret');
+    expect(err.message).not.toContain('tail1234567890');
+    expect(err.message).toContain('[REDACTED — line contained sensitive data]');
+    for (const call of (logger.error as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(String(call[0])).not.toContain('tail1234567890');
+    }
+  });
+
+  it('sanitizes multi-line stderr chunks per line, not per chunk (issue #151)', async () => {
+    const stderrEmitter = fakeProcess.stderr as unknown as EventEmitter;
+    fakeProcess.sendCommand.mockImplementation((cmd: any) => {
+      if (cmd.cmd === 'init') {
+        setTimeout(() => {
+          fakeProcess.emit('message', {
+            type: 'status',
+            status: 'init_received',
+            sessionId: cmd.sessionId
+          });
+          setTimeout(() => {
+            // A benign line and a secret-bearing line arriving in the same chunk:
+            // only the secret-bearing line should be redacted.
+            stderrEmitter.emit('data', Buffer.from(
+              'benign-diagnostic-line\nGITHUB_PAT=github_pat_secret1234567890\n'
+            ));
+            fakeProcess.emit('exit', 1, null);
+          }, 0);
+        }, 0);
+      }
+    });
+
+    const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+    await expect(startPromise).rejects.toThrow(/Proxy exited during initialization/);
+    const err = await startPromise.catch((e: Error) => e);
+
+    expect(err.message).toContain('benign-diagnostic-line');
+    expect(err.message).not.toContain('github_pat_secret');
+    expect(err.message).toContain('[REDACTED — line contained sensitive data]');
+  });
+
+  it('flushes a trailing partial stderr line when the stream ends (issue #151)', async () => {
+    const stderrEmitter = fakeProcess.stderr as unknown as EventEmitter;
+    fakeProcess.sendCommand.mockImplementation((cmd: any) => {
+      if (cmd.cmd === 'init') {
+        setTimeout(() => {
+          fakeProcess.emit('message', {
+            type: 'status',
+            status: 'init_received',
+            sessionId: cmd.sessionId
+          });
+          setTimeout(() => {
+            // A crashing process's final write often lacks a trailing newline.
+            stderrEmitter.emit('data', Buffer.from('fatal: adapter exploded'));
+            stderrEmitter.emit('end');
+            fakeProcess.emit('exit', 1, null);
+          }, 0);
+        }, 0);
+      }
+    });
+
+    const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+    await expect(startPromise).rejects.toThrow(/Proxy exited during initialization/);
+    const err = await startPromise.catch((e: Error) => e);
+
+    expect(err.message).toContain('fatal: adapter exploded');
+  });
+
+  it('includes a partial stderr line flushed after exit in captured exit details (issue #151)', async () => {
+    vi.useFakeTimers();
+    try {
+      const stderrEmitter = fakeProcess.stderr as unknown as EventEmitter;
+      fakeProcess.sendCommand.mockImplementation((cmd: any) => {
+        if (cmd.cmd === 'init') {
+          setTimeout(() => {
+            // The pipe can drain after the process 'exit' event: the trailing
+            // partial line arrives via stream 'end' only after exit fired.
+            stderrEmitter.emit('data', Buffer.from('late boot failure'));
+            fakeProcess.emit('exit', 2, 'SIGTERM');
+            stderrEmitter.emit('end');
+          }, 0);
+        }
+      });
+
+      const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+      // Drive the real-time init-retry backoff (~15.5s) via fake timers.
+      await vi.advanceTimersByTimeAsync(35000);
+      await expect(startPromise).rejects.toThrow(
+        /Proxy exit details -> code=2 signal=SIGTERM stderr:\nlate boot failure/
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('fails to start when bootstrap worker script is missing', async () => {

--- a/tests/unit/utils/line-buffer.test.ts
+++ b/tests/unit/utils/line-buffer.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { LineBuffer } from '../../../src/utils/line-buffer.js';
+
+describe('LineBuffer', () => {
+  it('returns complete lines and holds the trailing partial', () => {
+    const buf = new LineBuffer();
+    expect(buf.append('one\ntwo\npart')).toEqual(['one', 'two']);
+    expect(buf.append('ial\n')).toEqual(['partial']);
+  });
+
+  it('joins content split across appends (issue #151 straddle case)', () => {
+    const buf = new LineBuffer();
+    expect(buf.append('GITHUB_PAT=ghp_abc')).toEqual([]);
+    expect(buf.append('def123\n')).toEqual(['GITHUB_PAT=ghp_abcdef123']);
+  });
+
+  it('strips trailing carriage returns from CRLF input', () => {
+    const buf = new LineBuffer();
+    expect(buf.append('one\r\ntwo\r\n')).toEqual(['one', 'two']);
+  });
+
+  it('returns multiple lines from a single append', () => {
+    const buf = new LineBuffer();
+    expect(buf.append('a\nb\nc\n')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('flush returns the pending partial line and clears it', () => {
+    const buf = new LineBuffer();
+    buf.append('no newline yet');
+    expect(buf.flush()).toEqual(['no newline yet']);
+    expect(buf.flush()).toEqual([]);
+  });
+
+  it('flush on an empty buffer returns nothing', () => {
+    expect(new LineBuffer().flush()).toEqual([]);
+  });
+
+  it('force-emits an oversized pending line to bound memory', () => {
+    const buf = new LineBuffer(16);
+    expect(buf.append('x'.repeat(20))).toEqual(['x'.repeat(20)]);
+    expect(buf.flush()).toEqual([]);
+  });
+
+  it('does not force-emit when a newline drains the pending data', () => {
+    const buf = new LineBuffer(16);
+    expect(buf.append('short line\nnext')).toEqual(['short line']);
+    expect(buf.flush()).toEqual(['next']);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #151. `ProxyManager`'s stderr handler sanitized each raw stream `data` chunk as if it were a single line. Stream chunks split at arbitrary byte boundaries, so a secret assignment straddling a boundary leaked its tail: the first chunk (`GITHUB_PAT=github_pat_abc…`) matched the key-based redaction pattern, but the remainder arrived as a bare alphanumeric fragment with nothing left to match, and passed through into logs and init-failure tool errors.

## Fix

- New `LineBuffer` utility (`src/utils/line-buffer.ts`): accumulates chunks, releases only complete lines (CR-stripped), holds the trailing partial line, bounds pending growth at 8 KB.
- `ProxyManager` routes stderr through it, so `sanitizeStderr` only ever sees whole lines and the straddle case disappears.
- The pending partial line is flushed on the stream's own `end`/`close` — **not** on process `exit`, because the pipe can still deliver the rest of a split line after exit, which would re-create the leak.
- Lines that surface after the exit snapshot was taken are appended to `lastExitDetails.capturedStderr` (bounded at 100), so init-failure errors still include the final unterminated line a crashing process typically writes.

Side benefit: multi-line chunks are now sanitized per line — one secret-bearing line no longer redacts benign lines that shared its chunk, and each line lands as its own log entry.

## Verification

- New unit tests: straddled secret is fully redacted end-to-end through the init-failure error path; per-line (not per-chunk) sanitization; trailing-partial flush on stream end; post-exit flush lands in captured exit details; `LineBuffer` behavior incl. CRLF and the pending-size bound.
- Full unit suite (2423 tests) and integration suite pass; lint clean.
- Verified live via the dev proxy: rebuilt server, drove a real Python debug session. Pre-change logs show multi-line stderr chunks logged as single entries with embedded `\n` (7 occurrences); post-change logs show 0 — every proxy stderr line is split and sanitized individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)