### PR TITLE
fix(dev-proxy): line-buffer and sanitize backend output before logging (fixes #154)

### DIFF
--- a/tests/unit/dev-proxy/backend-logger.test.ts
+++ b/tests/unit/dev-proxy/backend-logger.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the dev-proxy backend output logger (issue #154).
+ *
+ * The helper lives in tools/dev-proxy/backend-logger.mjs (separate from
+ * dev-proxy.mjs, which runs main() at module top level and therefore cannot
+ * be imported safely).
+ *
+ * These tests verify that backend stdout/stderr chunks are line-buffered
+ * before sanitization — a secret assignment split across two chunks must be
+ * reassembled and redacted as a single line (the defect class fixed for the
+ * server in #151), not emitted as two partial lines that slip past the
+ * redaction patterns.
+ */
+import { describe, it, expect } from 'vitest';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- plain-JS module without type declarations
+import { createBackendLogger, sanitizeStderrTail } from '../../../tools/dev-proxy/backend-logger.mjs';
+
+const REDACTED = '[REDACTED — line contained sensitive data]';
+
+function makeLogger(prefix?: string) {
+  const writes: string[] = [];
+  const write = (s: string) => writes.push(s);
+  const logger = prefix === undefined ? createBackendLogger(write) : createBackendLogger(write, prefix);
+  return { writes, logger };
+}
+
+describe('dev-proxy createBackendLogger', () => {
+  it('emits complete lines with the [backend] prefix', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData('hello\nworld\n');
+    expect(writes).toEqual(['[backend] hello\n', '[backend] world\n']);
+  });
+
+  it('reassembles a line straddling two chunks into a single line', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData('Server star');
+    logger.onData('ted on port 3001\n');
+    expect(writes).toEqual(['[backend] Server started on port 3001\n']);
+  });
+
+  it('redacts a secret assignment split across two chunks as one line', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData('GITHUB_P');
+    logger.onData(`AT=ghp_${'a'.repeat(30)}\n`);
+    expect(writes).toEqual([`[backend] ${REDACTED}\n`]);
+  });
+
+  it('redacts a complete secret line but passes benign lines through', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData(`GITHUB_PAT=ghp_${'a'.repeat(30)}\nPATH=/usr/bin\n`);
+    expect(writes).toEqual([`[backend] ${REDACTED}\n`, '[backend] PATH=/usr/bin\n']);
+  });
+
+  it('drops blank and whitespace-only lines', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData('\n\n  \nfoo\n');
+    expect(writes).toEqual(['[backend] foo\n']);
+  });
+
+  it('strips trailing CR from CRLF line endings', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData('windows line\r\n');
+    expect(writes).toEqual(['[backend] windows line\n']);
+  });
+
+  it('accepts Buffer chunks (stream data events)', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData(Buffer.from('from a buffer\n'));
+    expect(writes).toEqual(['[backend] from a buffer\n']);
+  });
+
+  it('flush() emits a held partial line once, then nothing', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData('trailing partial');
+    expect(writes).toEqual([]);
+    logger.flush();
+    expect(writes).toEqual(['[backend] trailing partial\n']);
+    logger.flush();
+    expect(writes).toEqual(['[backend] trailing partial\n']);
+  });
+
+  it('sanitizes a partial secret line emitted via flush()', () => {
+    const { writes, logger } = makeLogger();
+    logger.onData(`API_KEY=sk-${'b'.repeat(30)}`);
+    logger.flush();
+    expect(writes).toEqual([`[backend] ${REDACTED}\n`]);
+  });
+
+  it('keeps buffer state independent across logger instances', () => {
+    const a = makeLogger();
+    const b = makeLogger();
+    a.logger.onData('stdout par');
+    b.logger.onData('stderr line\n');
+    expect(a.writes).toEqual([]);
+    expect(b.writes).toEqual(['[backend] stderr line\n']);
+    a.logger.onData('tial\n');
+    expect(a.writes).toEqual(['[backend] stdout partial\n']);
+  });
+
+  it('supports a custom prefix', () => {
+    const { writes, logger } = makeLogger('[build]');
+    logger.onData('done\n');
+    expect(writes).toEqual(['[build] done\n']);
+  });
+});
+
+describe('dev-proxy sanitizeStderrTail re-export', () => {
+  it('redacts secret-looking lines and keeps benign ones', () => {
+    const out = sanitizeStderrTail(`compiling...\nGITHUB_PAT=ghp_${'c'.repeat(30)}\ndone\n`);
+    expect(out).toContain('compiling...');
+    expect(out).toContain(REDACTED);
+    expect(out).toContain('done');
+    expect(out).not.toContain('ghp_');
+  });
+
+  it('caps output to the last maxLines lines', () => {
+    const text = Array.from({ length: 30 }, (_, i) => `line ${i}`).join('\n');
+    const out = sanitizeStderrTail(text, { maxLines: 5, maxChars: 2000 });
+    expect(out).toContain('line 29');
+    expect(out).not.toContain('line 0\n');
+    expect(out).toContain('(last 5 of 30 lines)');
+  });
+});

