### PR TITLE
ci: bump codeql-action/init to v4.37.1 to match autobuild/analyze

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.37.1
       with:
         languages: ${{ matrix.language }}
 


### PR DESCRIPTION
## Summary
- Dependabot bumped `codeql-action/autobuild` and `codeql-action/analyze` to v4.37.1 in #195 and #199, but left `codeql-action/init` pinned at v4.37.0.
- The `codeql-action` components must all run the same version — the mismatch broke every CodeQL run on `main` with: "Loaded a configuration file for version '4.37.0', but running version '4.37.1'".
- Bumps `init` to the same v4.37.1 SHA (`7188fc363630916deb702c7fdcf4e481b751f97a`, verified against the upstream `v4.37.1` tag) already used by the other two steps.

## Test plan
- [x] Local lint/build/unit/integration tests pass (pre-push hook)
- [ ] CI green on this PR, including the `CodeQL` workflow