### PR TITLE
fix: make test:e2e:smoke find its files on Windows (#187)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:python": "vitest run tests/adapters/python",
     "posttest:python": "node scripts/cleanup-test-processes.js",
     "pretest:e2e:smoke": "pnpm run build",
-    "test:e2e:smoke": "vitest run tests/e2e/mcp-server-smoke*.test.ts",
+    "test:e2e:smoke": "vitest run tests/e2e/mcp-server-smoke",
     "test:e2e:container": "docker build --no-cache -t mcp-debugger:local . && vitest run tests/e2e/docker/",
     "pretest:e2e:npx": "pnpm run build",
     "test:e2e:npx": "vitest run tests/e2e/npx",


### PR DESCRIPTION
## Summary

Fixes #187 — `pnpm run test:e2e:smoke` failed on Windows with "No test files found, exiting with code 1" because cmd.exe (pnpm's default script shell on Windows) never expands the `*` in `vitest run tests/e2e/mcp-server-smoke*.test.ts`, so vitest received the pattern as a literal filter matching nothing. Bash expands the glob before vitest sees it, which is why CI (ubuntu) and Git Bash users never hit this.

## The fix

The issue suggested quoting the glob, but verification showed vitest 4 treats positional CLI args as **substring filters, not globs** — the quoted pattern also matches nothing (and worse: `vitest list` exits 0 with zero files, so a quoted glob would silently run nothing wherever globbing is left to vitest). So this uses the issue's fallback suggestion — a filter that needs no shell expansion:

```json
"test:e2e:smoke": "vitest run tests/e2e/mcp-server-smoke"
```

## Verification

- `npx vitest list --filesOnly tests/e2e/mcp-server-smoke` → exactly the 18 smoke files, from both PowerShell and `cmd /c` (the shell pnpm uses for scripts)
- Substring filters only apply to files already matched by the config's `include` (`*.test.ts`), so helpers can't leak in
- Pre-push hook: lint + build + 2488 unit / 21 integration tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
