### PR TITLE
ci: bump codeql-action init/autobuild/analyze to v4.37.3 in lockstep

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,14 +30,14 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.37.1
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.37.1
+      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.37.1
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
       with:
         category: /language:${{ matrix.language }}


### PR DESCRIPTION
Replaces dependabot #208 and #210, which bumped `analyze` and `init` in separate PRs and failed CI: `codeql.yml` pins `init`/`autobuild`/`analyze` to a single SHA and CodeQL hard-fails when the versions diverge (same pattern previously fixed in #201).

This bumps all three to v4.37.3 (`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`) together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)