### PR TITLE
fix(proxy): send DAP disconnect before destroying socket; win32 launch-mode tree-kill (fixes #156)

### DIFF
--- a/src/proxy/dap-proxy-adapter-manager.ts
+++ b/src/proxy/dap-proxy-adapter-manager.ts
@@ -187,52 +187,67 @@ export class GenericAdapterManager {
   }
 
   /**
-   * Gracefully shutdown an adapter process
+   * Gracefully shutdown an adapter process.
+   *
+   * killProcessTree (launch mode only): on Windows the debuggee may be a
+   * grandchild of the adapter (e.g. rdbg -c spawns the target as a child),
+   * and a bare kill of the adapter is TerminateProcess — near-instant —
+   * which orphans the grandchild. taskkill /T can only discover children
+   * while the parent is alive, so the tree-kill must be the FIRST strike,
+   * not a fallback (issue #156). Callers must never set it for attach mode.
    */
-  async shutdown(process: ChildProcess | null): Promise<void> {
+  async shutdown(process: ChildProcess | null, options: { killProcessTree?: boolean } = {}): Promise<void> {
     if (!process || !process.pid) {
       this.logger.info('[AdapterManager] No active adapter process to terminate.');
       return;
     }
 
+    // An adapter that honored the DAP disconnect exits on its own during the
+    // worker's grace wait — by now its PID may already belong to an unrelated
+    // process, so signalling it (let alone taskkill /T /F) is a PID-reuse hazard.
+    if (process.exitCode !== null || process.signalCode !== null) {
+      this.logger.info(`[AdapterManager] Adapter process PID: ${process.pid} already exited (code=${process.exitCode}, signal=${process.signalCode}). Nothing to terminate.`);
+      return;
+    }
+
     this.logger.info(`[AdapterManager] Attempting to terminate adapter process PID: ${process.pid}`);
+
+    const treeKillFirst = options.killProcessTree === true && globalThis.process.platform === 'win32';
 
     try {
       if (!process.killed) {
-        this.logger.info(`[AdapterManager] Sending SIGTERM to adapter process PID: ${process.pid}`);
-
         // Track actual termination via exit event (process.killed only indicates signal was sent)
         let exited = false;
         const onExit = () => { exited = true; };
         process.once('exit', onExit);
 
-        process.kill('SIGTERM');
+        if (treeKillFirst) {
+          this.logger.info(`[AdapterManager] Killing adapter process tree via taskkill /T /F for PID: ${process.pid}`);
+          try {
+            this.processSpawner.spawn('taskkill', ['/PID', String(process.pid), '/T', '/F'], {
+              stdio: 'ignore',
+              windowsHide: true
+            });
+          } catch (tkErr) {
+            this.logger.error('[AdapterManager] taskkill tree-kill failed to spawn:', tkErr as Error);
+          }
+        } else {
+          this.logger.info(`[AdapterManager] Sending SIGTERM to adapter process PID: ${process.pid}`);
+          process.kill('SIGTERM');
+        }
 
         // Wait a short period for graceful exit
         await new Promise(resolve => setTimeout(resolve, 300));
 
         if (!exited) {
-          this.logger.warn(`[AdapterManager] Adapter process PID: ${process.pid} did not exit after SIGTERM. Sending SIGKILL.`);
+          this.logger.warn(`[AdapterManager] Adapter process PID: ${process.pid} did not exit after ${treeKillFirst ? 'taskkill' : 'SIGTERM'}. Sending SIGKILL.`);
           try {
             process.kill('SIGKILL');
           } catch {
             // ignore SIGKILL errors
           }
-
-          // Windows-specific fallback: force kill entire process tree
-          if (globalThis.process.platform === 'win32' && process.pid) {
-            try {
-              this.logger.warn(`[AdapterManager] Forcing termination via taskkill /T /F for PID: ${process.pid}`);
-              this.processSpawner.spawn('taskkill', ['/PID', String(process.pid), '/T', '/F'], {
-                stdio: 'ignore',
-                windowsHide: true
-              });
-            } catch (tkErr) {
-              this.logger.error('[AdapterManager] taskkill fallback failed:', tkErr as Error);
-            }
-          }
         } else {
-          this.logger.info(`[AdapterManager] Adapter process PID: ${process.pid} exited after SIGTERM.`);
+          this.logger.info(`[AdapterManager] Adapter process PID: ${process.pid} exited after ${treeKillFirst ? 'taskkill' : 'SIGTERM'}.`);
         }
       } else {
         this.logger.info(`[AdapterManager] Adapter process PID: ${process.pid} was already marked as killed.`);

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -983,18 +983,23 @@ export class DapProxyWorker {
     // Clear request tracking
     this.requestTracker.clear();
 
-    // Reject any in-flight DAP requests and clear timers immediately
-    if (this.dapClient) {
-      this.dapClient.shutdown('worker shutdown');
-    }
-
-    // Disconnect DAP client — for attach mode via handleTerminate(), dapClient is
-    // already null (handled by auto-detach above). But if shutdown() is reached through
-    // other paths (signals, crashes, parent death), dapClient may still be live.
-    // In attach mode, always use terminateDebuggee=false to preserve the debuggee.
+    // Graceful DAP disconnect FIRST, while the socket is still alive (#156) —
+    // launch-mode adapters only terminate their debuggee when they receive
+    // disconnect with terminateDebuggee=true (rdbg keeps it alive and re-arms
+    // on a bare socket drop). For attach mode via handleTerminate(), dapClient
+    // is already null (handled by auto-detach above); on other paths (signals,
+    // crashes, parent death) attach mode uses terminateDebuggee=false to
+    // preserve the debuggee. disconnect() caps the request at 1s and a dead
+    // socket rejects synchronously, so this cannot stall shutdown.
     if (this.connectionManager && this.dapClient) {
       const terminateDebuggee = !this.isAttachMode;
       await this.connectionManager.disconnect(this.dapClient, terminateDebuggee);
+    }
+
+    // THEN reject any in-flight DAP requests and destroy the socket (no-op if
+    // connectionManager.disconnect() above already tore the client down).
+    if (this.dapClient) {
+      this.dapClient.shutdown('worker shutdown');
     }
     this.dapClient = null;
 
@@ -1010,9 +1015,13 @@ export class DapProxyWorker {
       await new Promise(resolve => setTimeout(resolve, 500));
     }
 
-    // Terminate adapter process
+    // Terminate adapter process. Launch mode owns the debuggee, which may be
+    // a grandchild of the adapter (e.g. rdbg -c), so request a process-tree
+    // kill; attach mode must never tree-kill (the guard is explicit so a
+    // future attach flow that proxies through a spawned process cannot take
+    // a pre-existing debuggee down with it — see #156).
     if (this.processManager && this.adapterProcess) {
-      await this.processManager.shutdown(this.adapterProcess);
+      await this.processManager.shutdown(this.adapterProcess, { killProcessTree: !this.isAttachMode });
     }
     this.adapterProcess = null;
 

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -974,7 +974,58 @@ describe('DapProxyWorker', () => {
       // Launch mode: shutdown calls disconnect with terminateDebuggee=true
       expect(connectionStub.disconnect).toHaveBeenCalledWith(mockDapClient, true);
       expect(mockDapClient.shutdown).toHaveBeenCalledWith('worker shutdown');
+      // The disconnect must be sent while the socket is still alive — i.e.
+      // BEFORE dapClient.shutdown() destroys it — or the adapter never
+      // receives terminateDebuggee and orphans its debuggee (issue #156).
+      expect(connectionStub.disconnect.mock.invocationCallOrder[0]).toBeLessThan(
+        (mockDapClient.shutdown as Mock).mock.invocationCallOrder[0]
+      );
       expect(worker.getState()).toBe(ProxyState.TERMINATED);
+    });
+
+    it('shutdown requests an adapter process tree-kill in launch mode', async () => {
+      vi.useFakeTimers();
+      try {
+        const processStub = { shutdown: vi.fn().mockResolvedValue(undefined) };
+        const connectionStub = { disconnect: vi.fn().mockResolvedValue(undefined) };
+        const adapterProc = { pid: 4242 };
+        (worker as any).dapClient = mockDapClient;
+        (worker as any).processManager = processStub;
+        (worker as any).connectionManager = connectionStub;
+        (worker as any).adapterProcess = adapterProc;
+        (worker as any).state = ProxyState.CONNECTED;
+
+        const terminatePromise = worker.handleTerminate();
+        await vi.advanceTimersByTimeAsync(500);
+        await terminatePromise;
+
+        expect(processStub.shutdown).toHaveBeenCalledWith(adapterProc, { killProcessTree: true });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('shutdown must not request a tree-kill in attach mode', async () => {
+      vi.useFakeTimers();
+      try {
+        const processStub = { shutdown: vi.fn().mockResolvedValue(undefined) };
+        const connectionStub = { disconnect: vi.fn().mockResolvedValue(undefined) };
+        const adapterProc = { pid: 4242 };
+        (worker as any).dapClient = mockDapClient;
+        (worker as any).processManager = processStub;
+        (worker as any).connectionManager = connectionStub;
+        (worker as any).adapterProcess = adapterProc;
+        (worker as any).state = ProxyState.CONNECTED;
+        (worker as any).isAttachMode = true;
+
+        const terminatePromise = worker.handleTerminate();
+        await vi.advanceTimersByTimeAsync(500);
+        await terminatePromise;
+
+        expect(processStub.shutdown).toHaveBeenCalledWith(adapterProc, { killProcessTree: false });
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('handleTerminate should auto-detach in attach mode', async () => {

--- a/tests/unit/proxy/dap-proxy-adapter-manager.test.ts
+++ b/tests/unit/proxy/dap-proxy-adapter-manager.test.ts
@@ -26,6 +26,8 @@ function createMockProcess(pid = 12345) {
   const proc = new EventEmitter() as any;
   proc.pid = pid;
   proc.killed = false;
+  proc.exitCode = null;
+  proc.signalCode = null;
   proc.kill = vi.fn();
   proc.unref = vi.fn();
   proc.stdout = new EventEmitter();
@@ -302,6 +304,111 @@ describe('GenericAdapterManager', () => {
         expect.stringContaining('Error during adapter process termination'),
         expect.anything()
       );
+    });
+  });
+
+  describe('shutdown with killProcessTree (launch mode)', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+
+    const setPlatform = (value: string) => {
+      Object.defineProperty(process, 'platform', { value, configurable: true });
+    };
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', originalPlatform);
+      vi.useRealTimers();
+    });
+
+    it('tree-kills via taskkill while the parent is still alive on win32', async () => {
+      setPlatform('win32');
+      vi.useFakeTimers();
+
+      const proc = createMockProcess(999);
+      // taskkill takes the tree down: simulate the adapter exiting right after
+      (spawner.spawn as any).mockImplementation(() => {
+        process.nextTick(() => proc.emit('exit', 1, null));
+        return createMockProcess(555);
+      });
+
+      const shutdownPromise = manager.shutdown(proc, { killProcessTree: true });
+      await vi.advanceTimersByTimeAsync(300);
+      await shutdownPromise;
+
+      expect(spawner.spawn).toHaveBeenCalledWith(
+        'taskkill',
+        ['/PID', '999', '/T', '/F'],
+        expect.objectContaining({ windowsHide: true })
+      );
+      // A bare parent kill is TerminateProcess (near-instant) and taskkill /T
+      // cannot discover children of a dead parent — the debuggee grandchild
+      // would be orphaned (issue #156). The tree-kill must be the first strike.
+      expect(proc.kill).not.toHaveBeenCalledWith('SIGTERM');
+      expect(proc.kill).not.toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('does not kill anything when the adapter already exited (PID may be recycled)', async () => {
+      setPlatform('win32');
+
+      const proc = createMockProcess(999);
+      // Adapter honored the DAP disconnect and exited during the grace wait —
+      // its PID may already belong to an unrelated process.
+      proc.exitCode = 1;
+
+      await manager.shutdown(proc, { killProcessTree: true });
+
+      expect(spawner.spawn).not.toHaveBeenCalled();
+      expect(proc.kill).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('already exited')
+      );
+    });
+
+    it('escalates to SIGKILL when taskkill does not terminate the adapter', async () => {
+      setPlatform('win32');
+      vi.useFakeTimers();
+
+      const proc = createMockProcess(999);
+      // spawner.spawn succeeds but the adapter never exits
+
+      const shutdownPromise = manager.shutdown(proc, { killProcessTree: true });
+      await vi.advanceTimersByTimeAsync(300);
+      await shutdownPromise;
+
+      expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('keeps the SIGTERM-first path on win32 without killProcessTree', async () => {
+      setPlatform('win32');
+      vi.useFakeTimers();
+
+      const proc = createMockProcess(999);
+      proc.kill.mockImplementation(() => {
+        process.nextTick(() => proc.emit('exit', 0, null));
+      });
+
+      const shutdownPromise = manager.shutdown(proc);
+      await vi.advanceTimersByTimeAsync(300);
+      await shutdownPromise;
+
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(spawner.spawn).not.toHaveBeenCalled();
+    });
+
+    it('keeps the SIGTERM-first path on non-win32 even with killProcessTree', async () => {
+      setPlatform('linux');
+      vi.useFakeTimers();
+
+      const proc = createMockProcess(999);
+      proc.kill.mockImplementation(() => {
+        process.nextTick(() => proc.emit('exit', 0, null));
+      });
+
+      const shutdownPromise = manager.shutdown(proc, { killProcessTree: true });
+      await vi.advanceTimersByTimeAsync(300);
+      await shutdownPromise;
+
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(spawner.spawn).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Fixes #156.

## Root causes

**A — worker shutdown destroyed the socket before the graceful disconnect.** `DapProxyWorker.shutdown()` called `dapClient.shutdown()` (which sets `isDisconnectingOrDisconnected` and destroys the TCP socket) *before* `connectionManager.disconnect(dapClient, terminateDebuggee)`. The disconnect request could never be sent — every launch-mode session logged `Socket not connected or destroyed` — so no launch-mode adapter was ever asked to terminate its debuggee. rdbg deliberately keeps the debuggee alive on a bare socket drop and re-arms, orphaning the grandchild `ruby.exe` on every paused-at-close launch session.

**B — the win32 tree-kill was unreachable.** `GenericAdapterManager.shutdown()` only reached its `taskkill /PID … /T /F` fallback if the adapter survived SIGTERM by 300 ms. On Windows SIGTERM is a near-instant TerminateProcess, so the fallback never ran — and once the parent is dead, `/T` can't discover the grandchild anyway.

## Changes

- **Reorder `DapProxyWorker.shutdown()`**: graceful DAP disconnect first (while the socket is alive), socket teardown second. `disconnect()` caps the request at 1 s and a dead socket rejects synchronously, so shutdown can't stall (parent budget is 5 s).
- **`GenericAdapterManager.shutdown()` gains `killProcessTree`**: on win32 the tree-kill is now the *first* strike (while the parent is alive), with SIGKILL as the escalation. The worker sets `killProcessTree: !isAttachMode` — the explicit launch-mode scoping requested in the issue discussion; attach mode keeps the SIGTERM path and never tree-kills.
- **Already-exited guard**: with the disconnect actually working, adapters now normally self-exit during the grace wait — signalling (let alone `taskkill /T /F`-ing) their possibly-recycled PID would be a PID-reuse hazard, so the kill sequence is skipped when `exitCode`/`signalCode` show the process already exited.

## Verification

- New unit tests: disconnect-before-socket-teardown ordering; tree-kill first strike on win32 launch mode; no tree-kill for attach mode / non-win32; no kills when already exited.
- Live repro on Windows (the issue's deterministic repro): paused Ruby session at a breakpoint → `close_debug_session` → DAP trace shows `disconnect {terminateDebuggee: true}` sent and acknowledged, rdbg terminates the debuggee and self-exits, **zero `ruby.exe` remaining**, and the log shows the clean `already exited … Nothing to terminate` path (no taskkill/SIGKILL issued).
- Full unit suite (2466), lint, ruby launch + attach e2e smoke (attach still leaves the target running), python e2e smoke — all green.

## Out of scope (noted in #156)

- `jvm-orphan-reaper` stays: it covers crashed/SIGKILLed prior runs, a different failure mode.
- `scripts/cleanup-test-processes.js` win32 no-op left as-is: pattern-killing `ruby.exe` on a dev box is riskier than the benefit.
- POSIX group-kill defense-in-depth: unnecessary — the reordered disconnect restores graceful termination on all platforms, and POSIX SIGTERM reaches rdbg's signal handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)