### PR TITLE
refactor: inject process handles so tests never mutate the global process (#183)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
       run: pnpm run test:ci-coverage
       env:
         CI: true
+        # Hard-fail on process-listener leaks (issues #159/#183)
+        LEAK_GUARD_STRICT: '1'
     
     - name: Upload Windows test diagnostics
       if: failure() && matrix.os == 'windows-latest'

--- a/.github/workflows/flake-hunt.yml
+++ b/.github/workflows/flake-hunt.yml
@@ -61,4 +61,6 @@ jobs:
       run: pnpm run test:flake
       env:
         CI: true
+        # Hard-fail on process-listener leaks (issues #159/#183)
+        LEAK_GUARD_STRICT: '1'
         FLAKE_RUNS: ${{ github.event.inputs.runs || '10' }}

--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -52,13 +52,7 @@ export const ErrorMessages = {
 
 ### 1. Process-Level Error Handling
 
-Two implementations of global error handlers exist in the codebase:
-
-1. **`ProxyRunner.setupGlobalErrorHandlers()`** (`src/proxy/dap-proxy-core.ts`) -- Logs errors and sends IPC messages, but does **not** call `process.exit()` for unhandled rejections. Used when the entry point wires up error handling through the ProxyRunner instance.
-
-2. **`setupGlobalErrorHandlers()` standalone function** (`src/proxy/dap-proxy-dependencies.ts`) -- A standalone function that logs errors, sends IPC messages, and **always exits the process** after shutdown (including for unhandled rejections). Available as an alternative bootstrap path. Note: `dap-proxy-entry.ts` actually uses `runner.setupGlobalErrorHandlers()` (the ProxyRunner instance method), not this standalone function.
-
-**ProxyRunner version** (`src/proxy/dap-proxy-core.ts`):
+Global error handlers for the proxy process are registered by **`ProxyRunner.setupGlobalErrorHandlers()`** (`src/proxy/dap-proxy-core.ts`), wired up by `dap-proxy-entry.ts`. It logs errors and sends IPC messages, but does **not** exit the process for unhandled rejections. All handlers are registered on the runner's injected process handle (`this.proc`, defaulting to the global `process` — issue #183), so unit tests can drive them through a fake without touching the real process object.
 
 ```typescript
 setupGlobalErrorHandlers(
@@ -66,7 +60,7 @@ setupGlobalErrorHandlers(
   getCurrentSessionId: () => string | null
 ): void {
   // Uncaught exception handler - exits after shutdown
-  process.on('uncaughtException', (error: Error) => {
+  this.proc.on('uncaughtException', (error: Error) => {
     this.logger.error('[ProxyRunner] Uncaught exception:', error);
     const sessionId = getCurrentSessionId() || 'unknown';
 
@@ -77,12 +71,12 @@ setupGlobalErrorHandlers(
     });
 
     errorShutdown().finally(() => {
-      process.exit(1);
+      this.proc.exit(1);
     });
   });
 
   // Unhandled rejection handler - logs but does NOT exit
-  process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
+  this.proc.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
     this.logger.error('[ProxyRunner] Unhandled rejection:', { reason, promise });
     const sessionId = getCurrentSessionId() || 'unknown';
 
@@ -94,31 +88,23 @@ setupGlobalErrorHandlers(
   });
 
   // Graceful shutdown on signals
-  process.on('SIGTERM', () => {
+  this.proc.on('SIGTERM', () => {
     this.logger.info('[ProxyRunner] Received SIGTERM, shutting down gracefully');
     errorShutdown().finally(() => {
-      process.exit(0);
+      this.proc.exit(0);
     });
   });
 
-  process.on('SIGINT', () => {
+  this.proc.on('SIGINT', () => {
     this.logger.info('[ProxyRunner] Received SIGINT, shutting down gracefully');
     errorShutdown().finally(() => {
-      process.exit(0);
+      this.proc.exit(0);
     });
   });
 }
 ```
 
-**Standalone version** (`src/proxy/dap-proxy-dependencies.ts`) exits after shutdown for **all** error types, including unhandled rejections:
-
-```typescript
-process.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
-  logger.error('[Proxy Worker UNHANDLED_REJECTION] Reason:', reason);
-  messageSender.send({ type: 'error', message: `...`, sessionId: '...' });
-  shutdownFn().finally(() => process.exit(1));  // exits the process
-});
-```
+(A divergent standalone `setupGlobalErrorHandlers()` used to exist in `src/proxy/dap-proxy-dependencies.ts`; it was dead in production and removed with issue #183.)
 
 ### 2. Component-Level Error Handling
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "posttest:watch": "node scripts/cleanup-test-processes.js",
     "test:unit": "vitest run --project unit",
     "posttest:unit": "node scripts/cleanup-test-processes.js",
+    "test:strict": "cross-env LEAK_GUARD_STRICT=1 vitest run --project unit --project integration",
+    "posttest:strict": "node scripts/cleanup-test-processes.js",
     "test:flake": "node scripts/flake-hunt.mjs",
     "posttest:flake": "node scripts/cleanup-test-processes.js",
     "test:integration": "vitest run --project integration",

--- a/packages/adapter-ruby/src/utils/ruby-utils.ts
+++ b/packages/adapter-ruby/src/utils/ruby-utils.ts
@@ -175,9 +175,10 @@ export interface RdbgInvocation {
 export function buildRdbgInvocation(
   rdbgPath: string,
   args: string[],
-  rubyPath?: string
+  rubyPath?: string,
+  platform: NodeJS.Platform = process.platform
 ): RdbgInvocation {
-  if (process.platform === 'win32' && /\.(bat|cmd)$/i.test(rdbgPath)) {
+  if (platform === 'win32' && /\.(bat|cmd)$/i.test(rdbgPath)) {
     const scriptPath = rdbgPath.replace(/\.(bat|cmd)$/i, '');
     if (path.isAbsolute(scriptPath) && fs.existsSync(scriptPath)) {
       return { command: rubyPath || 'ruby', args: [scriptPath, ...args] };

--- a/packages/adapter-ruby/tests/unit/ruby-utils.test.ts
+++ b/packages/adapter-ruby/tests/unit/ruby-utils.test.ts
@@ -120,11 +120,8 @@ describe('version probes', () => {
 });
 
 describe('buildRdbgInvocation platform behavior', () => {
-  afterEach(() => Object.defineProperty(process, 'platform', originalPlatform));
-
   it('returns the command unchanged for non-shim paths on Windows', () => {
-    setPlatform('win32');
-    expect(buildRdbgInvocation('C:\\tools\\rdbg.exe', ['--version'])).toEqual({
+    expect(buildRdbgInvocation('C:\\tools\\rdbg.exe', ['--version'], undefined, 'win32')).toEqual({
       command: 'C:\\tools\\rdbg.exe',
       args: ['--version']
     });

--- a/packages/shared/src/interfaces/adapter-policy-python.ts
+++ b/packages/shared/src/interfaces/adapter-policy-python.ts
@@ -97,7 +97,7 @@ export const PythonAdapterPolicy: AdapterPolicy = {
     };
   },
   
-  resolveExecutablePath: (providedPath?: string) => {
+  resolveExecutablePath: (providedPath?: string, platform: NodeJS.Platform = process.platform) => {
     // Python-specific executable path resolution
     // Priority: provided path > PYTHON_PATH env > default python command
     if (providedPath) {
@@ -110,7 +110,7 @@ export const PythonAdapterPolicy: AdapterPolicy = {
     }
 
     // Platform-specific default: 'python' on Windows, 'python3' on Unix-like systems
-    return process.platform === 'win32' ? 'python' : 'python3';
+    return platform === 'win32' ? 'python' : 'python3';
   },
   
   getDebuggerConfiguration: () => {

--- a/packages/shared/src/interfaces/adapter-policy.ts
+++ b/packages/shared/src/interfaces/adapter-policy.ts
@@ -139,11 +139,12 @@ export interface AdapterPolicy {
   /**
    * Resolve the executable path for this language.
    * Handles language-specific executable resolution logic.
-   * 
+   *
    * @param providedPath Optional path provided by the user
+   * @param platform Platform override for tests (issue #183); implementations default it to process.platform
    * @returns The resolved executable path or undefined
    */
-  resolveExecutablePath(providedPath?: string): string | undefined;
+  resolveExecutablePath(providedPath?: string, platform?: NodeJS.Platform): string | undefined;
 
   /**
    * Get debugger configuration and requirements.

--- a/src/cli/error-handlers.ts
+++ b/src/cli/error-handlers.ts
@@ -1,23 +1,27 @@
 import type { Logger as WinstonLoggerType } from 'winston';
+import type { ProcessLike } from '../interfaces/process-interfaces.js';
 
 export interface ErrorHandlerDependencies {
   logger: WinstonLoggerType;
   exitProcess?: (code: number) => void;
+  /** Injectable process handle for handler registration (issue #183); defaults to the global process. */
+  proc?: ProcessLike;
 }
 
 export function setupErrorHandlers(dependencies: ErrorHandlerDependencies): void {
-  const { logger, exitProcess = process.exit } = dependencies;
+  const proc = dependencies.proc ?? process;
+  const { logger, exitProcess = (code: number) => proc.exit(code) } = dependencies;
 
-  process.on('uncaughtException', (err: Error, origin: string) => {
-    logger.error(`[Server UNCAUGHT_EXCEPTION] Origin: ${origin}`, { 
-      errorName: err.name, 
-      errorMessage: err.message, 
-      errorStack: err.stack 
+  proc.on('uncaughtException', (err: Error, origin: string) => {
+    logger.error(`[Server UNCAUGHT_EXCEPTION] Origin: ${origin}`, {
+      errorName: err.name,
+      errorMessage: err.message,
+      errorStack: err.stack
     });
     exitProcess(1);
   });
 
-  process.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
+  proc.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
     logger.error('[Server UNHANDLED_REJECTION] Reason:', { reason });
     logger.error('[Server UNHANDLED_REJECTION] Promise:', { promise });
     // Do not exit: in a long-running server (HTTP server mode), stray rejections

--- a/src/cli/http-command.ts
+++ b/src/cli/http-command.ts
@@ -9,6 +9,7 @@ import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { DebugMcpServer } from '../server.js';
 import { SSEOptions } from './setup.js';
 import { watchStdinForParentExit } from './stdin-watchdog.js';
+import type { ProcessLike } from '../interfaces/process-interfaces.js';
 
 export interface ServerFactoryOptions {
   logLevel?: string;
@@ -19,8 +20,10 @@ export interface HttpCommandDependencies {
   logger: WinstonLoggerType;
   serverFactory: (options: ServerFactoryOptions) => DebugMcpServer;
   exitProcess?: (code: number) => void;
-  /** Injectable stdin for tests; defaults to process.stdin. */
+  /** Injectable stdin for tests; defaults to proc.stdin. */
   stdin?: NodeJS.ReadStream;
+  /** Injectable process handle for signals/env/exit (issue #183); defaults to the global process. */
+  proc?: ProcessLike;
 }
 
 interface SessionData {
@@ -170,7 +173,8 @@ export async function handleHttpCommand(
   options: SSEOptions,
   dependencies: HttpCommandDependencies
 ): Promise<void> {
-  const { logger, exitProcess = process.exit } = dependencies;
+  const proc = dependencies.proc ?? process;
+  const { logger, exitProcess = (code: number) => proc.exit(code) } = dependencies;
 
   if (options.logLevel) {
     logger.level = options.logLevel;
@@ -225,18 +229,19 @@ export async function handleHttpCommand(
       });
     };
 
-    process.on('SIGINT', gracefulShutdown);
-    process.on('SIGTERM', gracefulShutdown);
+    proc.on('SIGINT', gracefulShutdown);
+    proc.on('SIGTERM', gracefulShutdown);
 
     // Orphan self-defense (issue #122): when spawned by a supervisor with
     // MCP_EXIT_ON_STDIN_CLOSE=1 and a stdin pipe, shut down gracefully if
     // that pipe closes (supervisor died or asked us to stop). Strictly
     // opt-in — standalone/detached servers are unaffected.
     watchStdinForParentExit({
-      stdin: dependencies.stdin ?? process.stdin,
+      stdin: dependencies.stdin ?? proc.stdin,
       logger,
       shutdown: gracefulShutdown,
       exitProcess,
+      env: proc.env,
     });
   } catch (error) {
     logger.error('Failed to start server in HTTP mode', { error });

--- a/src/cli/sse-command.ts
+++ b/src/cli/sse-command.ts
@@ -5,6 +5,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { DebugMcpServer } from '../server.js';
 import { SSEOptions } from './setup.js';
 import { watchStdinForParentExit } from './stdin-watchdog.js';
+import type { ProcessLike } from '../interfaces/process-interfaces.js';
 
 export interface ServerFactoryOptions {
   logLevel?: string;
@@ -15,8 +16,10 @@ export interface SSECommandDependencies {
   logger: WinstonLoggerType;
   serverFactory: (options: ServerFactoryOptions) => DebugMcpServer;
   exitProcess?: (code: number) => void;
-  /** Injectable stdin for tests; defaults to process.stdin. */
+  /** Injectable stdin for tests; defaults to proc.stdin. */
   stdin?: NodeJS.ReadStream;
+  /** Injectable process handle for signals/env/exit (issue #183); defaults to the global process. */
+  proc?: ProcessLike;
 }
 
 interface SessionData {
@@ -193,7 +196,8 @@ export async function handleSSECommand(
   options: SSEOptions,
   dependencies: SSECommandDependencies
 ): Promise<void> {
-  const { logger, exitProcess = process.exit } = dependencies;
+  const proc = dependencies.proc ?? process;
+  const { logger, exitProcess = (code: number) => proc.exit(code) } = dependencies;
   
   if (options.logLevel) {
     logger.level = options.logLevel;
@@ -259,18 +263,19 @@ export async function handleSSECommand(
       });
     };
 
-    process.on('SIGINT', gracefulShutdown);
-    process.on('SIGTERM', gracefulShutdown);
+    proc.on('SIGINT', gracefulShutdown);
+    proc.on('SIGTERM', gracefulShutdown);
 
     // Orphan self-defense (issue #122): when spawned by a supervisor with
     // MCP_EXIT_ON_STDIN_CLOSE=1 and a stdin pipe, shut down gracefully if
     // that pipe closes (supervisor died or asked us to stop). Strictly
     // opt-in — standalone/detached servers are unaffected.
     watchStdinForParentExit({
-      stdin: dependencies.stdin ?? process.stdin,
+      stdin: dependencies.stdin ?? proc.stdin,
       logger,
       shutdown: gracefulShutdown,
       exitProcess,
+      env: proc.env,
     });
   } catch (error) {
     logger.error('Failed to start server in SSE mode', { error });

--- a/src/cli/stdin-watchdog.ts
+++ b/src/cli/stdin-watchdog.ts
@@ -17,7 +17,8 @@ export const STDIN_CLOSE_ENV_VAR = 'MCP_EXIT_ON_STDIN_CLOSE';
 const DEFAULT_BACKSTOP_MS = 5000;
 
 export interface StdinWatchdogOptions {
-  stdin: NodeJS.ReadStream;
+  /** Only .on() and .resume() are used, so any readable stream (incl. test fakes) works. */
+  stdin: NodeJS.ReadableStream;
   logger: { warn: (msg: string) => void };
   /** Graceful shutdown to initiate; expected to eventually exit the process. */
   shutdown: () => void | Promise<void>;

--- a/src/cli/stdio-command.ts
+++ b/src/cli/stdio-command.ts
@@ -2,6 +2,7 @@ import type { Logger as WinstonLoggerType } from 'winston';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { DebugMcpServer } from '../server.js';
 import { StdioOptions } from './setup.js';
+import type { ProcessLike } from '../interfaces/process-interfaces.js';
 
 export interface ServerFactoryOptions {
   logLevel?: string;
@@ -12,15 +13,18 @@ export interface StdioCommandDependencies {
   logger: WinstonLoggerType;
   serverFactory: (options: ServerFactoryOptions) => DebugMcpServer;
   exitProcess?: (code: number) => void;
-  /** Injectable stdin for tests; defaults to process.stdin. */
+  /** Injectable stdin for tests; defaults to proc.stdin. */
   stdin?: NodeJS.ReadStream;
+  /** Injectable process handle for signals/env/exit diagnostics (issue #183); defaults to the global process. */
+  proc?: ProcessLike;
 }
 
 export async function handleStdioCommand(
-  options: StdioOptions, 
+  options: StdioOptions,
   dependencies: StdioCommandDependencies
 ): Promise<void> {
-  const { logger, serverFactory, exitProcess = process.exit } = dependencies;
+  const proc = dependencies.proc ?? process;
+  const { logger, serverFactory, exitProcess = (code: number) => proc.exit(code) } = dependencies;
   
   if (options.logLevel) {
     logger.level = options.logLevel;
@@ -66,7 +70,7 @@ export async function handleStdioCommand(
     };
     
     // Keep the process alive
-    const stdin = dependencies.stdin ?? process.stdin;
+    const stdin: NodeJS.ReadableStream = dependencies.stdin ?? proc.stdin;
     stdin.resume();
 
     // Stdin EOF means the MCP client is gone — exit so we don't leak as an
@@ -76,7 +80,7 @@ export async function handleStdioCommand(
     // unexpectedly in detached `docker run` setups and the server must stay
     // alive; rely on transport close or signals there (see c251b3ff).
     stdin.on('end', () => {
-      if (process.env.MCP_CONTAINER === 'true') {
+      if (proc.env.MCP_CONTAINER === 'true') {
         logger.warn('[MCP] Stdin ended; ignoring in container mode and waiting for transport close or signal.');
         return;
       }
@@ -86,22 +90,22 @@ export async function handleStdioCommand(
     });
 
     // Add robust exit/signal diagnostics (logged to file; console output is silenced for protocol safety)
-    process.on('SIGTERM', () => {
+    proc.on('SIGTERM', () => {
       logger.warn('[MCP] SIGTERM received, exiting.');
       try { clearInterval(keepAlive); } catch {}
       exitProcess(0);
     });
-    process.on('SIGINT', () => {
+    proc.on('SIGINT', () => {
       logger.warn('[MCP] SIGINT received, exiting.');
       try { clearInterval(keepAlive); } catch {}
       exitProcess(0);
     });
-    process.on('exit', (code) => {
+    proc.on('exit', (code) => {
       logger.error('[MCP] Process exiting', {
         code,
-        argv: process.argv,
-        env_console_silenced: process.env.CONSOLE_OUTPUT_SILENCED,
-        uptime: process.uptime()
+        argv: proc.argv,
+        env_console_silenced: proc.env.CONSOLE_OUTPUT_SILENCED,
+        uptime: proc.uptime()
       });
     });
   } catch (error) {

--- a/src/interfaces/process-interfaces.ts
+++ b/src/interfaces/process-interfaces.ts
@@ -57,3 +57,42 @@ export interface IProxyProcess extends IProcess {
   sendCommand(command: object): void;
   waitForInitialization(timeout?: number): Promise<void>;
 }
+
+/**
+ * Minimal handle on the CURRENT process (issue #183).
+ *
+ * Structurally satisfied by the global `process` and by EventEmitter-backed
+ * fakes (see tests/test-utils/mocks/fake-current-process.ts). Members are
+ * deliberately widened relative to NodeJS.Process where the exact Node types
+ * (tty stream intersections, `never` returns, per-event listener overloads)
+ * would make fakes unimplementable:
+ *  - stdin/stdout are the generic stream interfaces (readline only needs these)
+ *  - exit returns void instead of never
+ *  - on/removeListener/listeners use EventEmitter's general signatures
+ *
+ * `send` is optional exactly like NodeJS.Process['send']: absence of the
+ * member models a process spawned without an IPC channel, and IPC-mode
+ * detection remains `typeof proc.send === 'function'`.
+ */
+export interface ProcessLike {
+  /* eslint-disable @typescript-eslint/no-explicit-any -- general EventEmitter signatures; required for structural compat with NodeJS.Process */
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- must match EventEmitter#listeners return type for assignability
+  listeners(event: string | symbol): Function[];
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- must match EventEmitter#rawListeners return type for assignability
+  rawListeners(event: string | symbol): Function[];
+  listenerCount(event: string | symbol): number;
+
+  exit(code?: number): void;
+  send?(message: unknown): boolean;
+  connected: boolean;
+
+  env: NodeJS.ProcessEnv;
+  argv: string[];
+  uptime(): number;
+
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+}

--- a/src/proxy/dap-proxy-adapter-manager.ts
+++ b/src/proxy/dap-proxy-adapter-manager.ts
@@ -31,7 +31,9 @@ export class GenericAdapterManager {
   constructor(
     private processSpawner: IProcessSpawner,
     private logger: ILogger,
-    private fileSystem: IFileSystem
+    private fileSystem: IFileSystem,
+    /** Platform override for tests (issue #183); defaults to the real platform. */
+    private platform: NodeJS.Platform = globalThis.process.platform
   ) {}
 
   /**
@@ -212,7 +214,7 @@ export class GenericAdapterManager {
 
     this.logger.info(`[AdapterManager] Attempting to terminate adapter process PID: ${process.pid}`);
 
-    const treeKillFirst = options.killProcessTree === true && globalThis.process.platform === 'win32';
+    const treeKillFirst = options.killProcessTree === true && this.platform === 'win32';
 
     try {
       if (!process.killed) {

--- a/src/proxy/dap-proxy-core.ts
+++ b/src/proxy/dap-proxy-core.ts
@@ -16,22 +16,30 @@ import {
 } from './dap-proxy-interfaces.js';
 import { getErrorMessage } from '../errors/debug-errors.js';
 import { sanitizePayloadForLogging } from '@debugmcp/shared';
+import type { ProcessLike } from '../interfaces/process-interfaces.js';
 
 export interface ProxyRunnerOptions {
   /**
    * Whether to use IPC for communication (when available)
    */
   useIPC?: boolean;
-  
+
   /**
    * Whether to use stdin/readline as fallback
    */
   useStdin?: boolean;
-  
+
   /**
    * Custom message handler for testing
    */
   onMessage?: (message: string) => Promise<void>;
+
+  /**
+   * Process-like handle used for IPC, signals, exit, and stdio. Defaults to
+   * the global `process`; injectable so unit tests never mutate the real
+   * process object (issue #183).
+   */
+  proc?: ProcessLike;
 }
 
 /**
@@ -50,13 +58,15 @@ export class ProxyRunner {
   private heartbeatTickCounter = 0;
   private disconnectHandler?: () => void;
   private errorHandler?: (err: Error) => void;
+  private readonly proc: ProcessLike;
 
   constructor(
     private dependencies: DapProxyDependencies,
     logger: ILogger,
     private options: ProxyRunnerOptions = {}
   ) {
-    this.worker = new DapProxyWorker(dependencies);
+    this.proc = options.proc ?? process;
+    this.worker = new DapProxyWorker(dependencies, { exit: (code) => this.proc.exit(code) });
     this.logger = logger;
   }
 
@@ -76,7 +86,7 @@ export class ProxyRunner {
       const processMessage = this.options.onMessage || this.createMessageProcessor();
 
       // Set up communication channels based on options and availability
-      if (this.options.useIPC !== false && typeof process.send === 'function') {
+      if (this.options.useIPC !== false && typeof this.proc.send === 'function') {
         this.setupIPCCommunication(processMessage);
       } else if (this.options.useStdin !== false) {
         this.setupStdinCommunication(processMessage);
@@ -86,20 +96,20 @@ export class ProxyRunner {
 
       this.logger.info('[ProxyRunner] Ready to receive commands');
 
-      if (typeof process.send === 'function') {
+      if (typeof this.proc.send === 'function') {
         this.heartbeatInterval = setInterval(() => {
           try {
             this.heartbeatTickCounter += 1;
             this.logger.debug(
-              `[ProxyRunner] Heartbeat tick #${this.heartbeatTickCounter} send attempt (process.connected=${process.connected})`
+              `[ProxyRunner] Heartbeat tick #${this.heartbeatTickCounter} send attempt (process.connected=${this.proc.connected})`
             );
-            process.send?.({
+            this.proc.send?.({
               type: 'ipc-heartbeat-tick',
               timestamp: Date.now(),
               counter: this.heartbeatTickCounter
             });
           } catch (tickError) {
-            // process.send throws only when the IPC channel is closed (the
+            // proc.send throws only when the IPC channel is closed (the
             // payload is static, so serialization cannot fail) — the parent is
             // unreachable. Shut down instead of lingering. This replaces the
             // self-SIGTERM the old proxy-bootstrap heartbeat performed (#123).
@@ -108,7 +118,7 @@ export class ProxyRunner {
               tickError
             );
             this.stop().finally(() => {
-              process.exit(1);
+              this.proc.exit(1);
             });
           }
         }, 5000);
@@ -118,7 +128,7 @@ export class ProxyRunner {
       const timeoutDuration = 10000; // 10 seconds - should be enough for normal initialization
       const initTimeout = setTimeout(() => {
         this.logger.warn(`[ProxyRunner] No initialization received within ${timeoutDuration / 1000} seconds, exiting...`);
-        process.exit(1);
+        this.proc.exit(1);
       }, timeoutDuration);
 
       // Store timeout so we can clear it when init is received
@@ -159,17 +169,17 @@ export class ProxyRunner {
     await this.worker.shutdown();
     
     // Clean up communication channels
-    if (this.messageHandler && process.removeListener) {
-      process.removeListener('message', this.messageHandler);
+    if (this.messageHandler && this.proc.removeListener) {
+      this.proc.removeListener('message', this.messageHandler);
     }
 
     if (this.disconnectHandler) {
-      process.removeListener('disconnect', this.disconnectHandler);
+      this.proc.removeListener('disconnect', this.disconnectHandler);
       this.disconnectHandler = undefined;
     }
 
     if (this.errorHandler) {
-      process.removeListener('error', this.errorHandler);
+      this.proc.removeListener('error', this.errorHandler);
       this.errorHandler = undefined;
     }
 
@@ -230,7 +240,7 @@ export class ProxyRunner {
 
         this.logger.info(`[ProxyRunner] Worker state is TERMINATED. Exiting in ${exitDelay}ms.`);
         setTimeout(() => {
-          process.exit(0);
+          this.proc.exit(0);
         }, exitDelay);
       }
     };
@@ -243,7 +253,7 @@ export class ProxyRunner {
     this.logger.info('[ProxyRunner] Setting up IPC communication');
     
     // Test if IPC channel exists
-    if (typeof process.send !== 'function') {
+    if (typeof this.proc.send !== 'function') {
       this.logger.error('[ProxyRunner] ERROR: process.send is not a function - IPC channel not available!');
       return;
     }
@@ -256,14 +266,14 @@ export class ProxyRunner {
         `[ProxyRunner] IPC message #${this.ipcMessageCounter} received type=${typeof message}`
       );
       this.logger.debug(
-        `[ProxyRunner] IPC listener count=${process.listenerCount('message')}`
+        `[ProxyRunner] IPC listener count=${this.proc.listenerCount('message')}`
       );
       this.logger.debug(`[ProxyRunner] Raw message snapshot:`, sanitizePayloadForLogging(message));
       this.logger.debug('[ProxyRunner] IPC message received (raw):', JSON.stringify(sanitizePayloadForLogging(message)).substring(0, 200));
-      this.logger.debug(`[ProxyRunner] IPC channel status on receive: connected=${process.connected}`);
-      if (typeof process.send === 'function') {
+      this.logger.debug(`[ProxyRunner] IPC channel status on receive: connected=${this.proc.connected}`);
+      if (typeof this.proc.send === 'function') {
         try {
-          process.send({
+          this.proc.send({
             type: 'ipc-heartbeat',
             counter: this.ipcMessageCounter,
             timestamp: Date.now()
@@ -296,7 +306,7 @@ export class ProxyRunner {
       }
     };
 
-    process.on('message', this.messageHandler);
+    this.proc.on('message', this.messageHandler);
     this.logger.info('[ProxyRunner] IPC message handler attached');
 
     this.disconnectHandler = () => {
@@ -304,15 +314,15 @@ export class ProxyRunner {
       // Trigger full stop so attach-mode auto-detach and cleanup run before exit.
       // Use the same pattern as SIGTERM in setupGlobalErrorHandlers().
       this.stop().finally(() => {
-        process.exit(0);
+        this.proc.exit(0);
       });
     };
-    process.on('disconnect', this.disconnectHandler);
+    this.proc.on('disconnect', this.disconnectHandler);
 
     this.errorHandler = (err: Error) => {
       this.logger.error('[ProxyRunner] IPC channel error:', err);
     };
-    process.on('error', this.errorHandler);
+    this.proc.on('error', this.errorHandler);
   }
 
   /**
@@ -322,8 +332,8 @@ export class ProxyRunner {
     this.logger.info('[ProxyRunner] Setting up stdin/readline communication');
     
     this.rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
+      input: this.proc.stdin,
+      output: this.proc.stdout,
       terminal: false
     });
 
@@ -339,7 +349,7 @@ export class ProxyRunner {
       }
       this.logger.warn('[ProxyRunner] stdin closed — parent process gone, shutting down');
       this.stop().finally(() => {
-        process.exit(0);
+        this.proc.exit(0);
       });
     });
   }
@@ -352,10 +362,10 @@ export class ProxyRunner {
     getCurrentSessionId: () => string | null
   ): void {
     // Uncaught exception handler
-    process.on('uncaughtException', (error: Error) => {
+    this.proc.on('uncaughtException', (error: Error) => {
       this.logger.error('[ProxyRunner] Uncaught exception:', error);
       const sessionId = getCurrentSessionId() || 'unknown';
-      
+
       this.dependencies.messageSender.send({
         type: 'error',
         message: `Proxy uncaught exception: ${error.message}`,
@@ -363,12 +373,12 @@ export class ProxyRunner {
       });
 
       errorShutdown().finally(() => {
-        process.exit(1);
+        this.proc.exit(1);
       });
     });
 
     // Unhandled rejection handler
-    process.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
+    this.proc.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
       this.logger.error('[ProxyRunner] Unhandled rejection:', { reason, promise });
       const sessionId = getCurrentSessionId() || 'unknown';
       
@@ -380,18 +390,18 @@ export class ProxyRunner {
     });
 
     // SIGTERM handler
-    process.on('SIGTERM', () => {
+    this.proc.on('SIGTERM', () => {
       this.logger.info('[ProxyRunner] Received SIGTERM, shutting down gracefully');
       errorShutdown().finally(() => {
-        process.exit(0);
+        this.proc.exit(0);
       });
     });
 
     // SIGINT handler
-    process.on('SIGINT', () => {
+    this.proc.on('SIGINT', () => {
       this.logger.info('[ProxyRunner] Received SIGINT, shutting down gracefully');
       errorShutdown().finally(() => {
-        process.exit(0);
+        this.proc.exit(0);
       });
     });
   }
@@ -399,18 +409,21 @@ export class ProxyRunner {
 
 /**
  * Detect if the module is being run directly or as a worker
+ *
+ * @param proc injectable process handle (issue #183); `require.main === module`
+ * stays module-scoped and cannot be injected.
  */
-export function detectExecutionMode(): {
+export function detectExecutionMode(proc: Pick<ProcessLike, 'send' | 'env' | 'argv'> = process): {
   isDirectRun: boolean;
   hasIPC: boolean;
   isWorkerEnv: boolean;
 } {
-  const isDirectRun = 
+  const isDirectRun =
     (typeof require !== 'undefined' && require.main === module) ||
-    (typeof import.meta !== 'undefined' && import.meta.url === `file://${process.argv[1]}`);
+    (typeof import.meta !== 'undefined' && import.meta.url === `file://${proc.argv[1]}`);
 
-  const hasIPC = typeof process.send === 'function';
-  const isWorkerEnv = process.env.DAP_PROXY_WORKER === 'true';
+  const hasIPC = typeof proc.send === 'function';
+  const isWorkerEnv = proc.env.DAP_PROXY_WORKER === 'true';
 
   return { isDirectRun, hasIPC, isWorkerEnv };
 }

--- a/src/proxy/dap-proxy-dependencies.ts
+++ b/src/proxy/dap-proxy-dependencies.ts
@@ -12,11 +12,17 @@ import {
   ILogger,
   ILoggerFactory
 } from './dap-proxy-interfaces.js';
+import type { ProcessLike } from '../interfaces/process-interfaces.js';
 
 /**
  * Create production dependencies for the DAP Proxy Worker
+ *
+ * @param proc injectable process handle for the messageSender's IPC/stdout
+ * channel (issue #183); defaults to the global `process`.
  */
-export function createProductionDependencies(): DapProxyDependencies {
+export function createProductionDependencies(
+  proc: Pick<ProcessLike, 'send' | 'stdout'> = process
+): DapProxyDependencies {
   // Logger factory for delayed initialization
   const loggerFactory: ILoggerFactory = async (sessionId: string, logDir: string) => {
     const logPath = path.join(logDir, `proxy-${sessionId}.log`);
@@ -44,10 +50,10 @@ export function createProductionDependencies(): DapProxyDependencies {
     
     messageSender: {
       send: (message: unknown) => {
-        if (process.send) {
-          process.send(message);
+        if (proc.send) {
+          proc.send(message);
         } else {
-          process.stdout.write(JSON.stringify(message) + '\n');
+          proc.stdout.write(JSON.stringify(message) + '\n');
         }
       }
     }
@@ -64,46 +70,4 @@ export function createConsoleLogger(): ILogger {
     debug: (...args: unknown[]) => console.error('[DEBUG]', ...args),
     warn: (...args: unknown[]) => console.error('[WARN]', ...args)
   };
-}
-
-/**
- * Setup global error handlers for the proxy process
- */
-export function setupGlobalErrorHandlers(
-  logger: ILogger,
-  messageSender: { send: (msg: unknown) => void },
-  shutdownFn: () => Promise<void>,
-  getCurrentSessionId: () => string | null
-): void {
-  process.on('uncaughtException', (err: Error, origin: string) => {
-    logger.error(`[Proxy Worker UNCAUGHT_EXCEPTION] Origin: ${origin}`, err);
-    messageSender.send({
-      type: 'error',
-      message: `Proxy worker uncaught exception: ${err.message} (origin: ${origin})`,
-      sessionId: getCurrentSessionId() || 'unknown'
-    });
-    shutdownFn().finally(() => process.exit(1));
-  });
-
-  process.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
-    logger.error('[Proxy Worker UNHANDLED_REJECTION] Reason:', reason, 'Promise:', promise);
-    messageSender.send({
-      type: 'error',
-      message: `Proxy worker unhandled rejection: ${String(reason)}`,
-      sessionId: getCurrentSessionId() || 'unknown'
-    });
-    shutdownFn().finally(() => process.exit(1));
-  });
-
-  process.on('SIGINT', async () => {
-    logger.info('[Proxy] SIGINT received, shutting down proxy worker.');
-    await shutdownFn();
-    process.exit(0);
-  });
-
-  process.on('SIGTERM', async () => {
-    logger.info('[Proxy] SIGTERM received, shutting down proxy worker.');
-    await shutdownFn();
-    process.exit(0);
-  });
 }

--- a/src/proxy/dap-proxy.ts
+++ b/src/proxy/dap-proxy.ts
@@ -21,8 +21,7 @@ export type {
 // Re-export dependencies for testing
 export {
   createProductionDependencies,
-  createConsoleLogger,
-  setupGlobalErrorHandlers
+  createConsoleLogger
 } from './dap-proxy-dependencies.js';
 
 // Re-export message parser

--- a/src/utils/jvm-orphan-reaper.ts
+++ b/src/utils/jvm-orphan-reaper.ts
@@ -228,10 +228,15 @@ export function parseArgs(pid: number, args: string[]): TaggedJvm | null {
   return { pid, ownerPid, sessionTag };
 }
 
-export function isPidAlive(pid: number): boolean {
+/** Sends a signal to a pid; injectable so tests never spy the global process.kill (issue #183). */
+export type SignalFn = (pid: number, signal: NodeJS.Signals | number) => void;
+
+const defaultSignal: SignalFn = (pid, signal) => process.kill(pid, signal);
+
+export function isPidAlive(pid: number, signal: SignalFn = defaultSignal): boolean {
   if (pid <= 0) return false;
   try {
-    process.kill(pid, 0);
+    signal(pid, 0);
     return true;
   } catch (e) {
     const code = (e as NodeJS.ErrnoException).code;
@@ -243,9 +248,9 @@ export function isPidAlive(pid: number): boolean {
 }
 
 /** @internal Exposed for unit tests; not part of the public module API. */
-export function defaultKill(pid: number): boolean {
+export function defaultKill(pid: number, signal: SignalFn = defaultSignal): boolean {
   try {
-    process.kill(pid, 'SIGKILL');
+    signal(pid, 'SIGKILL');
     return true;
   } catch (e) {
     const code = (e as NodeJS.ErrnoException).code;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -50,13 +50,18 @@ const fileTransportCache = new Map<string, winston.transport>();
 
 let staleLogCleanupDone = false;
 
+/** Sends a signal to a pid; injectable so tests never spy the global process.kill (issue #183). */
+type SignalFn = (pid: number, signal: NodeJS.Signals | number) => void;
+
+const defaultSignal: SignalFn = (pid, signal) => process.kill(pid, signal);
+
 /**
  * Best-effort check whether a pid belongs to a live process.
  * EPERM means "alive but not ours" — treat as alive.
  */
-function isProcessAlive(pid: number): boolean {
+function isProcessAlive(pid: number, signal: SignalFn = defaultSignal): boolean {
   try {
-    process.kill(pid, 0);
+    signal(pid, 0);
     return true;
   } catch (err) {
     return (err as NodeJS.ErrnoException).code === 'EPERM';
@@ -76,10 +81,11 @@ function isProcessAlive(pid: number): boolean {
  */
 export function cleanupStaleLogFiles(
   logDir: string,
-  opts: { maxAgeMs?: number; now?: number } = {}
+  opts: { maxAgeMs?: number; now?: number; signal?: SignalFn } = {}
 ): void {
   const maxAgeMs = opts.maxAgeMs ?? STALE_LOG_MAX_AGE_MS;
   const now = opts.now ?? Date.now();
+  const signal = opts.signal ?? defaultSignal;
 
   let entries: string[];
   try {
@@ -94,7 +100,7 @@ export function cleanupStaleLogFiles(
       continue;
     }
     const pid = Number(match[1]);
-    if (pid === process.pid || isProcessAlive(pid)) {
+    if (pid === process.pid || isProcessAlive(pid, signal)) {
       continue;
     }
     const fullPath = path.join(logDir, name);

--- a/tests/adapters/ruby/unit/adapter-policy-ruby.test.ts
+++ b/tests/adapters/ruby/unit/adapter-policy-ruby.test.ts
@@ -250,15 +250,9 @@ describe('getPolicyForLanguage', () => {
 });
 
 describe('buildRdbgInvocation', () => {
-  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
   let tmpDir: string | null = null;
 
-  const setPlatform = (platform: string) => {
-    Object.defineProperty(process, 'platform', { value: platform });
-  };
-
   afterEach(() => {
-    Object.defineProperty(process, 'platform', originalPlatform);
     if (tmpDir) {
       fs.rmSync(tmpDir, { recursive: true, force: true });
       tmpDir = null;
@@ -266,30 +260,27 @@ describe('buildRdbgInvocation', () => {
   });
 
   it('passes through unchanged on non-Windows platforms', () => {
-    setPlatform('linux');
-    expect(buildRdbgInvocation('/usr/bin/rdbg', ['--open'])).toEqual({
+    expect(buildRdbgInvocation('/usr/bin/rdbg', ['--open'], undefined, 'linux')).toEqual({
       command: '/usr/bin/rdbg',
       args: ['--open']
     });
   });
 
   it('runs the sibling rdbg script via ruby for a .bat shim (RubyInstaller layout)', () => {
-    setPlatform('win32');
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rdbg-test-'));
     const batPath = path.join(tmpDir, 'rdbg.bat');
     const scriptPath = path.join(tmpDir, 'rdbg');
     fs.writeFileSync(batPath, '@echo off');
     fs.writeFileSync(scriptPath, '#!/usr/bin/env ruby');
 
-    expect(buildRdbgInvocation(batPath, ['--open'], 'C:\\Ruby34-x64\\bin\\ruby.exe')).toEqual({
+    expect(buildRdbgInvocation(batPath, ['--open'], 'C:\\Ruby34-x64\\bin\\ruby.exe', 'win32')).toEqual({
       command: 'C:\\Ruby34-x64\\bin\\ruby.exe',
       args: [scriptPath, '--open']
     });
   });
 
   it('throws with RDBG_PATH guidance when no sibling script exists', () => {
-    setPlatform('win32');
-    expect(() => buildRdbgInvocation('rdbg.bat', ['--open', '--port', '1']))
+    expect(() => buildRdbgInvocation('rdbg.bat', ['--open', '--port', '1'], undefined, 'win32'))
       .toThrow(/Set RDBG_PATH to the rdbg Ruby script/);
   });
 });

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -96,22 +96,17 @@ describe('DapProxyWorker', () => {
   let mockDapClient: IDapClient;
   let mockMessageSender: ReturnType<typeof createMockMessageSender>;
 
-  // Guard: unit tests must NEVER call the real process.exit. The worker schedules
-  // its exit via setImmediate + setTimeout(100ms) (see handleInit's error path), so
-  // a worker built with the DEFAULT (real process.exit) hook can leak a pending
-  // timer that fires during a LATER test once `sequence.shuffle` randomizes order.
-  // Spying process.exit to a no-op for every test makes such a leak harmless; the
-  // two tests that assert on process.exit install their own spy on top. The global
-  // afterEach in tests/vitest.setup.ts (vi.restoreAllMocks) restores this each time.
-  beforeEach(() => {
-    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-  });
+  // Every worker in this file is constructed with an injected exit hook
+  // (issue #183): no test can reach the real process.exit, even via the
+  // worker's setImmediate + setTimeout(100ms) exit scheduling (see
+  // handleInit's error path), and no global process spy net is needed.
+  let workerExitSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockLogger = createMockLogger();
     mockDapClient = createMockDapClient();
     mockMessageSender = createMockMessageSender();
-    
+
     dependencies = {
       fileSystem: createMockFileSystem(),
       loggerFactory: vi.fn().mockResolvedValue(mockLogger),
@@ -121,8 +116,9 @@ describe('DapProxyWorker', () => {
       },
       messageSender: mockMessageSender
     };
-    
-    worker = new DapProxyWorker(dependencies);
+
+    workerExitSpy = vi.fn();
+    worker = new DapProxyWorker(dependencies, { exit: workerExitSpy });
   });
 
   afterEach(async () => {
@@ -1066,7 +1062,7 @@ describe('DapProxyWorker', () => {
       await worker.handleCommand(initPayload);
 
       // Reset state to allow DAP commands (but still not connected)
-      worker = new DapProxyWorker(dependencies);
+      worker = new DapProxyWorker(dependencies, { exit: workerExitSpy });
 
       const dapPayload: DapCommandPayload = {
         cmd: 'dap',
@@ -1091,7 +1087,7 @@ describe('DapProxyWorker', () => {
 
     it('should reject commands when shutting down', async () => {
       // Create a new worker and manually set it up in a connected state
-      const testWorker = new DapProxyWorker(dependencies);
+      const testWorker = new DapProxyWorker(dependencies, { exit: vi.fn() });
       
       // Manually set up the worker state
       (testWorker as any).state = ProxyState.CONNECTED;
@@ -1220,7 +1216,7 @@ describe('DapProxyWorker', () => {
   describe('JavaScript Adapter Command Queueing', () => {
     it('should queue commands for JavaScript adapter', async () => {
       // Create a fresh worker in initialized state but not connected
-      let jsWorker = new DapProxyWorker(dependencies);
+      let jsWorker = new DapProxyWorker(dependencies, { exit: vi.fn() });
       // Set up JavaScript policy detection
       const jsInitPayload: ProxyInitPayload = {
         cmd: 'init',
@@ -1236,18 +1232,12 @@ describe('DapProxyWorker', () => {
         }
       };
       
-      // Mock process.exit to avoid test termination
-      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-      
       try {
         // This will fail to connect but will set up JS policy
         await jsWorker.handleCommand(jsInitPayload);
       } catch {
         // Expected to fail - that's okay
       }
-      
-      // Restore process.exit
-      exitSpy.mockRestore();
 
       // Now send a command - it should be queued for JavaScript adapter
       await jsWorker.handleCommand({
@@ -1441,21 +1431,17 @@ describe('DapProxyWorker', () => {
         executablePath: 'python'
       };
 
-      // Mock process.exit to prevent test from actually exiting
-      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
       await worker.handleCommand(payload);
 
       // Advance past the setImmediate + setTimeout(100ms) IPC flush pattern
       await vi.advanceTimersByTimeAsync(200);
 
-      // Verify that process.exit was called with error code
+      // Verify that the exit hook was called with error code
       // This is the key behavior - critical errors during init cause process exit
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(workerExitSpy).toHaveBeenCalledWith(1);
 
       // Note: Logger won't be called since it's created AFTER ensureDir, which is what's failing
 
-      exitSpy.mockRestore();
       vi.useRealTimers();
     });
 

--- a/tests/test-utils/mocks/fake-current-process.ts
+++ b/tests/test-utils/mocks/fake-current-process.ts
@@ -1,0 +1,82 @@
+/**
+ * Fake of the CURRENT process handle (ProcessLike) for unit tests — issue #183.
+ *
+ * EventEmitter-backed, so production code's proc.on(...) attaches listeners to
+ * THIS object, never to the real global process: tests drive lifecycle events
+ * with fakeProc.emit(...) and nothing can leak into the vitest fork worker
+ * (issue #159). Not to be confused with FakeProcess in
+ * tests/implementations/test/fake-process-launcher.ts, which models a spawned
+ * CHILD process (IProcess).
+ */
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { vi, type Mock } from 'vitest';
+import type { ProcessLike } from '../../../src/interfaces/process-interfaces.js';
+
+export class FakeCurrentProcess extends EventEmitter implements ProcessLike {
+  /** Recording exit mock — never terminates anything. Assert with expect(fakeProc.exit).toHaveBeenCalledWith(n). */
+  public exit: Mock<(code?: number) => void> = vi.fn();
+
+  /**
+   * IPC send. Defaults to a recording mock returning true (IPC available).
+   * Set to undefined (or call disableIPC()) to model "spawned without IPC".
+   */
+  public send?: Mock<(message: unknown) => boolean> = vi.fn(() => true);
+
+  public connected = true;
+  public env: NodeJS.ProcessEnv = {};
+  public argv: string[] = ['/usr/bin/node', '/fake/dap-proxy-entry.js'];
+  public uptime: Mock<() => number> = vi.fn(() => 0);
+
+  public stdin = new PassThrough();
+  public stdout = new PassThrough();
+
+  /** Everything written to stdout, decoded as utf8, in write order. */
+  public readonly stdoutChunks: string[] = [];
+
+  constructor() {
+    super();
+    this.stdout.on('data', (chunk: Buffer) => this.stdoutChunks.push(chunk.toString('utf8')));
+  }
+
+  /** Fresh live IPC channel: new recording send mock, connected = true. */
+  enableIPC(): this {
+    this.send = vi.fn(() => true);
+    this.connected = true;
+    return this;
+  }
+
+  /** No IPC channel: send undefined, connected = false. */
+  disableIPC(): this {
+    this.send = undefined;
+    this.connected = false;
+    return this;
+  }
+
+  /** Broken IPC channel: send throws (e.g. ERR_IPC_CHANNEL_CLOSED). */
+  failSendWith(error: Error): this {
+    this.send = vi.fn(() => {
+      throw error;
+    });
+    this.connected = false;
+    return this;
+  }
+
+  /** Payloads passed to send() so far (empty when IPC is disabled). */
+  get sentMessages(): unknown[] {
+    return this.send ? this.send.mock.calls.map((c) => c[0]) : [];
+  }
+
+  /** Last listener registered for an event — for tests that must await an async handler. */
+  lastListener(event: string): (...args: unknown[]) => unknown {
+    const ls = this.listeners(event);
+    if (ls.length === 0) {
+      throw new Error(`No '${event}' listener registered on FakeCurrentProcess`);
+    }
+    return ls[ls.length - 1] as (...args: unknown[]) => unknown;
+  }
+}
+
+export function createFakeCurrentProcess(): FakeCurrentProcess {
+  return new FakeCurrentProcess();
+}

--- a/tests/unit/cli/error-handlers.test.ts
+++ b/tests/unit/cli/error-handlers.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setupErrorHandlers } from '../../../src/cli/error-handlers.js';
+import { FakeCurrentProcess } from '../../test-utils/mocks/fake-current-process.js';
 import type { Logger as WinstonLoggerType } from 'winston';
 
 describe('Error Handlers', () => {
   let mockLogger: WinstonLoggerType;
   let mockExitProcess: ReturnType<typeof vi.fn>;
-  let originalProcessOn: typeof process.on;
-  let processListeners: Map<string, Function[]>;
+  let fakeProc: FakeCurrentProcess;
 
   beforeEach(() => {
     // Create mock logger
@@ -21,50 +21,29 @@ describe('Error Handlers', () => {
     // Create mock exit function
     mockExitProcess = vi.fn();
 
-    // Store original process.on
-    originalProcessOn = process.on;
-    processListeners = new Map();
-
-    // Mock process.on to capture listeners
-    process.on = vi.fn((event: string, listener: Function) => {
-      if (!processListeners.has(event)) {
-        processListeners.set(event, []);
-      }
-      processListeners.get(event)!.push(listener);
-      return process;
-    }) as any;
-  });
-
-  afterEach(() => {
-    // Restore original process.on
-    process.on = originalProcessOn;
-    processListeners.clear();
+    // Handlers attach to the fake's emitter, never the real process (issue #183)
+    fakeProc = new FakeCurrentProcess();
   });
 
   it('should set up uncaughtException handler', () => {
-    setupErrorHandlers({ logger: mockLogger, exitProcess: mockExitProcess });
+    setupErrorHandlers({ logger: mockLogger, exitProcess: mockExitProcess, proc: fakeProc });
 
-    expect(process.on).toHaveBeenCalledWith('uncaughtException', expect.any(Function));
+    expect(fakeProc.listenerCount('uncaughtException')).toBe(1);
   });
 
   it('should set up unhandledRejection handler', () => {
-    setupErrorHandlers({ logger: mockLogger, exitProcess: mockExitProcess });
+    setupErrorHandlers({ logger: mockLogger, exitProcess: mockExitProcess, proc: fakeProc });
 
-    expect(process.on).toHaveBeenCalledWith('unhandledRejection', expect.any(Function));
+    expect(fakeProc.listenerCount('unhandledRejection')).toBe(1);
   });
 
   it('should handle uncaughtException by logging and exiting', () => {
-    setupErrorHandlers({ logger: mockLogger, exitProcess: mockExitProcess });
+    setupErrorHandlers({ logger: mockLogger, exitProcess: mockExitProcess, proc: fakeProc });
 
     const error = new Error('Test error');
     error.stack = 'Test stack trace';
-    const origin = 'uncaughtException';
 
-    // Get the uncaughtException handler
-    const uncaughtExceptionHandler = processListeners.get('uncaughtException')![0] as (err: Error, origin: string) => void;
-    
-    // Trigger the handler
-    uncaughtExceptionHandler(error, origin);
+    fakeProc.emit('uncaughtException', error, 'uncaughtException');
 
     // Verify logger was called with correct params
     expect(mockLogger.error).toHaveBeenCalledWith(
@@ -81,7 +60,7 @@ describe('Error Handlers', () => {
   });
 
   it('should handle unhandledRejection by logging without exiting', async () => {
-    setupErrorHandlers({ logger: mockLogger, exitProcess: mockExitProcess });
+    setupErrorHandlers({ logger: mockLogger, exitProcess: mockExitProcess, proc: fakeProc });
 
     const reason = 'Test rejection reason';
     const promise = Promise.reject(reason);
@@ -89,11 +68,7 @@ describe('Error Handlers', () => {
     // Catch the rejection to prevent unhandled rejection warning
     promise.catch(() => {});
 
-    // Get the unhandledRejection handler
-    const unhandledRejectionHandler = processListeners.get('unhandledRejection')![0] as (reason: any, promise: Promise<unknown>) => void;
-
-    // Trigger the handler
-    unhandledRejectionHandler(reason, promise);
+    fakeProc.emit('unhandledRejection', reason, promise);
 
     // Verify logger was called
     expect(mockLogger.error).toHaveBeenCalledWith('[Server UNHANDLED_REJECTION] Reason:', { reason });
@@ -103,23 +78,12 @@ describe('Error Handlers', () => {
     expect(mockExitProcess).not.toHaveBeenCalled();
   });
 
-  it('should use process.exit by default if exitProcess is not provided', () => {
-    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-    
-    setupErrorHandlers({ logger: mockLogger });
+  it('should fall back to proc.exit if exitProcess is not provided', () => {
+    setupErrorHandlers({ logger: mockLogger, proc: fakeProc });
 
-    const error = new Error('Test error');
-    const origin = 'uncaughtException';
+    fakeProc.emit('uncaughtException', new Error('Test error'), 'uncaughtException');
 
-    // Get the uncaughtException handler
-    const uncaughtExceptionHandler = processListeners.get('uncaughtException')![0] as (err: Error, origin: string) => void;
-    
-    // Trigger the handler
-    uncaughtExceptionHandler(error, origin);
-
-    // Verify process.exit was called
-    expect(processExitSpy).toHaveBeenCalledWith(1);
-
-    processExitSpy.mockRestore();
+    // Verify the injected process handle's exit was called
+    expect(fakeProc.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/tests/unit/cli/http-command.test.ts
+++ b/tests/unit/cli/http-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { EventEmitter } from 'events';
 import { createHttpApp, handleHttpCommand } from '../../../src/cli/http-command.js';
+import { FakeCurrentProcess } from '../../test-utils/mocks/fake-current-process.js';
 import type { Logger as WinstonLoggerType } from 'winston';
 import { DebugMcpServer } from '../../../src/server.js';
 
@@ -19,7 +20,7 @@ describe('HTTP Command Handler', () => {
   let mockExitProcess: ReturnType<typeof vi.fn>;
   let mockServer: DebugMcpServer;
   let mockTransport: any;
-  let originalProcessOn: typeof process.on;
+  let fakeProc: FakeCurrentProcess;
   let mockApp: any;
 
   // Track transports created so tests can drive them
@@ -45,7 +46,9 @@ describe('HTTP Command Handler', () => {
 
     mockServerFactory = vi.fn().mockReturnValue(mockServer);
     mockExitProcess = vi.fn();
-    originalProcessOn = process.on;
+    // Signal handlers attach to the fake's emitter, never the real process
+    // (issues #159/#183).
+    fakeProc = new FakeCurrentProcess();
 
     createdTransports = [];
 
@@ -86,7 +89,6 @@ describe('HTTP Command Handler', () => {
   });
 
   afterEach(() => {
-    process.on = originalProcessOn;
     vi.unstubAllEnvs();
     vi.clearAllTimers();
     vi.useRealTimers();
@@ -396,11 +398,9 @@ describe('HTTP Command Handler', () => {
       });
       mockApp.listen = listen;
 
-      process.on = vi.fn() as any;
-
       await handleHttpCommand(
         { port: '4000', logLevel: 'debug' },
-        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess }
+        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, proc: fakeProc }
       );
 
       expect(mockLogger.level).toBe('debug');
@@ -409,8 +409,8 @@ describe('HTTP Command Handler', () => {
         expect.stringContaining('http://localhost:4000/mcp')
       );
       expect(mockExitProcess).not.toHaveBeenCalled();
-      expect(process.on).toHaveBeenCalledWith('SIGINT', expect.any(Function));
-      expect(process.on).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+      expect(fakeProc.listenerCount('SIGINT')).toBe(1);
+      expect(fakeProc.listenerCount('SIGTERM')).toBe(1);
     });
 
     it('exits with code 1 when the app cannot be created', async () => {
@@ -429,21 +429,19 @@ describe('HTTP Command Handler', () => {
     });
 
     it('handles SIGINT by closing all transports, stopping all servers, then exiting', async () => {
-      let sigintHandler: Function = () => {};
       const listen = vi.fn((_port: number, cb: Function) => {
         cb();
         return mockHttpServer;
       });
       mockApp.listen = listen;
 
-      process.on = vi.fn((event: string, handler: Function) => {
-        if (event === 'SIGINT') sigintHandler = handler;
-      }) as any;
-
       await handleHttpCommand(
         { port: '3001' },
-        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess }
+        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, proc: fakeProc }
       );
+
+      // gracefulShutdown is async — grab the registered listener so it can be awaited
+      const sigintHandler = fakeProc.lastListener('SIGINT');
 
       // Inject mock sessions
       const t1 = { close: vi.fn() };
@@ -479,16 +477,15 @@ describe('HTTP Command Handler', () => {
           cb();
           return mockHttpServer;
         });
-        process.on = vi.fn() as any;
       });
 
       it('shuts down gracefully and exits 0 when stdin ends and the env gate is set', async () => {
-        vi.stubEnv('MCP_EXIT_ON_STDIN_CLOSE', '1');
+        fakeProc.env.MCP_EXIT_ON_STDIN_CLOSE = '1';
         const stdin = makeFakeStdin();
 
         await handleHttpCommand(
           { port: '3001' },
-          { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, stdin }
+          { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, stdin, proc: fakeProc }
         );
 
         // The watchdog must resume stdin so EOF is actually observed
@@ -508,12 +505,12 @@ describe('HTTP Command Handler', () => {
       });
 
       it('shuts down only once when end and close both fire', async () => {
-        vi.stubEnv('MCP_EXIT_ON_STDIN_CLOSE', '1');
+        fakeProc.env.MCP_EXIT_ON_STDIN_CLOSE = '1';
         const stdin = makeFakeStdin();
 
         await handleHttpCommand(
           { port: '3001' },
-          { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, stdin }
+          { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, stdin, proc: fakeProc }
         );
 
         stdin.emit('end');
@@ -529,7 +526,7 @@ describe('HTTP Command Handler', () => {
 
         await handleHttpCommand(
           { port: '3001' },
-          { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, stdin }
+          { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, stdin, proc: fakeProc }
         );
 
         expect(stdin.resume).not.toHaveBeenCalled();
@@ -551,11 +548,10 @@ describe('HTTP Command Handler', () => {
       mockHttpServer.on = vi.fn((event: string, handler: Function) => {
         if (event === 'error') errorHandler = handler;
       });
-      process.on = vi.fn() as any;
 
       await handleHttpCommand(
         { port: '3001' },
-        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess }
+        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, proc: fakeProc }
       );
 
       const err = Object.assign(new Error('addr in use'), { code: 'EADDRINUSE' });

--- a/tests/unit/cli/sse-command.test.ts
+++ b/tests/unit/cli/sse-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import express from 'express';
 import { createSSEApp, handleSSECommand } from '../../../src/cli/sse-command.js';
+import { FakeCurrentProcess } from '../../test-utils/mocks/fake-current-process.js';
 import type { Logger as WinstonLoggerType } from 'winston';
 import { DebugMcpServer } from '../../../src/server.js';
 import { EventEmitter } from 'events';
@@ -20,7 +21,7 @@ describe('SSE Command Handler', () => {
   let mockExitProcess: ReturnType<typeof vi.fn>;
   let mockServer: DebugMcpServer;
   let mockTransport: any;
-  let originalProcessOn: typeof process.on;
+  let fakeProc: FakeCurrentProcess;
 
   beforeEach(() => {
     // Create mock logger
@@ -47,8 +48,9 @@ describe('SSE Command Handler', () => {
     // Create mock exit function
     mockExitProcess = vi.fn();
 
-    // Store original process.on
-    originalProcessOn = process.on;
+    // Signal handlers attach to the fake's emitter, never the real process
+    // (issues #159/#183).
+    fakeProc = new FakeCurrentProcess();
 
     // Setup mock transport
     MockedSSEServerTransport.mockImplementation(function(path: string, res: any) {
@@ -72,8 +74,6 @@ describe('SSE Command Handler', () => {
   });
 
   afterEach(() => {
-    // Restore original process.on
-    process.on = originalProcessOn;
     // Clear all timers
     vi.clearAllTimers();
     vi.useRealTimers();
@@ -615,13 +615,11 @@ describe('SSE Command Handler', () => {
         sseTransports: new Map()
       } as any);
 
-      // Mock process.on to prevent actual signal handlers
-      process.on = vi.fn() as any;
-
       await handleSSECommand(options, {
         logger: mockLogger,
         serverFactory: mockServerFactory,
-        exitProcess: mockExitProcess
+        exitProcess: mockExitProcess,
+        proc: fakeProc
       });
 
       // Verify log level was set
@@ -635,15 +633,15 @@ describe('SSE Command Handler', () => {
       // Verify server listen was called
       expect(mockListen).toHaveBeenCalledWith(4000, expect.any(Function));
 
-      // Verify SIGINT handler was registered
-      expect(process.on).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+      // Verify SIGINT handler was registered on the injected handle
+      expect(fakeProc.listenerCount('SIGINT')).toBe(1);
 
       // Verify process did not exit
       expect(mockExitProcess).not.toHaveBeenCalled();
     });
 
     it('shuts down gracefully when stdin ends and MCP_EXIT_ON_STDIN_CLOSE=1 (issue #122)', async () => {
-      vi.stubEnv('MCP_EXIT_ON_STDIN_CLOSE', '1');
+      fakeProc.env.MCP_EXIT_ON_STDIN_CLOSE = '1';
 
       const httpServer = {
         close: vi.fn((cb?: Function) => cb && cb()),
@@ -659,7 +657,6 @@ describe('SSE Command Handler', () => {
         post: vi.fn(),
         listen: mockListen
       } as any);
-      process.on = vi.fn() as any;
 
       const stdin = new EventEmitter() as unknown as NodeJS.ReadStream & {
         resume: ReturnType<typeof vi.fn>;
@@ -671,7 +668,8 @@ describe('SSE Command Handler', () => {
         logger: mockLogger,
         serverFactory: mockServerFactory,
         exitProcess: mockExitProcess,
-        stdin
+        stdin,
+        proc: fakeProc
       });
 
       expect(stdin.resume).toHaveBeenCalled();
@@ -684,8 +682,6 @@ describe('SSE Command Handler', () => {
       const sharedDebugServer = mockServerFactory.mock.results[0].value;
       expect(sharedDebugServer.stop).toHaveBeenCalled();
       expect(httpServer.close).toHaveBeenCalled();
-
-      vi.unstubAllEnvs();
     });
 
     it('should handle server start failure', async () => {
@@ -730,13 +726,11 @@ describe('SSE Command Handler', () => {
         sseTransports: new Map()
       } as any);
 
-      // Mock process.on
-      process.on = vi.fn() as any;
-
       await handleSSECommand(options, {
         logger: mockLogger,
         serverFactory: mockServerFactory,
-        exitProcess: mockExitProcess
+        exitProcess: mockExitProcess,
+        proc: fakeProc
       });
 
       // Verify listen was called with integer port
@@ -745,7 +739,6 @@ describe('SSE Command Handler', () => {
 
     it('should handle SIGINT for graceful shutdown', async () => {
       const options = { port: '3001' };
-      let sigintHandler: Function = () => {};
 
       // Create mock app with sseTransports
       const mockApp = {
@@ -762,18 +755,15 @@ describe('SSE Command Handler', () => {
 
       vi.mocked(express).mockReturnValue(mockApp as any);
 
-      // Capture SIGINT handler
-      process.on = vi.fn((event, handler) => {
-        if (event === 'SIGINT') {
-          sigintHandler = handler as Function;
-        }
-      }) as any;
-
       await handleSSECommand(options, {
         logger: mockLogger,
         serverFactory: mockServerFactory,
-        exitProcess: mockExitProcess
+        exitProcess: mockExitProcess,
+        proc: fakeProc
       });
+
+      // gracefulShutdown is async — grab the registered listener so it can be awaited
+      const sigintHandler = fakeProc.lastListener('SIGINT');
 
       // Add some mock sessions
       const mockSession1 = { transport: { close: vi.fn() } };
@@ -801,10 +791,9 @@ describe('SSE Command Handler', () => {
       expect(mockExitProcess).toHaveBeenCalledWith(0);
     });
 
-    it('should use process.exit by default if exitProcess is not provided', async () => {
-      const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    it('should fall back to proc.exit if exitProcess is not provided', async () => {
       const error = new Error('Server start failed');
-      
+
       // Mock express to throw error
       vi.mocked(express).mockImplementation(() => {
         throw error;
@@ -812,13 +801,12 @@ describe('SSE Command Handler', () => {
 
       await handleSSECommand({ port: '3001' }, {
         logger: mockLogger,
-        serverFactory: mockServerFactory
+        serverFactory: mockServerFactory,
+        proc: fakeProc
       });
 
-      // Verify process.exit was called
-      expect(processExitSpy).toHaveBeenCalledWith(1);
-
-      processExitSpy.mockRestore();
+      // Verify the injected process handle's exit was called
+      expect(fakeProc.exit).toHaveBeenCalledWith(1);
     });
 
     it('should not change log level if not provided', async () => {
@@ -838,12 +826,11 @@ describe('SSE Command Handler', () => {
         sseTransports: new Map()
       } as any);
 
-      process.on = vi.fn() as any;
-
       await handleSSECommand(options, {
         logger: mockLogger,
         serverFactory: mockServerFactory,
-        exitProcess: mockExitProcess
+        exitProcess: mockExitProcess,
+        proc: fakeProc
       });
 
       // Verify log level was not changed

--- a/tests/unit/cli/stdio-command.test.ts
+++ b/tests/unit/cli/stdio-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { handleStdioCommand } from '../../../src/cli/stdio-command.js';
+import { FakeCurrentProcess } from '../../test-utils/mocks/fake-current-process.js';
 import type { Logger as WinstonLoggerType } from 'winston';
 import { DebugMcpServer } from '../../../src/server.js';
 
@@ -11,8 +12,7 @@ describe('STDIO Command Handler', () => {
   let mockServerFactory: ReturnType<typeof vi.fn>;
   let mockExitProcess: ReturnType<typeof vi.fn>;
   let mockServer: DebugMcpServer;
-  const originalProcessOn = process.on;
-  let capturedProcessListeners: Map<string, Function[]>;
+  let fakeProc: FakeCurrentProcess;
 
   function makeFakeStdin() {
     const stdin = new EventEmitter() as unknown as NodeJS.ReadStream & {
@@ -48,25 +48,15 @@ describe('STDIO Command Handler', () => {
     // Create mock exit function
     mockExitProcess = vi.fn();
 
-    // Capture process listeners WITHOUT attaching them (issue #159): a
-    // successful handleStdioCommand registers real SIGTERM/SIGINT/exit
-    // listeners that would otherwise leak into the vitest fork worker.
-    capturedProcessListeners = new Map();
-    process.on = vi.fn(function (this: NodeJS.Process, event: string, listener: (...args: unknown[]) => void) {
-      const list = capturedProcessListeners.get(event) ?? [];
-      list.push(listener);
-      capturedProcessListeners.set(event, list);
-      return this;
-    }) as unknown as typeof process.on;
+    // Signal/exit listeners attach to the fake's emitter, never the real
+    // process (issues #159/#183).
+    fakeProc = new FakeCurrentProcess();
   });
 
   afterEach(() => {
-    process.on = originalProcessOn;
-    // Fire captured SIGTERM handlers once: each closes over the 60s keepAlive
+    // Fire the SIGTERM handlers once: each closes over the 60s keepAlive
     // interval and clears it; the exit goes to the mocked exitProcess.
-    for (const listener of capturedProcessListeners.get('SIGTERM') ?? []) {
-      listener();
-    }
+    fakeProc.emit('SIGTERM');
   });
 
   it('should start server successfully in stdio mode', async () => {
@@ -79,7 +69,8 @@ describe('STDIO Command Handler', () => {
       logger: mockLogger,
       serverFactory: mockServerFactory,
       exitProcess: mockExitProcess,
-      stdin: makeFakeStdin()
+      stdin: makeFakeStdin(),
+      proc: fakeProc
     });
 
     // Verify log level was set
@@ -104,6 +95,31 @@ describe('STDIO Command Handler', () => {
     expect(mockExitProcess).not.toHaveBeenCalled();
   });
 
+  it('should register SIGTERM/SIGINT/exit listeners on the injected process handle', async () => {
+    await handleStdioCommand({}, {
+      logger: mockLogger,
+      serverFactory: mockServerFactory,
+      exitProcess: mockExitProcess,
+      stdin: makeFakeStdin(),
+      proc: fakeProc
+    });
+
+    expect(fakeProc.listenerCount('SIGTERM')).toBe(1);
+    expect(fakeProc.listenerCount('SIGINT')).toBe(1);
+    expect(fakeProc.listenerCount('exit')).toBe(1);
+
+    // SIGINT exits 0 through the injected exitProcess
+    fakeProc.emit('SIGINT');
+    expect(mockExitProcess).toHaveBeenCalledWith(0);
+
+    // 'exit' diagnostics read argv/env/uptime from the handle
+    fakeProc.emit('exit', 0);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[MCP] Process exiting',
+      expect.objectContaining({ code: 0, argv: fakeProc.argv, uptime: 0 })
+    );
+  });
+
   it('should not change log level if not provided in options', async () => {
     const options = {};
     mockLogger.level = 'warn';
@@ -112,7 +128,8 @@ describe('STDIO Command Handler', () => {
       logger: mockLogger,
       serverFactory: mockServerFactory,
       exitProcess: mockExitProcess,
-      stdin: makeFakeStdin()
+      stdin: makeFakeStdin(),
+      proc: fakeProc
     });
 
     // Verify log level was not changed
@@ -128,14 +145,15 @@ describe('STDIO Command Handler', () => {
   it('should handle server start failure', async () => {
     const options = {};
     const error = new Error('Server start failed');
-    
+
     // Make server.start reject
     mockServer.start = vi.fn().mockRejectedValue(error);
 
     await handleStdioCommand(options, {
       logger: mockLogger,
       serverFactory: mockServerFactory,
-      exitProcess: mockExitProcess
+      exitProcess: mockExitProcess,
+      proc: fakeProc
     });
 
     // Verify error was logged
@@ -145,22 +163,20 @@ describe('STDIO Command Handler', () => {
     expect(mockExitProcess).toHaveBeenCalledWith(1);
   });
 
-  it('should use process.exit by default if exitProcess is not provided', async () => {
-    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  it('should fall back to proc.exit if exitProcess is not provided', async () => {
     const error = new Error('Server start failed');
-    
+
     // Make server.start reject
     mockServer.start = vi.fn().mockRejectedValue(error);
 
     await handleStdioCommand({}, {
       logger: mockLogger,
-      serverFactory: mockServerFactory
+      serverFactory: mockServerFactory,
+      proc: fakeProc
     });
 
-    // Verify process.exit was called
-    expect(processExitSpy).toHaveBeenCalledWith(1);
-
-    processExitSpy.mockRestore();
+    // Verify the injected process handle's exit was called
+    expect(fakeProc.exit).toHaveBeenCalledWith(1);
   });
 
   it('should handle server factory throwing an error', async () => {
@@ -172,7 +188,8 @@ describe('STDIO Command Handler', () => {
     await handleStdioCommand({}, {
       logger: mockLogger,
       serverFactory: mockServerFactory,
-      exitProcess: mockExitProcess
+      exitProcess: mockExitProcess,
+      proc: fakeProc
     });
 
     // Verify error was logged
@@ -183,10 +200,6 @@ describe('STDIO Command Handler', () => {
   });
 
   describe('stdin EOF handling (issue #122)', () => {
-    afterEach(() => {
-      vi.unstubAllEnvs();
-    });
-
     it('exits 0 when stdin ends in host mode (MCP client disconnected)', async () => {
       const stdin = makeFakeStdin();
 
@@ -194,7 +207,8 @@ describe('STDIO Command Handler', () => {
         logger: mockLogger,
         serverFactory: mockServerFactory,
         exitProcess: mockExitProcess,
-        stdin
+        stdin,
+        proc: fakeProc
       });
 
       expect(stdin.resume).toHaveBeenCalled();
@@ -209,14 +223,15 @@ describe('STDIO Command Handler', () => {
     });
 
     it('keeps running on stdin end in container mode (MCP_CONTAINER=true)', async () => {
-      vi.stubEnv('MCP_CONTAINER', 'true');
+      fakeProc.env.MCP_CONTAINER = 'true';
       const stdin = makeFakeStdin();
 
       await handleStdioCommand({}, {
         logger: mockLogger,
         serverFactory: mockServerFactory,
         exitProcess: mockExitProcess,
-        stdin
+        stdin,
+        proc: fakeProc
       });
 
       stdin.emit('end');

--- a/tests/unit/implementations/environment-impl.test.ts
+++ b/tests/unit/implementations/environment-impl.test.ts
@@ -29,6 +29,10 @@ describe('ProcessEnvironment', () => {
   });
 
   it('returns current working directory', () => {
+    // Sanctioned boundary test (issue #183): ProcessEnvironment IS the
+    // adapter over the global process, so its delegation test legitimately
+    // spies the global. Method-level, auto-restored, listener-free — cannot
+    // trip the process-listener leak guard.
     const fakeCwd = 'C:\\fake-path';
     vi.spyOn(process, 'cwd').mockReturnValue(fakeCwd);
 

--- a/tests/unit/implementations/process-launcher-impl.test.ts
+++ b/tests/unit/implementations/process-launcher-impl.test.ts
@@ -83,15 +83,12 @@ describe('ProxyProcessLauncherImpl', () => {
     vi.stubEnv('MCP_CONTAINER', 'true');
 
     const spawnSpy = vi.spyOn(processManager, 'spawn');
-    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
 
     const launcher = new ProxyProcessLauncherImpl(processManager);
     launcher.launchProxy('./dist/proxy.js', 'session-container');
 
     const options = spawnSpy.mock.calls[0]?.[2] as any;
     expect(options.detached).toBe(false);
-
-    platformSpy.mockRestore();
   });
 
   it('reuses initialization promise for concurrent callers', async () => {

--- a/tests/unit/proxy/dap-proxy-adapter-manager.test.ts
+++ b/tests/unit/proxy/dap-proxy-adapter-manager.test.ts
@@ -308,19 +308,16 @@ describe('GenericAdapterManager', () => {
   });
 
   describe('shutdown with killProcessTree (launch mode)', () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
-
-    const setPlatform = (value: string) => {
-      Object.defineProperty(process, 'platform', { value, configurable: true });
-    };
+    // Platform is constructor-injected (issue #183) — no global mutation.
+    const makeManager = (platform: NodeJS.Platform) =>
+      new GenericAdapterManager(spawner, logger, fileSystem, platform);
 
     afterEach(() => {
-      Object.defineProperty(process, 'platform', originalPlatform);
       vi.useRealTimers();
     });
 
     it('tree-kills via taskkill while the parent is still alive on win32', async () => {
-      setPlatform('win32');
+      manager = makeManager('win32');
       vi.useFakeTimers();
 
       const proc = createMockProcess(999);
@@ -347,7 +344,7 @@ describe('GenericAdapterManager', () => {
     });
 
     it('does not kill anything when the adapter already exited (PID may be recycled)', async () => {
-      setPlatform('win32');
+      manager = makeManager('win32');
 
       const proc = createMockProcess(999);
       // Adapter honored the DAP disconnect and exited during the grace wait —
@@ -364,7 +361,7 @@ describe('GenericAdapterManager', () => {
     });
 
     it('escalates to SIGKILL when taskkill does not terminate the adapter', async () => {
-      setPlatform('win32');
+      manager = makeManager('win32');
       vi.useFakeTimers();
 
       const proc = createMockProcess(999);
@@ -378,7 +375,7 @@ describe('GenericAdapterManager', () => {
     });
 
     it('keeps the SIGTERM-first path on win32 without killProcessTree', async () => {
-      setPlatform('win32');
+      manager = makeManager('win32');
       vi.useFakeTimers();
 
       const proc = createMockProcess(999);
@@ -395,7 +392,7 @@ describe('GenericAdapterManager', () => {
     });
 
     it('keeps the SIGTERM-first path on non-win32 even with killProcessTree', async () => {
-      setPlatform('linux');
+      manager = makeManager('linux');
       vi.useFakeTimers();
 
       const proc = createMockProcess(999);

--- a/tests/unit/proxy/dap-proxy-core.test.ts
+++ b/tests/unit/proxy/dap-proxy-core.test.ts
@@ -1,10 +1,15 @@
 /**
  * Unit tests for dap-proxy-core.ts — ProxyRunner, detectExecutionMode, shouldAutoExecute
+ *
+ * All tests drive ProxyRunner through an injected FakeCurrentProcess (issue
+ * #183): no test in this file touches the global process object, so nothing
+ * can leak listeners into the vitest fork worker (issue #159).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ProxyRunner, detectExecutionMode, shouldAutoExecute } from '../../../src/proxy/dap-proxy-core.js';
 import { ProxyState } from '../../../src/proxy/dap-proxy-interfaces.js';
 import type { DapProxyDependencies, ILogger } from '../../../src/proxy/dap-proxy-interfaces.js';
+import { FakeCurrentProcess } from '../../test-utils/mocks/fake-current-process.js';
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -44,19 +49,6 @@ function createMockLogger(): ILogger {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Safety net (issue #159)                                            */
-/* ------------------------------------------------------------------ */
-
-// No code path in this file may hard-exit the fork worker: ProxyRunner.start()
-// arms a real 10s init timeout that calls process.exit(1). Describes that
-// assert on exit re-spy process.exit and get this same mock instance back.
-// Restoration is centralized in tests/vitest.setup.ts (restoreAllMocks), which
-// runs after file-local afterEach hooks have awaited runner.stop().
-beforeEach(() => {
-  vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-});
-
-/* ------------------------------------------------------------------ */
 /*  ProxyRunner                                                        */
 /* ------------------------------------------------------------------ */
 
@@ -64,41 +56,33 @@ describe('ProxyRunner', () => {
   let deps: DapProxyDependencies;
   let logger: ILogger;
   let runner: ProxyRunner;
-
-  // Save original process.send
-  const originalSend = process.send;
+  let fakeProc: FakeCurrentProcess;
 
   beforeEach(() => {
     deps = createMockDependencies();
     logger = createMockLogger();
-    // Ensure process.send is undefined so we don't accidentally set up IPC
-    delete (process as any).send;
+    // No IPC channel so we don't accidentally set up IPC (or its heartbeat)
+    fakeProc = new FakeCurrentProcess().disableIPC();
   });
 
   afterEach(async () => {
-    // Restore process.send
-    if (originalSend) {
-      process.send = originalSend;
-    } else {
-      delete (process as any).send;
-    }
     if (runner) {
       await runner.stop();
     }
   });
 
   it('constructs without errors', () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     expect(runner).toBeDefined();
   });
 
   it('getWorkerState() returns UNINITIALIZED initially', () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     expect(runner.getWorkerState()).toBe(ProxyState.UNINITIALIZED);
   });
 
   it('getWorker() returns a DapProxyWorker instance', () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     const worker = runner.getWorker();
     expect(worker).toBeDefined();
     expect(typeof worker.handleCommand).toBe('function');
@@ -107,7 +91,8 @@ describe('ProxyRunner', () => {
   it('start() sets up communication and logs ready message', async () => {
     runner = new ProxyRunner(deps, logger, {
       useIPC: false,
-      useStdin: false
+      useStdin: false,
+      proc: fakeProc
     });
     await runner.start();
 
@@ -117,19 +102,19 @@ describe('ProxyRunner', () => {
   });
 
   it('start() throws if called twice', async () => {
-    runner = new ProxyRunner(deps, logger, { useIPC: false, useStdin: false });
+    runner = new ProxyRunner(deps, logger, { useIPC: false, useStdin: false, proc: fakeProc });
     await runner.start();
     await expect(runner.start()).rejects.toThrow('already running');
   });
 
   it('stop() is idempotent when not running', async () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     // Should not throw
     await runner.stop();
   });
 
   it('stop() cleans up after start()', async () => {
-    runner = new ProxyRunner(deps, logger, { useIPC: false, useStdin: false });
+    runner = new ProxyRunner(deps, logger, { useIPC: false, useStdin: false, proc: fakeProc });
     await runner.start();
     await runner.stop();
 
@@ -144,7 +129,8 @@ describe('ProxyRunner', () => {
     runner = new ProxyRunner(deps, logger, {
       useIPC: false,
       useStdin: false,
-      onMessage
+      onMessage,
+      proc: fakeProc
     });
     await runner.start();
 
@@ -159,37 +145,23 @@ describe('ProxyRunner', () => {
 /* ------------------------------------------------------------------ */
 
 describe('detectExecutionMode', () => {
-  const originalSend = process.send;
-
-  afterEach(() => {
-    if (originalSend) {
-      process.send = originalSend;
-    } else {
-      delete (process as any).send;
-    }
-  });
-
-  it('detects IPC when process.send is a function', () => {
-    (process as any).send = vi.fn();
-    const mode = detectExecutionMode();
+  it('detects IPC when proc.send is a function', () => {
+    const mode = detectExecutionMode({ send: () => true, env: {}, argv: ['node', '/x.js'] });
     expect(mode.hasIPC).toBe(true);
   });
 
-  it('detects no IPC when process.send is undefined', () => {
-    delete (process as any).send;
-    const mode = detectExecutionMode();
+  it('detects no IPC when proc.send is undefined', () => {
+    const mode = detectExecutionMode({ env: {}, argv: ['node', '/x.js'] });
     expect(mode.hasIPC).toBe(false);
   });
 
   it('detects worker env when DAP_PROXY_WORKER=true', () => {
-    vi.stubEnv('DAP_PROXY_WORKER', 'true');
-    const mode = detectExecutionMode();
+    const mode = detectExecutionMode({ env: { DAP_PROXY_WORKER: 'true' }, argv: ['node', '/x.js'] });
     expect(mode.isWorkerEnv).toBe(true);
   });
 
   it('detects non-worker env when DAP_PROXY_WORKER is unset', () => {
-    vi.stubEnv('DAP_PROXY_WORKER', undefined);
-    const mode = detectExecutionMode();
+    const mode = detectExecutionMode({ env: {}, argv: ['node', '/x.js'] });
     expect(mode.isWorkerEnv).toBe(false);
   });
 });
@@ -224,87 +196,60 @@ describe('ProxyRunner IPC communication', () => {
   let deps: DapProxyDependencies;
   let logger: ILogger;
   let runner: ProxyRunner;
-  const originalSend = process.send;
-  const originalConnected = Object.getOwnPropertyDescriptor(process, 'connected');
+  let fakeProc: FakeCurrentProcess;
 
   beforeEach(() => {
     deps = createMockDependencies();
     logger = createMockLogger();
+    fakeProc = new FakeCurrentProcess(); // IPC enabled, connected
   });
 
   afterEach(async () => {
     if (runner) {
       await runner.stop();
     }
-    if (originalSend) {
-      process.send = originalSend;
-    } else {
-      delete (process as any).send;
-    }
-    if (originalConnected) {
-      Object.defineProperty(process, 'connected', originalConnected);
-    }
   });
 
-  it('sets up IPC when process.send is available', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
-    const processOnSpy = vi.spyOn(process, 'on');
-
-    runner = new ProxyRunner(deps, logger, { useIPC: true });
+  it('sets up IPC when proc.send is available', async () => {
+    runner = new ProxyRunner(deps, logger, { useIPC: true, proc: fakeProc });
     await runner.start();
 
-    const registeredEvents = processOnSpy.mock.calls.map(([event]) => event);
-    expect(registeredEvents).toContain('message');
-    expect(registeredEvents).toContain('disconnect');
-    expect(registeredEvents).toContain('error');
-
-    processOnSpy.mockRestore();
+    expect(fakeProc.listenerCount('message')).toBe(1);
+    expect(fakeProc.listenerCount('disconnect')).toBe(1);
+    expect(fakeProc.listenerCount('error')).toBe(1);
   });
 
   it('IPC message handler processes string messages', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
     const onMessage = vi.fn().mockResolvedValue(undefined);
 
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage, proc: fakeProc });
     await runner.start();
 
-    // Extract the message handler registered on process.on('message')
-    // The handler is already registered. Find it by getting all 'message' listeners.
-    const messageListeners = process.listeners('message');
-    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
-    expect(ipcHandler).toBeDefined();
+    const ipcHandler = fakeProc.lastListener('message');
 
     await ipcHandler('{"cmd":"init","sessionId":"test-1"}');
     expect(onMessage).toHaveBeenCalledWith('{"cmd":"init","sessionId":"test-1"}');
   });
 
   it('IPC message handler stringifies object messages', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
     const onMessage = vi.fn().mockResolvedValue(undefined);
 
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage, proc: fakeProc });
     await runner.start();
 
-    const messageListeners = process.listeners('message');
-    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
+    const ipcHandler = fakeProc.lastListener('message');
 
     await ipcHandler({ cmd: 'init', sessionId: 'test-2' });
     expect(onMessage).toHaveBeenCalledWith(JSON.stringify({ cmd: 'init', sessionId: 'test-2' }));
   });
 
   it('never logs adapter env values from IPC messages (issue #146)', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
     const onMessage = vi.fn().mockResolvedValue(undefined);
 
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage, proc: fakeProc });
     await runner.start();
 
-    const messageListeners = process.listeners('message');
-    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
+    const ipcHandler = fakeProc.lastListener('message');
 
     await ipcHandler({
       cmd: 'init',
@@ -327,15 +272,12 @@ describe('ProxyRunner IPC communication', () => {
   });
 
   it('never logs launchConfig env values from IPC messages (issue #146 family)', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
     const onMessage = vi.fn().mockResolvedValue(undefined);
 
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage, proc: fakeProc });
     await runner.start();
 
-    const messageListeners = process.listeners('message');
-    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
+    const ipcHandler = fakeProc.lastListener('message');
 
     await ipcHandler({
       cmd: 'init',
@@ -357,15 +299,12 @@ describe('ProxyRunner IPC communication', () => {
   });
 
   it('never logs adapter env values when message processing fails (issue #146)', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
     const onMessage = vi.fn().mockRejectedValue(new Error('processing failed'));
 
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage, proc: fakeProc });
     await runner.start();
 
-    const messageListeners = process.listeners('message');
-    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
+    const ipcHandler = fakeProc.lastListener('message');
 
     await ipcHandler({
       cmd: 'init',
@@ -388,14 +327,10 @@ describe('ProxyRunner IPC communication', () => {
   });
 
   it('IPC message handler warns on unexpected message type', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
-
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn() });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn(), proc: fakeProc });
     await runner.start();
 
-    const messageListeners = process.listeners('message');
-    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
+    const ipcHandler = fakeProc.lastListener('message');
 
     await ipcHandler(12345);
     expect(logger.warn).toHaveBeenCalledWith(
@@ -406,56 +341,36 @@ describe('ProxyRunner IPC communication', () => {
   });
 
   it('IPC message handler sends heartbeat acknowledgement', async () => {
-    const fakeSend = vi.fn();
-    (process as any).send = fakeSend;
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
-
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn().mockResolvedValue(undefined) });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn().mockResolvedValue(undefined), proc: fakeProc });
     await runner.start();
 
     // Reset send to count only message-triggered heartbeats
-    fakeSend.mockClear();
+    fakeProc.send!.mockClear();
 
-    const messageListeners = process.listeners('message');
-    const ipcHandler = messageListeners[messageListeners.length - 1] as Function;
+    const ipcHandler = fakeProc.lastListener('message');
 
     await ipcHandler('{"cmd":"ping"}');
-    // process.send should have been called with a heartbeat
-    expect(fakeSend).toHaveBeenCalledWith(
+    expect(fakeProc.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'ipc-heartbeat' })
     );
   });
 
   it('disconnect handler triggers worker shutdown and process exit', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn() });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn(), proc: fakeProc });
     await runner.start();
 
-    const disconnectListeners = process.listeners('disconnect');
-    const disconnectHandler = disconnectListeners[disconnectListeners.length - 1] as Function;
-    expect(disconnectHandler).toBeDefined();
-
-    disconnectHandler();
+    fakeProc.emit('disconnect');
     // Allow .finally() microtask to run
     await new Promise(r => setTimeout(r, 10));
 
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(fakeProc.exit).toHaveBeenCalledWith(0);
   });
 
   it('error handler logs IPC channel error', async () => {
-    (process as any).send = vi.fn();
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
-
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn() });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn(), proc: fakeProc });
     await runner.start();
 
-    const errorListeners = process.listeners('error');
-    const errorHandler = errorListeners[errorListeners.length - 1] as Function;
-
-    errorHandler(new Error('IPC broken'));
+    fakeProc.emit('error', new Error('IPC broken'));
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('IPC channel error'),
       expect.any(Error)
@@ -471,27 +386,22 @@ describe('ProxyRunner stdin communication', () => {
   let deps: DapProxyDependencies;
   let logger: ILogger;
   let runner: ProxyRunner;
-  const originalSend = process.send;
+  let fakeProc: FakeCurrentProcess;
 
   beforeEach(() => {
     deps = createMockDependencies();
     logger = createMockLogger();
-    delete (process as any).send;
+    fakeProc = new FakeCurrentProcess().disableIPC();
   });
 
   afterEach(async () => {
     if (runner) {
       await runner.stop();
     }
-    if (originalSend) {
-      process.send = originalSend;
-    } else {
-      delete (process as any).send;
-    }
   });
 
   it('sets up stdin/readline when IPC is not available', async () => {
-    runner = new ProxyRunner(deps, logger, { useStdin: true });
+    runner = new ProxyRunner(deps, logger, { useStdin: true, proc: fakeProc });
     await runner.start();
 
     expect(logger.info).toHaveBeenCalledWith(
@@ -500,15 +410,12 @@ describe('ProxyRunner stdin communication', () => {
   });
 
   it('shuts down and exits when stdin closes while running', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-    runner = new ProxyRunner(deps, logger, { useStdin: true, onMessage: vi.fn() });
+    runner = new ProxyRunner(deps, logger, { useStdin: true, onMessage: vi.fn(), proc: fakeProc });
     await runner.start();
     const shutdownSpy = vi.spyOn(runner.getWorker(), 'shutdown');
 
     // Simulate parent death: stdin EOF closes the readline interface
-    const rl = (runner as unknown as { rl: { emit: (event: string) => void } }).rl;
-    rl.emit('close');
+    fakeProc.stdin.end();
     // Allow the async stop() chain and .finally() to run
     await new Promise(r => setTimeout(r, 10));
 
@@ -516,20 +423,18 @@ describe('ProxyRunner stdin communication', () => {
       expect.stringContaining('stdin closed')
     );
     expect(shutdownSpy).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(fakeProc.exit).toHaveBeenCalledWith(0);
   });
 
   it('stop() closing the stdin interface does not exit the process', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-    runner = new ProxyRunner(deps, logger, { useStdin: true, onMessage: vi.fn() });
+    runner = new ProxyRunner(deps, logger, { useStdin: true, onMessage: vi.fn(), proc: fakeProc });
     await runner.start();
     await runner.stop();
 
     // Allow any readline 'close' handler triggered by stop() to run
     await new Promise(r => setTimeout(r, 10));
 
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(fakeProc.exit).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalledWith(
       expect.stringContaining('stdin closed')
     );
@@ -544,13 +449,13 @@ describe('ProxyRunner heartbeat and init timeout', () => {
   let deps: DapProxyDependencies;
   let logger: ILogger;
   let runner: ProxyRunner;
-  const originalSend = process.send;
-  const originalConnected = Object.getOwnPropertyDescriptor(process, 'connected');
+  let fakeProc: FakeCurrentProcess;
 
   beforeEach(() => {
     vi.useFakeTimers();
     deps = createMockDependencies();
     logger = createMockLogger();
+    fakeProc = new FakeCurrentProcess();
   });
 
   afterEach(async () => {
@@ -558,48 +463,29 @@ describe('ProxyRunner heartbeat and init timeout', () => {
     if (runner) {
       await runner.stop();
     }
-    if (originalSend) {
-      process.send = originalSend;
-    } else {
-      delete (process as any).send;
-    }
-    if (originalConnected) {
-      Object.defineProperty(process, 'connected', originalConnected);
-    }
   });
 
   it('sends heartbeat tick every 5 seconds when IPC is available', async () => {
-    const fakeSend = vi.fn();
-    (process as any).send = fakeSend;
-    Object.defineProperty(process, 'connected', { value: true, configurable: true });
-    // Mock process.exit to prevent init timeout from killing the process
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn() });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn(), proc: fakeProc });
     await runner.start();
-    fakeSend.mockClear();
+    fakeProc.send!.mockClear();
 
     vi.advanceTimersByTime(5000);
-    expect(fakeSend).toHaveBeenCalledWith(
+    expect(fakeProc.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'ipc-heartbeat-tick', counter: 1 })
     );
 
-    fakeSend.mockClear();
+    fakeProc.send!.mockClear();
     vi.advanceTimersByTime(5000);
-    expect(fakeSend).toHaveBeenCalledWith(
+    expect(fakeProc.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'ipc-heartbeat-tick', counter: 2 })
     );
   });
 
   it('shuts down and exits(1) when heartbeat tick send fails', async () => {
-    const fakeSend = vi.fn(() => {
-      throw new Error('ERR_IPC_CHANNEL_CLOSED: Channel closed');
-    });
-    (process as any).send = fakeSend;
-    Object.defineProperty(process, 'connected', { value: false, configurable: true });
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    fakeProc.failSendWith(new Error('ERR_IPC_CHANNEL_CLOSED: Channel closed'));
 
-    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn() });
+    runner = new ProxyRunner(deps, logger, { useIPC: true, onMessage: vi.fn(), proc: fakeProc });
     await runner.start();
     const shutdownSpy = vi.spyOn(runner.getWorker(), 'shutdown');
 
@@ -611,37 +497,35 @@ describe('ProxyRunner heartbeat and init timeout', () => {
       expect.any(Error)
     );
     expect(shutdownSpy).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fakeProc.exit).toHaveBeenCalledWith(1);
 
     // stop() cleared the interval (and init timeout): no further exits
-    exitSpy.mockClear();
+    fakeProc.exit.mockClear();
     await vi.advanceTimersByTimeAsync(15000);
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(fakeProc.exit).not.toHaveBeenCalled();
   });
 
   it('init timeout fires after 10 seconds', async () => {
-    delete (process as any).send;
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    fakeProc.disableIPC();
 
-    runner = new ProxyRunner(deps, logger, { useIPC: false, useStdin: false });
+    runner = new ProxyRunner(deps, logger, { useIPC: false, useStdin: false, proc: fakeProc });
     await runner.start();
 
     vi.advanceTimersByTime(10000);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fakeProc.exit).toHaveBeenCalledWith(1);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('No initialization received')
     );
   });
 
   it('init timeout does not fire before 10 seconds', async () => {
-    delete (process as any).send;
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    fakeProc.disableIPC();
 
-    runner = new ProxyRunner(deps, logger, { useIPC: false, useStdin: false });
+    runner = new ProxyRunner(deps, logger, { useIPC: false, useStdin: false, proc: fakeProc });
     await runner.start();
 
     vi.advanceTimersByTime(9999);
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(fakeProc.exit).not.toHaveBeenCalled();
   });
 });
 
@@ -653,120 +537,84 @@ describe('ProxyRunner.setupGlobalErrorHandlers', () => {
   let deps: DapProxyDependencies;
   let logger: ILogger;
   let runner: ProxyRunner;
-  const originalSend = process.send;
-  let processOnSpy: ReturnType<typeof vi.spyOn>;
-  let exitSpy: ReturnType<typeof vi.spyOn>;
-  let capturedHandlers: Record<string, Function>;
-  const guardedEvents = ['uncaughtException', 'unhandledRejection', 'SIGTERM', 'SIGINT'] as const;
-  let listenerBaseline: Map<string, Function[]>;
+  let fakeProc: FakeCurrentProcess;
 
   beforeEach(() => {
     deps = createMockDependencies();
     logger = createMockLogger();
-    delete (process as any).send;
-    listenerBaseline = new Map(
-      guardedEvents.map((event) => [event, process.rawListeners(event) as Function[]])
-    );
-    // Capture handlers WITHOUT attaching them: a real uncaughtException /
-    // SIGTERM listener that outlives the test calls process.exit() and can
-    // hard-kill the vitest fork worker (issue #159).
-    capturedHandlers = {};
-    processOnSpy = vi.spyOn(process, 'on').mockImplementation(function (this: any, event: string, fn: any) {
-      capturedHandlers[event] = fn;
-      return this;
-    });
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-  });
-
-  afterEach(async () => {
-    processOnSpy.mockRestore();
-    exitSpy.mockRestore();
-    // Belt-and-braces: remove anything that still reached the real process.
-    for (const event of guardedEvents) {
-      const evt: string = event;
-      const baseline = listenerBaseline.get(evt) ?? [];
-      for (const listener of process.rawListeners(evt)) {
-        if (!baseline.includes(listener as Function)) {
-          process.removeListener(evt, listener as (...args: unknown[]) => void);
-        }
-      }
-    }
-    if (originalSend) {
-      process.send = originalSend;
-    } else {
-      delete (process as any).send;
-    }
+    // Handlers attach to the fake's emitter — nothing can reach the real
+    // process, so no capture/baseline apparatus is needed (issues #159/#183).
+    fakeProc = new FakeCurrentProcess().disableIPC();
   });
 
   it('registers handlers for uncaughtException, unhandledRejection, SIGTERM, SIGINT', () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     const shutdownFn = vi.fn().mockResolvedValue(undefined);
     const getSessionId = vi.fn().mockReturnValue(null);
 
     runner.setupGlobalErrorHandlers(shutdownFn, getSessionId);
 
-    const events = processOnSpy.mock.calls.map(([event]) => event);
-    expect(events).toContain('uncaughtException');
-    expect(events).toContain('unhandledRejection');
-    expect(events).toContain('SIGTERM');
-    expect(events).toContain('SIGINT');
+    expect(fakeProc.listenerCount('uncaughtException')).toBe(1);
+    expect(fakeProc.listenerCount('unhandledRejection')).toBe(1);
+    expect(fakeProc.listenerCount('SIGTERM')).toBe(1);
+    expect(fakeProc.listenerCount('SIGINT')).toBe(1);
   });
 
   it('uncaughtException handler sends error and calls shutdown', async () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     const shutdownFn = vi.fn().mockResolvedValue(undefined);
     const getSessionId = vi.fn().mockReturnValue('sess-1');
 
     runner.setupGlobalErrorHandlers(shutdownFn, getSessionId);
 
-    capturedHandlers['uncaughtException'](new Error('crash'));
+    fakeProc.emit('uncaughtException', new Error('crash'));
     await new Promise(r => setTimeout(r, 10));
 
     expect(deps.messageSender.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'error', sessionId: 'sess-1' })
     );
     expect(shutdownFn).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fakeProc.exit).toHaveBeenCalledWith(1);
   });
 
   it('unhandledRejection handler sends error but does not exit', () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     const shutdownFn = vi.fn().mockResolvedValue(undefined);
     const getSessionId = vi.fn().mockReturnValue(null);
 
     runner.setupGlobalErrorHandlers(shutdownFn, getSessionId);
 
-    capturedHandlers['unhandledRejection']('reason', Promise.resolve());
+    fakeProc.emit('unhandledRejection', 'reason', Promise.resolve());
 
     expect(deps.messageSender.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'error', sessionId: 'unknown' })
     );
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(fakeProc.exit).not.toHaveBeenCalled();
   });
 
   it('SIGTERM handler shuts down and exits with 0', async () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     const shutdownFn = vi.fn().mockResolvedValue(undefined);
 
     runner.setupGlobalErrorHandlers(shutdownFn, vi.fn());
 
-    capturedHandlers['SIGTERM']();
+    fakeProc.emit('SIGTERM');
     await new Promise(r => setTimeout(r, 10));
 
     expect(shutdownFn).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(fakeProc.exit).toHaveBeenCalledWith(0);
   });
 
   it('SIGINT handler shuts down and exits with 0', async () => {
-    runner = new ProxyRunner(deps, logger);
+    runner = new ProxyRunner(deps, logger, { proc: fakeProc });
     const shutdownFn = vi.fn().mockResolvedValue(undefined);
 
     runner.setupGlobalErrorHandlers(shutdownFn, vi.fn());
 
-    capturedHandlers['SIGINT']();
+    fakeProc.emit('SIGINT');
     await new Promise(r => setTimeout(r, 10));
 
     expect(shutdownFn).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(fakeProc.exit).toHaveBeenCalledWith(0);
   });
 });

--- a/tests/unit/proxy/dap-proxy-dependencies.test.ts
+++ b/tests/unit/proxy/dap-proxy-dependencies.test.ts
@@ -1,12 +1,17 @@
 /**
  * Unit tests for dap-proxy-dependencies.ts
+ *
+ * The messageSender tests inject a FakeCurrentProcess (issue #183) instead of
+ * mutating the global process object. The standalone setupGlobalErrorHandlers
+ * was deleted with issue #183 — production uses
+ * ProxyRunner.setupGlobalErrorHandlers (covered in dap-proxy-core.test.ts).
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   createProductionDependencies,
-  createConsoleLogger,
-  setupGlobalErrorHandlers
+  createConsoleLogger
 } from '../../../src/proxy/dap-proxy-dependencies.js';
+import { FakeCurrentProcess } from '../../test-utils/mocks/fake-current-process.js';
 
 /* ------------------------------------------------------------------ */
 /*  createProductionDependencies                                       */
@@ -43,20 +48,26 @@ describe('createProductionDependencies', () => {
     expect(typeof deps.dapClientFactory.create).toBe('function');
   });
 
-  it('messageSender.send uses stdout when process.send is unavailable', () => {
-    const originalSend = process.send;
-    delete (process as any).send;
+  it('messageSender.send uses stdout when proc.send is unavailable', async () => {
+    const fakeProc = new FakeCurrentProcess().disableIPC();
 
-    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
-    const deps = createProductionDependencies();
+    const deps = createProductionDependencies(fakeProc);
     deps.messageSender.send({ type: 'test', data: 123 });
 
-    expect(stdoutWrite).toHaveBeenCalledWith(
+    // Let the PassThrough 'data' event flush
+    await new Promise(r => setImmediate(r));
+    expect(fakeProc.stdoutChunks.join('')).toBe(
       JSON.stringify({ type: 'test', data: 123 }) + '\n'
     );
+  });
 
-    stdoutWrite.mockRestore();
-    if (originalSend) process.send = originalSend;
+  it('messageSender.send uses proc.send when available', () => {
+    const fakeProc = new FakeCurrentProcess();
+
+    const deps = createProductionDependencies(fakeProc);
+    deps.messageSender.send({ type: 'test' });
+
+    expect(fakeProc.send).toHaveBeenCalledWith({ type: 'test' });
   });
 });
 
@@ -103,189 +114,5 @@ describe('createConsoleLogger', () => {
     logger.warn('caution');
     expect(spy).toHaveBeenCalledWith('[WARN]', 'caution');
     spy.mockRestore();
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  setupGlobalErrorHandlers                                           */
-/* ------------------------------------------------------------------ */
-
-describe('setupGlobalErrorHandlers', () => {
-  const handlers: Record<string, Function[]> = {};
-
-  afterEach(() => {
-    // Clean up all registered handlers
-    for (const [event, fns] of Object.entries(handlers)) {
-      for (const fn of fns) {
-        process.removeListener(event, fn as any);
-      }
-    }
-    for (const key of Object.keys(handlers)) {
-      delete handlers[key];
-    }
-  });
-
-  it('registers handlers for uncaughtException, unhandledRejection, SIGINT, SIGTERM', () => {
-    const spy = vi.spyOn(process, 'on').mockImplementation(function (this: any, event: string, fn: any) {
-      if (!handlers[event]) handlers[event] = [];
-      handlers[event].push(fn);
-      return this;
-    });
-
-    const logger = createConsoleLogger();
-    const messageSender = { send: vi.fn() };
-    const shutdownFn = vi.fn().mockResolvedValue(undefined);
-    const getSessionId = vi.fn().mockReturnValue(null);
-
-    setupGlobalErrorHandlers(logger, messageSender, shutdownFn, getSessionId);
-
-    const registeredEvents = spy.mock.calls.map(([event]) => event);
-    expect(registeredEvents).toContain('uncaughtException');
-    expect(registeredEvents).toContain('unhandledRejection');
-    expect(registeredEvents).toContain('SIGINT');
-    expect(registeredEvents).toContain('SIGTERM');
-
-    spy.mockRestore();
-  });
-
-  it('uncaughtException handler sends error and calls shutdown', async () => {
-    const capturedHandlers: Record<string, Function> = {};
-    const spy = vi.spyOn(process, 'on').mockImplementation(function (this: any, event: string, fn: any) {
-      capturedHandlers[event] = fn;
-      return this;
-    });
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-    const logger = createConsoleLogger();
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    const messageSender = { send: vi.fn() };
-    const shutdownFn = vi.fn().mockResolvedValue(undefined);
-    const getSessionId = vi.fn().mockReturnValue('session-1');
-
-    setupGlobalErrorHandlers(logger, messageSender, shutdownFn, getSessionId);
-
-    const handler = capturedHandlers['uncaughtException'];
-    expect(handler).toBeDefined();
-
-    await handler(new Error('test crash'), 'uncaughtException');
-    // Allow .finally() microtask to run
-    await new Promise(r => setTimeout(r, 0));
-
-    expect(messageSender.send).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error', sessionId: 'session-1' })
-    );
-    expect(shutdownFn).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
-
-    spy.mockRestore();
-    exitSpy.mockRestore();
-  });
-
-  it('unhandledRejection handler sends error, shuts down, and exits(1)', async () => {
-    const capturedHandlers: Record<string, Function> = {};
-    const spy = vi.spyOn(process, 'on').mockImplementation(function (this: any, event: string, fn: any) {
-      capturedHandlers[event] = fn;
-      return this;
-    });
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-    const logger = createConsoleLogger();
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    const messageSender = { send: vi.fn() };
-    const shutdownFn = vi.fn().mockResolvedValue(undefined);
-    const getSessionId = vi.fn().mockReturnValue(null);
-
-    setupGlobalErrorHandlers(logger, messageSender, shutdownFn, getSessionId);
-
-    const handler = capturedHandlers['unhandledRejection'];
-    handler('some reason', Promise.resolve());
-
-    expect(messageSender.send).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error', sessionId: 'unknown' })
-    );
-
-    // The handler schedules shutdownFn().finally(() => process.exit(1)) as a
-    // microtask chain. Settle it BEFORE restoring the exit spy — restoring
-    // first lets a REAL exit(1) fire between tests, which can hard-kill the
-    // vitest fork worker (issue #159).
-    await new Promise(r => setTimeout(r, 0));
-    expect(shutdownFn).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
-
-    spy.mockRestore();
-    exitSpy.mockRestore();
-  });
-
-  it('SIGTERM handler calls shutdown and exits with 0', async () => {
-    const capturedHandlers: Record<string, Function> = {};
-    const spy = vi.spyOn(process, 'on').mockImplementation(function (this: any, event: string, fn: any) {
-      capturedHandlers[event] = fn;
-      return this;
-    });
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-    const logger = createConsoleLogger();
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    const messageSender = { send: vi.fn() };
-    const shutdownFn = vi.fn().mockResolvedValue(undefined);
-    const getSessionId = vi.fn().mockReturnValue(null);
-
-    setupGlobalErrorHandlers(logger, messageSender, shutdownFn, getSessionId);
-
-    await capturedHandlers['SIGTERM']();
-    expect(shutdownFn).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(0);
-
-    spy.mockRestore();
-    exitSpy.mockRestore();
-  });
-
-  it('SIGINT handler calls shutdown and exits with 0', async () => {
-    const capturedHandlers: Record<string, Function> = {};
-    const spy = vi.spyOn(process, 'on').mockImplementation(function (this: any, event: string, fn: any) {
-      capturedHandlers[event] = fn;
-      return this;
-    });
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-    const logger = createConsoleLogger();
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    const messageSender = { send: vi.fn() };
-    const shutdownFn = vi.fn().mockResolvedValue(undefined);
-    const getSessionId = vi.fn().mockReturnValue(null);
-
-    setupGlobalErrorHandlers(logger, messageSender, shutdownFn, getSessionId);
-
-    await capturedHandlers['SIGINT']();
-    expect(shutdownFn).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(0);
-
-    spy.mockRestore();
-    exitSpy.mockRestore();
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  messageSender.send with process.send available                     */
-/* ------------------------------------------------------------------ */
-
-describe('messageSender with process.send', () => {
-  it('uses process.send when available', () => {
-    const originalSend = process.send;
-    const fakeSend = vi.fn();
-    (process as any).send = fakeSend;
-
-    const deps = createProductionDependencies();
-    deps.messageSender.send({ type: 'test' });
-
-    expect(fakeSend).toHaveBeenCalledWith({ type: 'test' });
-
-    if (originalSend) {
-      process.send = originalSend;
-    } else {
-      delete (process as any).send;
-    }
   });
 });

--- a/tests/unit/shared/adapter-policy-python.test.ts
+++ b/tests/unit/shared/adapter-policy-python.test.ts
@@ -1,19 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { PythonAdapterPolicy } from '../../../packages/shared/src/interfaces/adapter-policy-python.js';
 
 describe('PythonAdapterPolicy', () => {
-  let originalPlatform: PropertyDescriptor | undefined;
-
-  beforeEach(() => {
-    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-  });
-
-  afterEach(() => {
-    if (originalPlatform) {
-      Object.defineProperty(process, 'platform', originalPlatform);
-    }
-  });
-
   it('rejects child session support', () => {
     expect(() => PythonAdapterPolicy.buildChildStartArgs('', {})).toThrow(/does not support child sessions/);
   });
@@ -52,15 +40,8 @@ describe('PythonAdapterPolicy', () => {
     expect(PythonAdapterPolicy.resolveExecutablePath('/explicit/python')).toBe('/explicit/python');
 
     vi.stubEnv('PYTHON_PATH', undefined);
-    Object.defineProperty(process, 'platform', {
-      value: 'win32'
-    });
-    expect(PythonAdapterPolicy.resolveExecutablePath()).toBe('python');
-
-    Object.defineProperty(process, 'platform', {
-      value: 'linux'
-    });
-    expect(PythonAdapterPolicy.resolveExecutablePath()).toBe('python3');
+    expect(PythonAdapterPolicy.resolveExecutablePath(undefined, 'win32')).toBe('python');
+    expect(PythonAdapterPolicy.resolveExecutablePath(undefined, 'linux')).toBe('python3');
   });
 
   it('does not queue commands and reports initialization state', () => {

--- a/tests/unit/utils/jvm-orphan-reaper-internals.test.ts
+++ b/tests/unit/utils/jvm-orphan-reaper-internals.test.ts
@@ -122,79 +122,59 @@ describe('parseArgs', () => {
   });
 });
 
+/** Injected signal fn that throws an ErrnoException with the given code (issue #183). */
+function throwWith(code: string): () => never {
+  return () => {
+    const err = new Error(code) as NodeJS.ErrnoException;
+    err.code = code;
+    throw err;
+  };
+}
+
 describe('isPidAlive', () => {
-  it('returns false for pid <= 0 without calling process.kill', () => {
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
-    expect(isPidAlive(0)).toBe(false);
-    expect(isPidAlive(-1)).toBe(false);
-    expect(killSpy).not.toHaveBeenCalled();
+  it('returns false for pid <= 0 without signalling', () => {
+    const signal = vi.fn();
+    expect(isPidAlive(0, signal)).toBe(false);
+    expect(isPidAlive(-1, signal)).toBe(false);
+    expect(signal).not.toHaveBeenCalled();
   });
 
-  it('returns true when process.kill(pid, 0) succeeds', () => {
-    vi.spyOn(process, 'kill').mockImplementation(() => true);
-    expect(isPidAlive(12345)).toBe(true);
+  it('returns true when signalling pid 0 succeeds', () => {
+    const signal = vi.fn();
+    expect(isPidAlive(12345, signal)).toBe(true);
+    expect(signal).toHaveBeenCalledWith(12345, 0);
   });
 
-  it('returns true when process.kill throws EPERM (process exists, no permission)', () => {
-    vi.spyOn(process, 'kill').mockImplementation(() => {
-      const err = new Error('permission denied') as NodeJS.ErrnoException;
-      err.code = 'EPERM';
-      throw err;
-    });
-    expect(isPidAlive(12345)).toBe(true);
+  it('returns true when the signal throws EPERM (process exists, no permission)', () => {
+    expect(isPidAlive(12345, throwWith('EPERM'))).toBe(true);
   });
 
-  it('returns false when process.kill throws ESRCH (no such process)', () => {
-    vi.spyOn(process, 'kill').mockImplementation(() => {
-      const err = new Error('no such process') as NodeJS.ErrnoException;
-      err.code = 'ESRCH';
-      throw err;
-    });
-    expect(isPidAlive(12345)).toBe(false);
+  it('returns false when the signal throws ESRCH (no such process)', () => {
+    expect(isPidAlive(12345, throwWith('ESRCH'))).toBe(false);
   });
 
   it('returns false on unexpected error codes', () => {
-    vi.spyOn(process, 'kill').mockImplementation(() => {
-      const err = new Error('invalid arg') as NodeJS.ErrnoException;
-      err.code = 'EINVAL';
-      throw err;
-    });
-    expect(isPidAlive(12345)).toBe(false);
+    expect(isPidAlive(12345, throwWith('EINVAL'))).toBe(false);
   });
 });
 
 describe('defaultKill', () => {
   it('returns true when SIGKILL succeeds', () => {
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
-    expect(defaultKill(9001)).toBe(true);
-    expect(killSpy).toHaveBeenCalledWith(9001, 'SIGKILL');
+    const signal = vi.fn();
+    expect(defaultKill(9001, signal)).toBe(true);
+    expect(signal).toHaveBeenCalledWith(9001, 'SIGKILL');
   });
 
   it('returns false on ESRCH (process already gone)', () => {
-    vi.spyOn(process, 'kill').mockImplementation(() => {
-      const err = new Error('no such process') as NodeJS.ErrnoException;
-      err.code = 'ESRCH';
-      throw err;
-    });
-    expect(defaultKill(9001)).toBe(false);
+    expect(defaultKill(9001, throwWith('ESRCH'))).toBe(false);
   });
 
   it('returns false on EPERM (foreign-owned process)', () => {
-    vi.spyOn(process, 'kill').mockImplementation(() => {
-      const err = new Error('permission denied') as NodeJS.ErrnoException;
-      err.code = 'EPERM';
-      throw err;
-    });
-    expect(defaultKill(9001)).toBe(false);
+    expect(defaultKill(9001, throwWith('EPERM'))).toBe(false);
   });
 
   it('rethrows on unexpected error codes', () => {
-    vi.spyOn(process, 'kill').mockImplementation(() => {
-      const err = new Error('invalid arg') as NodeJS.ErrnoException;
-      err.code = 'EINVAL';
-      throw err;
-    });
-    expect(() => defaultKill(9001)).toThrow('invalid arg');
+    expect(() => defaultKill(9001, throwWith('EINVAL'))).toThrow('EINVAL');
   });
 });
 

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -261,19 +261,19 @@ describe('cleanupStaleLogFiles', () => {
     return filePath;
   }
 
-  function stubProcessKill(errorCode: string) {
-    return vi.spyOn(process, 'kill').mockImplementation(() => {
+  /** Injected signal fn that throws an ErrnoException with the given code (issue #183). */
+  function throwingSignal(errorCode: string): () => never {
+    return () => {
       const err = new Error(errorCode) as NodeJS.ErrnoException;
       err.code = errorCode;
       throw err;
-    });
+    };
   }
 
   it('deletes old per-pid log files of dead processes', () => {
-    stubProcessKill('ESRCH');
     const stale = makeAgedFile('debug-mcp-server-424242.log', WEEK_MS + 1000);
 
-    loggerModule.cleanupStaleLogFiles(tmpDir);
+    loggerModule.cleanupStaleLogFiles(tmpDir, { signal: throwingSignal('ESRCH') });
 
     expect(fs.existsSync(stale)).toBe(false);
   });
@@ -286,40 +286,36 @@ describe('cleanupStaleLogFiles', () => {
     expect(fs.existsSync(own)).toBe(true);
   });
 
-  it('skips files whose pid is alive but not ours (EPERM from process.kill)', () => {
-    stubProcessKill('EPERM');
+  it('skips files whose pid is alive but not ours (EPERM from the signal)', () => {
     const kept = makeAgedFile('debug-mcp-server-424242.log', WEEK_MS + 1000);
 
-    loggerModule.cleanupStaleLogFiles(tmpDir);
+    loggerModule.cleanupStaleLogFiles(tmpDir, { signal: throwingSignal('EPERM') });
 
     expect(fs.existsSync(kept)).toBe(true);
   });
 
-  it('skips files whose pid is alive (process.kill(pid, 0) succeeds)', () => {
-    vi.spyOn(process, 'kill').mockImplementation(() => true);
+  it('skips files whose pid is alive (signalling 0 succeeds)', () => {
     const kept = makeAgedFile('debug-mcp-server-424242.log', WEEK_MS + 1000);
 
-    loggerModule.cleanupStaleLogFiles(tmpDir);
+    loggerModule.cleanupStaleLogFiles(tmpDir, { signal: () => {} });
 
     expect(fs.existsSync(kept)).toBe(true);
   });
 
   it('keeps recent per-pid files of dead processes', () => {
-    stubProcessKill('ESRCH');
     const fresh = makeAgedFile('debug-mcp-server-424242.log', 60_000);
 
-    loggerModule.cleanupStaleLogFiles(tmpDir);
+    loggerModule.cleanupStaleLogFiles(tmpDir, { signal: throwingSignal('ESRCH') });
 
     expect(fs.existsSync(fresh)).toBe(true);
   });
 
   it('never touches non-pid log files, however old', () => {
-    stubProcessKill('ESRCH');
     const legacy = makeAgedFile('debug-mcp-server.log', WEEK_MS * 10);
     const proxy = makeAgedFile('proxy-session-abc.log', WEEK_MS * 10);
     const other = makeAgedFile('something-else.txt', WEEK_MS * 10);
 
-    loggerModule.cleanupStaleLogFiles(tmpDir);
+    loggerModule.cleanupStaleLogFiles(tmpDir, { signal: throwingSignal('ESRCH') });
 
     expect(fs.existsSync(legacy)).toBe(true);
     expect(fs.existsSync(proxy)).toBe(true);
@@ -327,10 +323,9 @@ describe('cleanupStaleLogFiles', () => {
   });
 
   it('supports overriding retention age', () => {
-    stubProcessKill('ESRCH');
     const stale = makeAgedFile('debug-mcp-server-424242.log', 5_000);
 
-    loggerModule.cleanupStaleLogFiles(tmpDir, { maxAgeMs: 1_000 });
+    loggerModule.cleanupStaleLogFiles(tmpDir, { maxAgeMs: 1_000, signal: throwingSignal('ESRCH') });
 
     expect(fs.existsSync(stale)).toBe(false);
   });


### PR DESCRIPTION
Fixes #183.

## What

The proper fix behind the #159 CI flake: production code no longer hardwires the global `process`, so tests no longer have to mutate it to drive the code under test. With the offenders gone, the #184 leak guard is promoted from lenient to enforcing: **CI now runs with `LEAK_GUARD_STRICT=1`**.

### New abstraction

- **`ProcessLike`** (`src/interfaces/process-interfaces.ts`) — minimal current-process surface (`on`/`removeListener`/`listeners`/`rawListeners`/`listenerCount`/`exit`/`send?`/`connected`/`env`/`argv`/`uptime`/`stdin`/`stdout`). Hand-rolled rather than `Pick<NodeJS.Process, ...>`: the exact Node types (tty stream intersections, `never`-returning `exit`, per-event listener overloads) make fakes unimplementable. Structurally satisfied by both the global `process` and the new EventEmitter-backed **`FakeCurrentProcess`** test fake (`tests/test-utils/mocks/fake-current-process.ts`).

### Injection sites (all default to the global `process` — production behavior unchanged, entry files untouched)

- `ProxyRunner` (`ProxyRunnerOptions.proc`): all ~20 touchpoints — IPC mode detection, heartbeat interval, 10s init timeout, `message`/`disconnect`/`error` listeners, readline stdio, and the `setupGlobalErrorHandlers` method. The worker exit hook is threaded as `(code) => this.proc.exit(code)` (identical to the worker's own default in prod).
- `detectExecutionMode(proc?)`, `createProductionDependencies(proc?)` (messageSender IPC/stdout channel).
- CLI commands (`stdio`, `http`, `sse`, `error-handlers`): `proc?: ProcessLike` in each dependencies object; signal registration, env gates, exit diagnostics, and the `exitProcess` default route through it. Stdin watchdog gets `env` from the handle.
- `GenericAdapterManager`: constructor-injected `platform` (win32 tree-kill branch, #156 heritage).
- Narrow seams where full `ProcessLike` would be ceremony: `SignalFn` for pid-liveness (`jvm-orphan-reaper`, logger stale-log cleanup); `platform` params on `resolveExecutablePath` and `buildRdbgInvocation`.

### Deleted

- The standalone `setupGlobalErrorHandlers()` in `dap-proxy-dependencies.ts` — dead in production (only its own tests called it) and behaviorally divergent from the `ProxyRunner` method prod uses (it exited on `unhandledRejection`; the real one doesn't). Docs updated.
- The #159-era test safety nets (top-level `process.exit` spy nets in dap-proxy-core/worker tests, listener-baseline belt-and-braces) — unreachable now that every runner/worker gets an injected handle.

### Deliberate exceptions

- `proxy-bootstrap.js` untouched (plain-JS pre-TS orphan-prevention layer).
- `environment-impl.test.ts` keeps its `process.cwd` spy, documented as the sanctioned boundary test — `ProcessEnvironment` IS the process abstraction; injecting a fake there is tautological.
- `packages/adapter-*` platform-redefinition tests (~60 sites, cannot trip the leak guard) deferred to a follow-up issue to keep this reviewable.

## Verification

- [x] Key checkpoint: after the `ProxyRunner` rewrite, the **unmodified** old tests still passed (default = global process, byte-identical)
- [x] `LEAK_GUARD_STRICT=1 pnpm run test:ci-coverage` (same command as CI, both projects) — green, 0 leak messages
- [x] `LEAK_GUARD_STRICT=1 FLAKE_RUNS=3 pnpm run test:flake` — 3/3 shuffled runs green
- [x] E2E smoke (python 5 tests, javascript 3 tests) — real proxy spawn over the default path
- [x] Acceptance greps: no `process.on =` reassignment, no `delete process.send`/`defineProperty(process, ...)`, no `vi.spyOn(process, 'exit'|'kill'|'on')` in migrated suites; `dap-proxy-core.ts` touches the global only in its two `= process` defaults
- [x] `npm run lint` clean

New convenience script: `pnpm run test:strict` (strict guard locally; default local runs stay lenient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)