### PR TITLE
docs: add OpenSSF Best Practices passing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/debugmcp/mcp-debugger.svg)](https://hub.docker.com/r/debugmcp/mcp-debugger)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/debugmcp/mcp-debugger/badge)](https://scorecard.dev/viewer/?uri=github.com/debugmcp/mcp-debugger)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13543/badge)](https://www.bestpractices.dev/projects/13543)
 
 ## 🎯 Overview
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,3 +81,4 @@ mcp-debugger follows these security principles:
 - **UX-level path validation**: File paths are checked for existence at request boundaries to give the MCP client immediate feedback on bad inputs. This is not an access-control mechanism — see [Trust Model](#trust-model).
 - **Least privilege**: CI workflows use minimal GitHub token permissions
 - **Supply chain hardening**: GitHub Actions are SHA-pinned, dependencies are audited, npm packages are published with sigstore provenance
+- **Self-assessed against community baselines**: [OpenSSF Best Practices "passing" badge](https://www.bestpractices.dev/projects/13543) and [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/debugmcp/mcp-debugger)


### PR DESCRIPTION
## Summary
- Adds the OpenSSF Best Practices badge to the README badge row — the project registered at bestpractices.dev and passed the self-assessment (project 13543), part of the OpenSSF Scorecard improvement effort.
- SECURITY.md's Security Design section now links both the Best Practices badge and the Scorecard viewer alongside the existing hardening bullets.

(SECURITY.md's supported-versions table was already refreshed to 0.22.x in #164 — no further change needed there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)