--- a/tools/dev-proxy/backend-logger.mjs
+++ b/tools/dev-proxy/backend-logger.mjs
@@ -1,0 +1,94 @@
+/**
+ * Backend output logging for dev-proxy — line-buffer and sanitize before forwarding.
+ *
+ * Why this exists (issue #154): stream 'data' events are chunked at arbitrary
+ * byte boundaries, so splitting each chunk on '\n' emits a line that straddles
+ * two chunks as two partial lines — and a secret assignment split that way
+ * slips past redaction patterns (the defect class fixed for the server in
+ * #151). Backend stdout/stderr must be reassembled into whole lines and run
+ * through the shared stderr sanitizer before being written to the proxy's
+ * stderr or embedded in a tool response.
+ *
+ * The sanitization utilities live in @debugmcp/shared, which the plain-.mjs
+ * proxy resolves through the workspace link to packages/shared/dist. That
+ * dist only exists after a build — and the proxy must keep its dev tools
+ * available on an unbuilt tree so dev_rebuild_and_restart can fix it. Hence
+ * the dynamic import with minimal fallbacks instead of a static import that
+ * would crash the proxy at startup.
+ *
+ * Kept in its own module so unit tests can import it without executing the
+ * dev-proxy entry point (dev-proxy.mjs runs main() at module top level).
+ */
+
+let LineBuffer;
+let sanitizeStderr;
+let sanitizeStderrTail;
+
+/** False when @debugmcp/shared dist was unavailable and fallbacks are active. */
+export let sharedUtilsLoaded = true;
+
+try {
+  ({ LineBuffer, sanitizeStderr, sanitizeStderrTail } = await import('@debugmcp/shared'));
+} catch {
+  // Shared dist not built yet — degrade to line buffering without redaction
+  // so the proxy can still bootstrap. dev-proxy.mjs logs a warning when it
+  // sees sharedUtilsLoaded === false.
+  sharedUtilsLoaded = false;
+
+  LineBuffer = class {
+    pending = '';
+
+    /** @param {string} chunk @returns {string[]} complete lines (CR stripped) */
+    append(chunk) {
+      this.pending += chunk;
+      const parts = this.pending.split('\n');
+      this.pending = parts.pop() ?? '';
+      const lines = parts.map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line));
+      if (this.pending.length > 8192) {
+        lines.push(this.pending);
+        this.pending = '';
+      }
+      return lines;
+    }
+
+    /** @returns {string[]} the held partial line, if any */
+    flush() {
+      if (this.pending === '') return [];
+      const line = this.pending;
+      this.pending = '';
+      return [line];
+    }
+  };
+
+  sanitizeStderr = (lines) => lines;
+
+  sanitizeStderrTail = (text, { maxChars = 2000 } = {}) =>
+    text.length > maxChars ? '…' + text.slice(-maxChars) : text;
+}
+
+export { sanitizeStderrTail };
+
+/**
+ * Create a logger for one backend output stream. Each logger owns its own
+ * line buffer — never share one across stdout and stderr, or partial lines
+ * from the two streams would interleave.
+ *
+ * @param {(text: string) => void} write Sink for prefixed, sanitized lines.
+ * @param {string} [prefix]
+ * @returns {{ onData: (data: Buffer | string) => void, flush: () => void }}
+ *   Attach onData to the stream's 'data' event; call flush on the stream's
+ *   own 'end'/'close' (not process exit — the pipe can still deliver the rest
+ *   of a split line after exit). flush is idempotent.
+ */
+export function createBackendLogger(write, prefix = '[backend]') {
+  const buffer = new LineBuffer();
+  const emit = (lines) => {
+    for (const line of sanitizeStderr(lines.filter((l) => l.trim().length > 0))) {
+      write(`${prefix} ${line}\n`);
+    }
+  };
+  return {
+    onData: (data) => emit(buffer.append(data.toString())),
+    flush: () => emit(buffer.flush()),
+  };
+}

--- a/tools/dev-proxy/dev-proxy.mjs
+++ b/tools/dev-proxy/dev-proxy.mjs
@@ -30,6 +30,7 @@ import { spawn, execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { installShutdownHandlers, killChildGracefully } from './shutdown.mjs';
+import { createBackendLogger, sanitizeStderrTail, sharedUtilsLoaded } from './backend-logger.mjs';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -55,13 +56,15 @@ function log(msg) {
   process.stderr.write(`[dev-proxy] ${msg}\n`);
 }
 
-function logBackend(data) {
-  const lines = data.toString().split('\n');
-  for (const line of lines) {
-    if (line.trim()) {
-      process.stderr.write(`[backend] ${line}\n`);
-    }
-  }
+// Backend output is line-buffered and sanitized per stream (issue #154);
+// see backend-logger.mjs. One logger per stream, flushed on the stream's
+// own 'end'/'close'.
+function attachBackendLogger(stream) {
+  if (!stream) return;
+  const logger = createBackendLogger((text) => process.stderr.write(text));
+  stream.on('data', logger.onData);
+  stream.on('end', logger.flush);
+  stream.on('close', logger.flush);
 }
 
 // ---------------------------------------------------------------------------
@@ -176,8 +179,8 @@ class BackendManager {
         env: { ...process.env, MCP_EXIT_ON_STDIN_CLOSE: '1' },
       });
 
-      this.child.stdout.on('data', logBackend);
-      this.child.stderr.on('data', logBackend);
+      attachBackendLogger(this.child.stdout);
+      attachBackendLogger(this.child.stderr);
 
       this.child.on('exit', (code, signal) => {
         log(`Backend exited (code=${code}, signal=${signal})`);
@@ -246,15 +249,24 @@ class BackendManager {
 
   rebuild() {
     log(`Running build: ${BUILD_CMD}`);
-    const result = execSync(BUILD_CMD, {
-      cwd: PROJECT_ROOT,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 120000,
-      env: { ...process.env },
-    });
+    let result;
+    try {
+      result = execSync(BUILD_CMD, {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 120000,
+        env: { ...process.env },
+      });
+    } catch (err) {
+      // execSync's error message embeds raw build stderr — sanitize before it
+      // reaches tool responses via err.message (issue #154). Include stdout
+      // too: build tools (tsc via npm) print their diagnostics there.
+      const output = [err.stdout, err.stderr].filter(Boolean).join('\n') || err.message || String(err);
+      throw new Error(`Build failed: ${sanitizeStderrTail(output, { maxLines: 20, maxChars: 2000 })}`);
+    }
     log('Build succeeded');
-    return result;
+    return sanitizeStderrTail(result, { maxLines: 50, maxChars: 2000 });
   }
 
   async rebuildAndRestart() {
@@ -338,9 +350,7 @@ class BackendManager {
       this.stdioTransport = transport;
 
       // Log backend stderr output
-      if (transport.stderr) {
-        transport.stderr.on('data', logBackend);
-      }
+      attachBackendLogger(transport.stderr);
 
       transport.onerror = (err) => {
         log(`Stdio transport error: ${err.message}`);
@@ -593,7 +603,7 @@ async function handleDevTool(backend, server, name, args) {
                   {
                     success: true,
                     action: 'rebuild_and_restart',
-                    buildOutput: buildOutput.substring(0, 2000),
+                    buildOutput,
                     status: backend.getStatus(),
                   },
                   null,
@@ -633,7 +643,7 @@ async function handleDevTool(backend, server, name, args) {
                 {
                   success: true,
                   action: 'rebuild_and_restart',
-                  buildOutput: buildOutput.substring(0, 2000),
+                  buildOutput,
                   status: backend.getStatus(),
                 },
                 null,
@@ -669,6 +679,10 @@ async function handleDevTool(backend, server, name, args) {
 // ---------------------------------------------------------------------------
 
 async function main() {
+  if (!sharedUtilsLoaded) {
+    log('WARNING: @debugmcp/shared dist not found — backend output redaction disabled until the project is built');
+  }
+
   const backend = new BackendManager();
 
   // Create the MCP Server that Claude Code talks to (via stdio)


### PR DESCRIPTION
## Problem (#154)

`tools/dev-proxy/dev-proxy.mjs` was outside the sanitization net that now covers the server and adapter packages (#146/#151/#153):

1. `logBackend()` split each stdout/stderr chunk on `\n` with no persistent line buffer, so a line straddling two chunks was emitted as two partial `[backend]` lines — and a secret assignment split that way slipped past redaction patterns (the defect class fixed in #151).
2. No sanitization was applied before backend output was written to the proxy's stderr.
3. `dev_rebuild_and_restart` / `dev_restart_debugger(rebuild:true)` embedded raw build stdout in the MCP tool response — and on build **failure**, `execSync`'s thrown message embeds raw build stderr, which flowed unsanitized into the tool response via `err.message`.

## Fix

- New `tools/dev-proxy/backend-logger.mjs` (own module for testability, same reason `shutdown.mjs` exists): reuses `LineBuffer` / `sanitizeStderr` / `sanitizeStderrTail` from `@debugmcp/shared` via dynamic import through the workspace link. If the shared dist isn't built, it falls back to a minimal inline line buffer (no redaction) with a logged warning — the proxy must keep its dev tools available on an unbuilt tree so `dev_rebuild_and_restart` can fix it.
- One logger per stream (stdout/stderr never share a buffer), flushed on the stream's own `end`/`close` — mirroring the `proxy-manager.ts` pattern from #151.
- `rebuild()` returns a sanitized tail (`maxLines: 50, maxChars: 2000`) and rethrows build failures with a sanitized combined stdout+stderr tail. Tool handlers embed that directly (previously a raw head slice; the tail is where build errors live).

## Testing

- 13 new unit tests in `tests/unit/dev-proxy/backend-logger.test.ts` (chunk-straddled secret redacted as one line, flush semantics, per-instance buffers, CRLF, Buffer input, `sanitizeStderrTail` bounds).
- E2E-verified against a fake backend emitting `GITHUB_PAT=ghp_…` split across two stderr writes: proxy stderr shows exactly one `[REDACTED — line contained sensitive data]` line, zero `ghp_` leaks; real-backend happy path and the unbuilt-tree fallback both verified manually.

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)