### PR TITLE
feat: ship agent debugging skill + MCP instructions and debugging-workflow prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@
 
 mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through debugging as structured tool calls. It lets AI agents set breakpoints, inspect variables, evaluate expressions, and step through running programs across seven languages — driving real language debuggers through the Debug Adapter Protocol (DAP).
 
+**No IDE required.** mcp-debugger runs anywhere Node.js runs: CI runners, Docker containers, Kubernetes pods, SSH boxes, and the sandboxes that cloud coding agents live in. It's the debugger for where IDEs can't go.
+
+### When to use mcp-debugger vs an IDE-bound debug server
+
+Microsoft's [DebugMCP](https://github.com/microsoft/DebugMCP) exposes VS Code's debugger over MCP and is a good choice when your agent works *inside* a running VS Code. The two projects make different structural trade-offs:
+
+| | mcp-debugger | microsoft/DebugMCP |
+|---|---|---|
+| Runs headless (CI, containers, k8s, cloud agents) | ✅ standalone Node process | ❌ requires a running VS Code |
+| Transports | stdio + Streamable HTTP | Streamable HTTP (localhost) |
+| Distribution | npx, npm, Docker image | VS Code Marketplace extension |
+| Remote attach without an IDE | ✅ debugpy / rdbg / JDWP, incl. pods via port-forward | ❌ |
+| Per-session process isolation | ✅ one proxy process per session | shares the VS Code instance |
+| Java hot-swap (`redefine_classes`) | ✅ | ❌ |
+| Debuggee output as subscribable MCP resource | ✅ | ❌ |
+| In-IDE debugging UX alongside the agent | ❌ (planned: [#217](https://github.com/debugmcp/mcp-debugger/issues/217)) | ✅ native |
+| C/C++, PHP | ❌ | ✅ via VS Code extensions |
+| Languages | Python, JS/TS, Ruby, Rust, Go, Java, .NET | Python, JS/TS, Ruby, Rust, Go, Java, .NET, C/C++, PHP |
+
+If your agent runs in a terminal, a pipeline, or a cloud sandbox — or needs to attach to a process on another machine — you want mcp-debugger.
+
 > 🆕 **v0.22.0** — **Ruby debugging support** lands (launch + attach via `rdbg`, including remote attach to containers and Kubernetes pods), alongside JavaScript attach-mode fixes and session/proxy lifecycle hardening. See the [CHANGELOG](./CHANGELOG.md) for the full release history.
 
 ## ✨ Key Features
@@ -40,6 +61,19 @@ mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through 
 - 🛡️ **Path validation** – Prevents crashes from non-existent files
 - 📝 **AI-aware line context** – Intelligent breakpoint placement with code context
 - ✅ **Comprehensive test suite** – unit, integration, and end-to-end coverage across every adapter ([CI status](https://github.com/debugmcp/mcp-debugger/actions/workflows/ci.yml))
+
+## 🧠 Agent Skill
+
+Tools tell an agent *what* it can do; a skill teaches it *how to debug well*. This repo ships an [agent skill](skills/debugging/) covering the session golden path, root-cause discipline (bisection over line-by-line stepping), attach/remote recipes, and per-language quirks:
+
+```bash
+# Claude Code (user-level)
+cp -r skills/debugging ~/.claude/skills/mcp-debugger
+# Cross-agent directories (Copilot CLI and friends)
+cp -r skills/debugging ~/.agents/skills/mcp-debugger
+```
+
+The server also serves condensed guidance in-band: MCP `instructions` on connect, plus a `debugging-workflow` prompt any MCP client can request. See [skills/debugging/README.md](skills/debugging/README.md) for details.
 
 ## 🚀 Quick Start
 

--- a/skills/debugging/README.md
+++ b/skills/debugging/README.md
@@ -1,0 +1,35 @@
+# mcp-debugger agent skill
+
+This directory is a self-contained [agent skill](https://agentskills.io) that teaches AI coding agents how to debug effectively with the mcp-debugger MCP server: when to debug instead of print, the session golden path, root-cause discipline, attach/remote recipes, and per-language quirks.
+
+The MCP server itself exposes only **tools** (plus a short `instructions` string and a `debugging-workflow` prompt as in-band pointers). The full procedural knowledge — workflow, bisection discipline, language references — lives here, where every agent harness can load it.
+
+## Install
+
+**Claude Code** (project- or user-level):
+
+```bash
+# user-level: available in every project
+mkdir -p ~/.claude/skills && cp -r skills/debugging ~/.claude/skills/mcp-debugger
+
+# project-level: committed with your repo
+mkdir -p .claude/skills && cp -r skills/debugging .claude/skills/mcp-debugger
+```
+
+**Cross-agent directories** (GitHub Copilot CLI, and harnesses that read `~/.agents/skills/`):
+
+```bash
+mkdir -p ~/.agents/skills && cp -r skills/debugging ~/.agents/skills/mcp-debugger
+mkdir -p ~/.copilot/skills && cp -r skills/debugging ~/.copilot/skills/mcp-debugger
+```
+
+**Any other agent**: paste the contents of `SKILL.md` into your system prompt or rules file (e.g. `.cursorrules`, Cline custom instructions), and keep the `references/` files reachable so the agent can read the per-language guides on demand.
+
+## Contents
+
+- `SKILL.md` — entry point: when to debug, golden path, root-cause discipline, attach recipes, current limitations
+- `references/python.md`, `javascript.md`, `ruby.md`, `rust.md`, `go.md`, `java.md`, `dotnet.md` — per-language prerequisites, quickstarts, quirks, troubleshooting
+
+## Keeping it honest
+
+The skill states current limitations (no exception breakpoints yet, per-language output-capture gaps) with issue links. If you hit a behavior the skill doesn't describe, please [open an issue](https://github.com/debugmcp/mcp-debugger/issues) — the skill is maintained against real agent transcripts.

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: mcp-debugger
+description: Use when investigating a bug, failing test, or unexpected runtime behavior and the mcp-debugger MCP server is available — drives real step-through debuggers (breakpoints, stack traces, variable inspection, expression evaluation) for Python, JavaScript/TypeScript, Ruby, Rust, Go, Java, and .NET/C#, locally or attached to remote processes.
+---
+
+# Debugging with mcp-debugger
+
+mcp-debugger exposes real language debuggers as MCP tools. Prefer it over print-debugging whenever you would otherwise need more than one edit-run cycle to see program state: a breakpoint plus `evaluate_expression` answers in one run what printf answers in three.
+
+## When to reach for the debugger
+
+- A test fails and the assertion message doesn't explain *why* the value is wrong.
+- Control flow surprises you (a branch that "can't happen", a loop that exits early).
+- State mutates somewhere between two known-good points and you need to bisect.
+- The bug lives in code you can't easily edit (third-party package, compiled artifact).
+- You need ground truth about runtime types/values instead of inferring them from source.
+
+Do NOT reach for it when a single glance at the code or one log line would answer the question — session setup costs a few seconds and the target must be runnable.
+
+## The golden path (launch)
+
+```text
+1. create_debug_session   {language: "python"}                 -> sessionId
+2. set_breakpoint         {sessionId, file: "<ABSOLUTE path>", line: N}
+3. start_debugging        {sessionId, scriptPath: "<ABSOLUTE path>"}
+4. get_stack_trace        {sessionId}                          -> frames (use frame.id, never assume 0)
+5. get_scopes             {sessionId, frameId: <frame.id>}     -> scope variablesReference
+6. get_variables          {sessionId, scope: <variablesReference>}
+   ... or get_local_variables {sessionId} for the common case
+7. evaluate_expression    {sessionId, expression: "x + y"}
+8. step_over / step_into / step_out / continue_execution
+9. get_output             {sessionId}                          -> captured debuggee stdout/stderr
+10. close_debug_session   {sessionId}                          -> ALWAYS, even on failure
+```
+
+Rules that prevent 90% of failed sessions:
+
+- **Absolute paths only** for `file` and `scriptPath` (relative paths are rejected in host mode).
+- **Use real frame IDs.** Take `id` from `get_stack_trace` frames; it is adapter-assigned and is not 0-indexed.
+- **Expand variable containers.** If a variable entry carries a `variablesReference`, call `get_variables` again with that reference to see children (Python's "special variables", object fields, array elements).
+- **Respect session state.** Stepping, evaluation, and variable reads require `PAUSED`. After `continue_execution` the session is `RUNNING`; after a step or breakpoint hit it returns to `PAUSED` with a persisted stop reason telling you why it stopped (`breakpoint`, `step`, `entry`, `exception`, ...).
+- **Breakpoints may verify late.** Some adapters (debugpy, JDI) report breakpoints unverified until the module/class loads; that is normal, not an error.
+- **Always `close_debug_session`** when done — it tears down the debuggee process tree.
+
+## Root-cause discipline
+
+1. State a hypothesis about where reality diverges from expectation *before* setting breakpoints.
+2. Set at most two breakpoints: last-known-good and first-known-bad. Run, inspect, halve the interval. Bisection beats stepping line-by-line from the top.
+3. At each pause, record what you *learned* (variable values, actual control flow), not just where you are.
+4. When the diverging line is found, inspect every input to that line before concluding — the bug is usually an operand, not the operator.
+5. Fix, then re-run the same session recipe to confirm the observed state changed as predicted.
+
+## Program output
+
+`get_output {sessionId}` returns buffered debuggee stdout/stderr with a cursor: pass the returned `nextCursor` back as `cursor` to read only new output. Each session also exposes the transcript as MCP resource `debug://sessions/{id}/output` with subscription support. Caveat: on Ruby, Go, and Rust, debuggee stdout capture currently has gaps (issues #222/#225/#223) — for those languages, verify behavior via `evaluate_expression`/breakpoints rather than stdout, or have the program write a file.
+
+## Attach instead of launch
+
+For an already-running process (including remote machines, containers, and Kubernetes pods via port-forward):
+
+```text
+attach_to_process {sessionId, host: "localhost", port: 5678, localRoot: "<local src>", remoteRoot: "<remote src>"}
+```
+
+- **Python**: target ran `python -m debugpy --listen <host>:<port> ...`
+- **Ruby**: target ran `rdbg --open --port <port> ...` (works through `kubectl port-forward`)
+- **Java**: target JVM has `-agentlib:jdwp=transport=dt_socket,server=y,address=*:<port>`; breakpoints in not-yet-loaded classes are deferred automatically
+
+`detach_from_process` leaves the target running; `close_debug_session` after detach cleans up the session.
+
+## Current limitations (be honest with yourself)
+
+- No exception breakpoints yet (#220): an uncaught exception terminates the session instead of pausing. To catch a throw, set a line breakpoint just inside the failing try/handler or on the raise path.
+- No breakpoint listing/removal tools yet: track what you set; re-creating the session resets breakpoints.
+- `pause_execution` support varies by adapter; prefer breakpoints over pausing a free-running program.
+
+## Language specifics
+
+Read the matching reference before your first session in a language — each has load-bearing quirks:
+
+| Language | Reference | Headline quirk |
+|---|---|---|
+| Python | references/python.md | expand "special variables" containers; late breakpoint verification |
+| JavaScript/TS | references/javascript.md | child-session architecture; internals filtered from stacks |
+| Ruby | references/ruby.md | entry pause auto-continued; stdout capture gap (#222) |
+| Rust | references/rust.md | GNU toolchain on Windows; scriptPath = source file, adapter finds Cargo project |
+| Go | references/go.md | Delve native DAP; stdout capture gap (#225) |
+| Java | references/java.md | javac -g required; FQCN breakpoints; redefine_classes hot-swap |
+| .NET/C# | references/dotnet.md | scriptPath = compiled .dll; Portable PDB required |

--- a/skills/debugging/references/dotnet.md
+++ b/skills/debugging/references/dotnet.md
@@ -1,0 +1,70 @@
+# .NET/C# debugging (mcp-debugger)
+
+## Prerequisites
+
+- .NET 6+ SDK (`dotnet --version`) to build the target app.
+- **netcoredbg** (Samsung's DAP debugger): download from github.com/Samsung/netcoredbg/releases, then set `NETCOREDBG_PATH` to the executable (Windows: `setx NETCOREDBG_PATH "C:\path\to\netcoredbg.exe"`, new shell required) or put its directory on PATH. Discovery order: `NETCOREDBG_X86_PATH` (x86 attach targets) → `NETCOREDBG_PATH` → caller-provided path → PATH → platform-specific fallbacks.
+- **Portable PDB symbols required.** .NET Core / .NET 5+ builds produce them by default. .NET Framework 4.8: compile with `/debug:portable`, or rely on the adapter's bundled Pdb2Pdb auto-conversion (Windows only).
+- .NET debugging is disabled in the Docker image (`DEBUG_MCP_DISABLE_LANGUAGES`); use a host deployment.
+
+## Launch quickstart
+
+Build first — `dotnet build` — then debug the **compiled .dll**, not the `.cs` file:
+
+```json
+create_debug_session  {"language": "dotnet", "name": "dotnet-bug-hunt"}
+// Breakpoints reference the SOURCE file:
+set_breakpoint        {"sessionId": "<id>", "file": "/abs/path/Program.cs", "line": 14}
+start_debugging       {
+  "sessionId": "<id>",
+  "scriptPath": "/abs/path/bin/Debug/net8.0/MyApp.dll",
+  "dapLaunchArgs": {
+    "program": "/abs/path/bin/Debug/net8.0/MyApp.dll",
+    "cwd": "/abs/path/project",
+    "stopOnEntry": false
+  }
+}
+get_stack_trace       {"sessionId": "<id>"}
+get_local_variables   {"sessionId": "<id>"}
+evaluate_expression   {"sessionId": "<id>", "expression": "x + y"}
+step_over             {"sessionId": "<id>"}
+continue_execution    {"sessionId": "<id>"}
+close_debug_session   {"sessionId": "<id>"}
+```
+
+- `dapLaunchArgs.program` is required and must point to the compiled assembly (`bin/Debug/net8.0/MyApp.dll` or `.exe`) — never a `.cs` source file. Pass command-line arguments via `dapLaunchArgs.args`.
+- Breakpoints go on executable lines (assignments, calls, conditionals) — not blank lines, comments, or `using` directives.
+- Rebuild after every source edit; the PDB must sit alongside the DLL and match it.
+
+## Attach / remote
+
+Local process attach by PID is supported:
+
+```json
+create_debug_session  {"language": "dotnet"}
+set_breakpoint        {"sessionId": "<id>", "file": "/abs/path/Worker.cs", "line": 30}
+attach_to_process     {"sessionId": "<id>", "processId": 12345, "sourcePaths": ["/abs/path/bin/Debug/net8.0"]}
+```
+
+- `sourcePaths` tells the adapter where to scan for PDBs (defaults to the target process's executable directory). On Windows, discovered Windows-format PDBs are auto-converted to Portable via Pdb2Pdb.
+- For 32-bit targets set `NETCOREDBG_X86_PATH` to an x86 netcoredbg build — the adapter detects the target's architecture.
+- `detach_from_process {"sessionId": "<id>"}` never terminates the debuggee (the adapter pins `terminateDebuggee: false`). There is no remote host/port attach — attach is by local PID.
+
+## Quirks
+
+- **TCP-to-stdio bridge:** on all platforms the adapter spawns netcoredbg in stdio mode behind a TCP bridge, working around a netcoredbg `--server=PORT` bug where the connection drops after the DAP initialize sequence. First use can take a moment while the bridge starts.
+- **Portable PDB or nothing:** netcoredbg cannot read Windows-format PDBs. Empty variable lists at a valid breakpoint are usually a symbol-format problem (`/debug:portable` for .NET Framework; the Pdb2Pdb fallback is Windows-only).
+- Compiler-generated noise is filtered from variables automatically: `<>c__DisplayClass*` closures, `CS$<>*` temporaries, `<>t__`/`<>s__` async state-machine fields, `$VB$*`.
+- Stack traces show user code only by default — frames without source and `System.*`/`Microsoft.*` frames are hidden. Pass `includeInternals: true` to `get_stack_trace` to see everything.
+- Supports .NET Core / .NET 5+ and .NET Framework 4.8 (CoreCLR and Desktop CLR).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| "netcoredbg not found" | Env var/PATH not set | Set `NETCOREDBG_PATH` to the executable (restart shell after `setx`) or add its dir to PATH |
+| Empty variables at breakpoint | Non-Portable PDB (typically .NET Framework) | Compile with `/debug:portable`; on Windows the adapter can auto-convert via Pdb2Pdb |
+| Breakpoints not firing | Stale build, missing PDB, or non-executable line | `dotnet build` after edits; keep the PDB next to the DLL; pick an executable line |
+| Launch fails / nothing starts | `program` points at `Program.cs` instead of the built assembly | Point `scriptPath` and `dapLaunchArgs.program` at `bin/Debug/netX.0/App.dll` |
+| Connection timeout on start | TCP-to-stdio bridge still starting, or port conflict | Retry; check nothing else holds the bridge port |
+| Attach to 32-bit process fails | Architecture mismatch | Set `NETCOREDBG_X86_PATH` to an x86 netcoredbg |

--- a/skills/debugging/references/go.md
+++ b/skills/debugging/references/go.md
@@ -1,0 +1,65 @@
+# Go debugging (mcp-debugger)
+
+## Prerequisites
+
+- Go 1.18+ (`go version`).
+- Delve with DAP support on PATH: `go install github.com/go-delve/delve/cmd/dlv@latest` (installs to `~/go/bin` — make sure that is on PATH). Verify with `dlv version` and `dlv dap --help`.
+- Go debugging is disabled in the Docker image by default (`DEBUG_MCP_DISABLE_LANGUAGES`); use a host deployment.
+
+## Launch quickstart
+
+```json
+create_debug_session  {"language": "go", "name": "go-bug-hunt"}
+set_breakpoint        {"sessionId": "<id>", "file": "/abs/path/main.go", "line": 10}
+start_debugging       {"sessionId": "<id>", "scriptPath": "/abs/path/main.go"}
+get_stack_trace       {"sessionId": "<id>"}
+get_local_variables   {"sessionId": "<id>"}
+evaluate_expression   {"sessionId": "<id>", "expression": "x + y*2"}
+step_over             {"sessionId": "<id>"}
+continue_execution    {"sessionId": "<id>"}
+close_debug_session   {"sessionId": "<id>"}
+```
+
+In the default `debug` mode Delve compiles and debugs the main package for you — pass the `.go` source as `scriptPath`. Other launch modes go through `dapLaunchArgs.mode`:
+
+```json
+// Debug a pre-compiled binary (build it with: go build -gcflags="all=-N -l" -o myprogram main.go)
+start_debugging {
+  "sessionId": "<id>",
+  "scriptPath": "/abs/path/myprogram",
+  "dapLaunchArgs": {"mode": "exec", "program": "/abs/path/myprogram"}
+}
+
+// Debug tests: scriptPath/program is the test *directory*
+start_debugging {
+  "sessionId": "<id>",
+  "scriptPath": "/abs/path/pkg",
+  "dapLaunchArgs": {"mode": "test", "program": "/abs/path/pkg"}
+}
+```
+
+For `exec` mode, always build with `-gcflags="all=-N -l"` (disables optimizations and inlining); optimized binaries skip breakpoints and hide variables. Conditional breakpoints work: add `"condition": "x > 10"` to `set_breakpoint`.
+
+## Attach / remote
+
+Not supported. The Go adapter implements launch mode only — `attach_to_process` has no Go backend. To debug a running service, restart it under a launch-mode session instead.
+
+## Quirks
+
+- **KNOWN ISSUE — debuggee stdout not forwarded (issue #225):** `get_output` does not capture the Go program's stdout. Do not debug by adding `fmt.Println` calls — set breakpoints and inspect state with `evaluate_expression`, `get_local_variables`, and `get_variables` instead.
+- **`stopOnEntry` is forced to `false`** by the Go adapter policy (unless you explicitly set it) to dodge Delve's "unknown goroutine 1" quirk. If you force `stopOnEntry: true` and see that error, it is harmless — execution continues. Set a breakpoint on the first line of `main` if you need an entry stop.
+- Goroutine-aware, with limits: stack traces show the current goroutine's frames; Go runtime and testing frames (paths with `/runtime/` or `/testing/`) are filtered out by default — pass `includeInternals: true` to `get_stack_trace` to see them. There are no MCP tools to list or switch goroutines.
+- Exception breakpoints `panic` and `fatal` are enabled by default — panics stop the debugger without any setup (`get_stack_trace` reports `stopReason`).
+- Delve's variable rendering auto-dereferences pointers, shows slices with len/cap, and maps as key-value pairs.
+- Use absolute paths for `file` and `scriptPath`; breakpoints must be on executable statements.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| "Delve not found" | `dlv` not installed or not on PATH | `go install github.com/go-delve/delve/cmd/dlv@latest`; ensure `~/go/bin` on PATH; check `dlv dap --help` |
+| "Go executable not found" | `go` not on PATH | Install Go 1.18+; verify `go version` |
+| Breakpoints not hit | Optimized binary (exec mode) or wrong path/line | Rebuild with `-gcflags="all=-N -l"`; absolute paths; line must be an executable statement |
+| "unknown goroutine 1" error | `stopOnEntry: true` with Delve | Leave `stopOnEntry` unset/false; the error is harmless if it appears |
+| `get_output` empty despite prints | Issue #225 — Go stdout not forwarded | Inspect state via `evaluate_expression` / breakpoints, not stdout |
+| Stack full of runtime frames | `includeInternals: true` set, or panic inside runtime | Omit `includeInternals` for user frames only |

--- a/skills/debugging/references/java.md
+++ b/skills/debugging/references/java.md
@@ -1,0 +1,72 @@
+# Java debugging (mcp-debugger)
+
+## Prerequisites
+
+- JDK 21+ recommended (`java` and `javac` on PATH, or `JAVA_HOME` set). Versions below 21 log a warning but may work.
+- No external adapter: a single-file JDI bridge (`JdiDapServer.java`, using `com.sun.jdi.*` from the JDK) is **compiled on first use via `javac`** — expect the first session to take a little longer.
+- **Compile target code with `javac -g`.** Without `-g` there is no `LocalVariableTable` and variable inspection returns empty lists even at a valid breakpoint. Gradle and Maven include debug info by default.
+
+## Launch quickstart
+
+```json
+create_debug_session  {"language": "java", "name": "java-bug-hunt"}
+// Breakpoint by fully-qualified class name — no file path needed:
+set_breakpoint        {"sessionId": "<id>", "file": "com.example.Main", "line": 10}
+start_debugging       {
+  "sessionId": "<id>",
+  "scriptPath": "/abs/path/src/com/example/Main.java",
+  "dapLaunchArgs": {
+    "mainClass": "com.example.Main",
+    "classpath": "/abs/path/classes",
+    "cwd": "/abs/path/project",
+    "stopOnEntry": false
+  }
+}
+get_stack_trace       {"sessionId": "<id>"}
+get_local_variables   {"sessionId": "<id>"}
+evaluate_expression   {"sessionId": "<id>", "expression": "a + b"}
+step_over             {"sessionId": "<id>"}
+continue_execution    {"sessionId": "<id>"}
+close_debug_session   {"sessionId": "<id>"}
+```
+
+- `set_breakpoint.file` accepts either an FQCN (`"com.example.Main"`) or an absolute `.java` path. FQCNs skip host file checks entirely.
+- `dapLaunchArgs.mainClass` is required; `classpath` defaults to `"."` but is almost always needed. Also supported: `sourcePath`, `env`, `args`, `vmArgs` (e.g. `-Xmx512m`), `javaPath`. For Java, `stopOnEntry` defaults to `true` — set it `false` to run straight to your breakpoints.
+- The expression evaluator supports field access, method calls, arithmetic, and string concatenation.
+
+## Attach / remote
+
+Start the target JVM with the JDWP agent (`suspend=y` pauses until a debugger attaches; `suspend=n` for already-running servers):
+
+```bash
+java -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=y -cp . MyServer
+```
+
+```json
+create_debug_session  {"language": "java"}
+set_breakpoint        {"sessionId": "<id>", "file": "com.example.MyServer", "line": 42}
+attach_to_process     {"sessionId": "<id>", "port": 5005, "host": "localhost", "sourcePaths": ["/abs/path/src"]}
+continue_execution    {"sessionId": "<id>"}   // required with suspend=y to let the JVM run to your breakpoint
+```
+
+- **Deferred breakpoints work natively:** for classes not yet loaded, the JDI bridge registers a `ClassPrepareRequest` and binds the breakpoint when the JVM loads the class, then reports `verified: true`. Set breakpoints freely before or after attach — no re-sends needed.
+- For a busy or warming JVM, raise `verifyTimeout` (ms) on `attach_to_process` — attach fails if no thread is reported within ~5 s by default. Attach sessions skip host-side file checks, so remote paths are fine.
+
+## Quirks
+
+- **`redefine_classes` hot-swap (Java only):** edit → recompile with `javac -g` → call `redefine_classes {"sessionId": "<id>", "classesDir": "/proj/build/classes/java/main", "sinceTimestamp": 0}`. Pass the returned `newestTimestamp` as `sinceTimestamp` next time for incremental swaps. Limits: no schema changes (adding/removing methods/fields fails per class, others still succeed), only already-loaded classes (others land in `skippedNotLoaded`), works paused or running.
+- Empty variables almost always mean the class was compiled without `-g`, or the source no longer matches the compiled class — recompile.
+- Breakpoints must sit on executable lines (assignments, calls, conditionals) — not blank lines, comments, imports, or bare declarations. Conditional breakpoints (`condition`) and exception breakpoints are supported.
+- `set_breakpoint` accepts a Java-only `suspendPolicy`: `"all"` (default) suspends every thread; `"thread"` suspends only the hitting thread.
+- Debuggee stdout/stderr is forwarded — `get_output {"sessionId": "<id>", "since": 0}` works for Java; poll with the returned `nextSince`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Variables list empty at breakpoint | Compiled without `-g`; or stale `.class` | `javac -g`, rebuild, restart session |
+| Breakpoint never fires | Non-executable line; wrong class name; JVM never runs it | Move to executable line; match FQCN to the loaded class; check code path |
+| Attach connects but nothing happens | JVM started with `suspend=y` still paused | Call `continue_execution` after attach |
+| "Java not found" | No JDK on PATH / `JAVA_HOME` unset | Install JDK 21+, set `JAVA_HOME` or fix PATH |
+| Attach connection timeout | Wrong port, firewall, or missing `server=y` | Verify the JDWP agent string and that the port is listening |
+| `redefine_classes` reports `failed` | Schema change (method/field added or removed) | Restart the session for structural edits; body-only edits hot-swap fine |

--- a/skills/debugging/references/javascript.md
+++ b/skills/debugging/references/javascript.md
@@ -1,0 +1,78 @@
+# JavaScript debugging (mcp-debugger)
+
+## Prerequisites
+
+- Node.js 22+ on PATH (or pass `executablePath` in `create_debug_session` to pick a specific Node).
+- No debugger install needed — the adapter bundles Microsoft's js-debug (`pwa-node`, the VSCode Node debugger). Node.js targets only; browser/Chrome debugging is not supported.
+- TypeScript: `.ts` files debug directly if `tsx` or `ts-node` is found (in `node_modules/.bin` or PATH). Otherwise debug the compiled `.js` — source maps still resolve breakpoints set in `.ts` files.
+- Always use absolute file paths.
+
+## Launch quickstart
+
+```text
+create_debug_session { "language": "javascript", "name": "js-bug-hunt" }
+  -> returns sessionId
+
+set_breakpoint  { "sessionId": "<id>", "file": "/abs/path/app.js", "line": 3 }
+start_debugging { "sessionId": "<id>", "scriptPath": "/abs/path/app.js" }
+  -> should stop at your breakpoint; if it stops in a Node internal frame instead,
+     call continue_execution to advance to user code
+
+get_stack_trace { "sessionId": "<id>" }          # shows app.js, internals filtered out
+evaluate_expression { "sessionId": "<id>", "expression": "a * b" }
+step_over       { "sessionId": "<id>" }
+get_local_variables { "sessionId": "<id>" }       # filters `this`, `__proto__`, V8 internals
+continue_execution { "sessionId": "<id>" }
+get_output      { "sessionId": "<id>" }           # console.log / stderr; pass since=nextSince to poll
+close_debug_session { "sessionId": "<id>" }
+```
+
+Pass environment, script args, or cwd through `dapLaunchArgs`:
+
+```text
+start_debugging {
+  "sessionId": "<id>", "scriptPath": "/abs/path/app.js",
+  "dapLaunchArgs": { "env": { "NODE_ENV": "development" }, "cwd": "/abs/path", "stopOnEntry": false }
+}
+```
+
+Conditional breakpoints are supported: `set_breakpoint { ..., "condition": "count > 5" }`.
+
+## Attach / remote
+
+Start the target Node process with the inspector listening, then attach by port:
+
+```bash
+node --inspect=9229 server.js        # or --inspect-brk=9229 to pause at first line
+```
+
+```text
+create_debug_session { "language": "javascript" }
+attach_to_process    { "sessionId": "<id>", "host": "127.0.0.1", "port": 9229 }
+set_breakpoint       { "sessionId": "<id>", "file": "/abs/path/server.js", "line": 42 }
+continue_execution   { "sessionId": "<id>" }
+```
+
+Shorthand: `create_debug_session { "language": "javascript", "host": "127.0.0.1", "port": 9229 }` attaches in one call. Attach is verified by polling for threads (`verifyTimeout`, default ~5000 ms). Detach with `detach_from_process { "sessionId": "<id>", "terminateProcess": false }`; remote debugging beyond a reachable host/port requires manual configuration (e.g. an SSH tunnel).
+
+## Quirks
+
+- **Child-session architecture.** js-debug runs a parent session for launch orchestration and spawns a child session for the actual debuggee. This is invisible to you: the proxy routes evaluate/step/stack commands to the active context automatically. Never create a second MCP session for the "other" half.
+- **Entry pause auto-continues.** With `stopOnEntry: false` (the default) the debugger automatically continues past entry breakpoints, so execution runs straight to your first breakpoint. Set `dapLaunchArgs: { "stopOnEntry": true }` only when you want control at the first line.
+- **Stack filtering hides Node internals.** `get_stack_trace` returns user frames only by default; pass `includeInternals: true` if you genuinely need Node.js internal frames. If execution initially stops inside internals, just `continue_execution`.
+- **TypeScript auto-detection.** Point `scriptPath` at the `.ts` file when `tsx`/`ts-node` is available. If neither is installed you get a warning (not an error) — fall back to the compiled `.js` with source maps.
+- **Child processes are not auto-attached.** `autoAttachChildProcesses` defaults to `false`; pass it as `true` in `dapLaunchArgs` to debug `spawn`-ed Node children.
+- **Output capture works** (`outputCapture: 'std'`): stdout/stderr appear as `get_output` entries; entries without a category default to `console`.
+- **Frame IDs are adapter-assigned.** Use the `id` field from `get_stack_trace` frames for `get_scopes` — not the array index, not 0. Locals scopes are named `Local`/`Block`, and values come back as strings.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Breakpoint never hits | Relative/mismatched path, or the line never executes | Use absolute paths; confirm the code path runs; for `.ts` confirm source maps or a TS runner |
+| Session fails to start | Node not found or script has a syntax error | Check Node on PATH or pass `executablePath`; run the script plainly first |
+| Stopped in a Node internal frame at start | Debugger paused before reaching user code | `continue_execution` — it will run to your breakpoint |
+| `.ts` debugging fails | No `tsx`/`ts-node` available | Install one, or debug the compiled `.js` output |
+| Variables empty / "Session is not paused" | Inspection while running | Wait for `paused` state, then use frame IDs from `get_stack_trace` |
+| Attach connection refused | Target not started with `--inspect=<port>` or port unreachable | Restart target with the inspector flag; verify the port |
+| Need adapter diagnostics | — | Relaunch with `dapLaunchArgs: { "trace": true }` |

--- a/skills/debugging/references/python.md
+++ b/skills/debugging/references/python.md
@@ -1,0 +1,73 @@
+# Python debugging (mcp-debugger)
+
+## Prerequisites
+
+- Python 3.7+ with debugpy installed: `pip install debugpy` (verify with `python -m debugpy --version`).
+- The server auto-detects the Python interpreter from PATH. To pin one, set the `PYTHON_PATH` env var (`PYTHON_EXECUTABLE` is checked as a fallback), or pass `executablePath` in `create_debug_session`.
+- Always use absolute file paths. In host mode relative paths are rejected; in container mode paths get a `/workspace/` prefix.
+
+## Launch quickstart
+
+```text
+create_debug_session { "language": "python", "name": "py-bug-hunt" }
+  -> returns sessionId
+
+set_breakpoint  { "sessionId": "<id>", "file": "/abs/path/app.py", "line": 14 }
+  -> "verified": false is NORMAL here (see Quirks); response echoes surrounding source
+
+start_debugging { "sessionId": "<id>", "scriptPath": "/abs/path/app.py", "args": ["--flag"] }
+  -> state "paused", reason "breakpoint"
+
+get_stack_trace { "sessionId": "<id>" }          # top frame's "id" is the frameId — NOT necessarily 0
+get_scopes      { "sessionId": "<id>", "frameId": <top frame id> }
+get_variables   { "sessionId": "<id>", "scope": <variablesReference from a scope> }
+evaluate_expression { "sessionId": "<id>", "expression": "a + b" }
+step_over       { "sessionId": "<id>" }
+continue_execution { "sessionId": "<id>" }
+get_output      { "sessionId": "<id>" }           # captured stdout/stderr; pass since=nextSince to poll
+close_debug_session { "sessionId": "<id>" }
+```
+
+Shortcut: `get_local_variables { "sessionId": "<id>" }` does stack -> scopes -> variables in one call and filters out `__builtins__` and special variables (pass `includeSpecial: true` to see them).
+
+Optional launch tuning via `dapLaunchArgs`: `{ "stopOnEntry": true }` to pause on the first line, `{ "justMyCode": false }` to step into library code. `dryRunSpawn: true` tests the spawn without debugging.
+
+## Attach / remote
+
+Python attaches only to a listening debugpy endpoint — attaching by `processId` is not supported. Start the target yourself:
+
+```bash
+python -m debugpy --listen 127.0.0.1:5678 --wait-for-client script.py
+```
+
+(`--wait-for-client` blocks the script until you attach — use it for anything short-lived.) Then:
+
+```text
+create_debug_session { "language": "python" }
+attach_to_process    { "sessionId": "<id>", "host": "127.0.0.1", "port": 5678 }
+set_breakpoint       { "sessionId": "<id>", "file": "/abs/path/script.py", "line": 20 }
+continue_execution   { "sessionId": "<id>" }
+```
+
+Shorthand: `create_debug_session { "language": "python", "host": "127.0.0.1", "port": 5678 }` creates the session and attaches in one call. After the handshake the attach is verified by polling for threads; raise `verifyTimeout` (default ~5000 ms) for slow targets. Detach with `detach_from_process { "sessionId": "<id>", "terminateProcess": false }`.
+
+## Quirks
+
+- **Breakpoints report `"verified": false` at set time.** debugpy verifies them asynchronously once it loads the module. Set them anyway, then `start_debugging` — they bind and hit. Do not retry-loop on the unverified flag.
+- **"special variables" container.** `get_variables` on a Locals scope may return `{"name": "special variables", "variablesReference": N}`. That is a container, not a variable: call `get_variables` again with `scope: N` to expand it and reveal the real locals. Always check `variablesReference > 0` / `expandable: true` and expand recursively. `get_local_variables` avoids this dance.
+- **frameId vs variablesReference.** `get_scopes` takes the frame `id` from `get_stack_trace`; `get_variables` takes the scope's `variablesReference`. They are different numbers — never swap them.
+- **Set breakpoints on executable lines** (assignments, calls, returns). Comments, blank lines, and bare `def`/`class` lines misbehave.
+- **evaluate_expression** runs in debugpy's `variables` (watch-style) context by default. Reads and arithmetic are reliable; whether mutations like `x = 5` take effect depends on debugpy — verify with a follow-up evaluate before relying on one. Collections are truncated at 300 items.
+- **Output capture works for Python** (`redirectOutput`): `print()` and stderr land in `get_output` entries, readable during and after the run until the session closes.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Session create/start fails, "Python not found" | Interpreter not on PATH | Set `PYTHON_PATH` (or `PYTHON_EXECUTABLE`), or pass `executablePath` in `create_debug_session` |
+| Launch fails mentioning debugpy | debugpy not installed for that interpreter | `python -m pip install debugpy` using the same interpreter the session uses |
+| `File not found` with a resolved path you didn't expect | Relative path resolved against the MCP client's cwd (or rejected in host mode) | Use absolute paths for `file` and `scriptPath` |
+| Breakpoint never hits | Wrong file path, line not executed, or non-executable line | Verify absolute path matches the running file; move breakpoint to an executable statement on a reached code path |
+| `evaluate_expression` -> "NameError: name ... is not defined" | Variable not assigned yet, or wrong frame | `get_stack_trace` to confirm location; step past the assignment; pass an explicit `frameId` |
+| Attach fails when passing `processId` | Python attach is port-only | Restart target with `python -m debugpy --listen 127.0.0.1:<port>` and attach with `host`/`port` |
+| "Session is not paused" errors | Inspection attempted while running | Wait for `paused` state (check `list_debug_sessions`), or `pause_execution` first |

--- a/skills/debugging/references/ruby.md
+++ b/skills/debugging/references/ruby.md
@@ -1,0 +1,88 @@
+# Ruby debugging (mcp-debugger)
+
+## Prerequisites
+
+- Ruby 2.7+ (3.1+ recommended — it bundles the `debug` gem). Need `debug` gem 1.7+ providing `rdbg`: `gem install debug`. Verify with `ruby --version` and `rdbg --version`.
+- Auto-detects `ruby`/`rdbg` from PATH and common install locations (RubyInstaller `C:\RubyXX-x64\bin`, Homebrew, system paths). Override with `RUBY_PATH` / `RDBG_PATH` env vars.
+- Windows: gem executables are `.bat` shims that Node cannot spawn directly — mcp-debugger automatically runs the sibling `rdbg` Ruby script via your Ruby interpreter. No configuration needed.
+- Use absolute file paths.
+
+## Launch quickstart
+
+```text
+create_debug_session { "language": "ruby", "name": "rb-bug-hunt" }
+  -> returns sessionId
+
+set_breakpoint  { "sessionId": "<id>", "file": "/abs/path/app.rb", "line": 15 }
+start_debugging { "sessionId": "<id>", "scriptPath": "/abs/path/app.rb" }
+  -> rdbg suspends the script at load, breakpoints are configured before any code runs,
+     then execution auto-continues to your breakpoint (stopOnEntry defaults to false)
+
+get_stack_trace { "sessionId": "<id>" }
+get_scopes      { "sessionId": "<id>", "frameId": <top frame id> }   # rdbg reports "Local variables"
+get_local_variables { "sessionId": "<id>" }
+evaluate_expression { "sessionId": "<id>", "expression": "items.size" }
+step_over       { "sessionId": "<id>" }
+continue_execution { "sessionId": "<id>" }
+close_debug_session { "sessionId": "<id>" }
+```
+
+Conditional breakpoints work: `set_breakpoint { ..., "condition": "i == 6" }`.
+
+**Bundler projects (Rails, RSpec):** run the target via `bundle exec` by passing `useBundler` in the adapter launch config:
+
+```text
+start_debugging {
+  "sessionId": "<id>",
+  "scriptPath": "/abs/path/bin/rspec",
+  "adapterLaunchConfig": { "useBundler": true }
+}
+```
+
+## Attach / remote
+
+Start the target with an rdbg DAP listener:
+
+```bash
+rdbg --open --host 127.0.0.1 --port 12345 app.rb            # suspended at load (debug startup)
+rdbg --open --host 127.0.0.1 --port 12345 --nonstop app.rb  # runs immediately (services)
+```
+
+```text
+create_debug_session { "language": "ruby", "name": "attach" }
+attach_to_process    { "sessionId": "<id>", "host": "127.0.0.1", "port": 12345 }
+  -> attach pauses the target (an explicit pause is issued if it was running),
+     so you can set breakpoints and inspect immediately
+set_breakpoint       { "sessionId": "<id>", "file": "/app/app.rb", "line": 18 }
+continue_execution   { "sessionId": "<id>" }
+detach_from_process  { "sessionId": "<id>", "terminateProcess": false }   # target keeps running; re-attach later
+```
+
+No adapter process is spawned for attach — the proxy connects straight to rdbg's TCP socket, so anything that forwards TCP gives remote debugging. Kubernetes pattern:
+
+```bash
+kubectl port-forward pod/my-pod 12399:12345
+# then: attach_to_process { "sessionId": "<id>", "host": "127.0.0.1", "port": 12399 }
+```
+
+For containers/pods, use the **debuggee's** filesystem paths in `set_breakpoint` (e.g. `/app/app.rb`, as reported by `get_stack_trace`) — host-side file existence checks are skipped for attach sessions. Security: the rdbg socket is unauthenticated and allows arbitrary code execution; reach it only via localhost port mappings, `kubectl port-forward`, or an SSH tunnel — never a public interface.
+
+## Quirks
+
+- **Launch always stops at load.** rdbg suspends the script before the first line so breakpoints bind even for scripts that finish in milliseconds. With `stopOnEntry: false` (default) that entry pause is released automatically; with `dapLaunchArgs: { "stopOnEntry": true }` you get control at the first line.
+- **KNOWN ISSUE — `get_output` captures nothing for Ruby (issue #222).** rdbg routes debuggee stdout/stderr to the adapter process, so no output entries are recorded. Do not diagnose by reading stdout. Instead: have the script write results to a file you can read, or pause at a breakpoint and use `evaluate_expression` / `get_local_variables` to inspect state directly.
+- **evaluate_expression runs in rdbg's `repl` context** — expressions can read *and modify* program state (`x = 5` works). Useful for testing fixes live.
+- **Scope name is `Local variables`** (not "Locals"); `get_local_variables` handles this for you. Locals are only reported while stopped.
+- **Windows `.bat` shim bypass is automatic** — if spawn fails anyway, set `RDBG_PATH` to the rdbg script inside your Ruby installation's `bin` directory.
+- **Ruby startup can take a few seconds** on launch; don't declare a timeout after one slow start.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `rdbg not found` | debug gem missing or not on PATH | `gem install debug`, or set `RDBG_PATH` (and `RUBY_PATH` if ruby itself isn't found) |
+| Connect timeout on launch | Slow Ruby startup, or spawn failed | Retry; check the session log in the temp directory for the spawn command and rdbg's stderr |
+| Connect refused on attach | Target not listening | Start it with `rdbg --open --host <h> --port <p>`; rdbg prints `Debugger can attach via TCP/IP` when ready; verify port-forwarding |
+| Breakpoint not verified on attach | Host path used for a remote/container target | Use the path as the debuggee sees it (e.g. `/app/app.rb` from `get_stack_trace`) |
+| Locals empty | Session not paused | Hit a breakpoint or `pause_execution` first — rdbg reports locals only while stopped |
+| `get_output` returns no entries | Issue #222 — Ruby debuggee stdio is not captured | Write to a file from the script, or inspect via `evaluate_expression` at a breakpoint |

--- a/skills/debugging/references/rust.md
+++ b/skills/debugging/references/rust.md
@@ -1,0 +1,71 @@
+# Rust debugging (mcp-debugger)
+
+## Prerequisites
+
+- Rust toolchain (`rustc`, `cargo`) installed via rustup.
+- CodeLLDB debug adapter is vendored automatically at install/build time (`pnpm install` postinstall, or `pnpm --filter @debugmcp/adapter-rust run build:adapter`). The published npx CLI ships only the Linux x64 CodeLLDB runtime — on macOS/Windows set `CODELLDB_PATH` to a local CodeLLDB install (e.g. from the VSCode extension) or vendor from a cloned repo.
+- **Windows: use the GNU toolchain.** CodeLLDB needs DWARF symbols; MSVC builds emit PDB, which LLDB reads only partially (variables often show `<unavailable>`). Build with:
+  ```bash
+  rustup target add x86_64-pc-windows-gnu
+  cargo +stable-gnu build --target x86_64-pc-windows-gnu
+  ```
+- Rust debugging is **disabled in the Docker image** by default (`DEBUG_MCP_DISABLE_LANGUAGES`). Use a host (stdio/http) deployment.
+
+## Launch quickstart
+
+Build first (`cargo build` — debug profile, not release), then:
+
+```json
+create_debug_session  {"language": "rust", "name": "rust-bug-hunt"}
+set_breakpoint        {"sessionId": "<id>", "file": "C:/proj/src/main.rs", "line": 10}
+start_debugging       {"sessionId": "<id>", "scriptPath": "C:/proj/src/main.rs"}
+get_stack_trace       {"sessionId": "<id>"}
+get_local_variables   {"sessionId": "<id>"}
+evaluate_expression   {"sessionId": "<id>", "expression": "my_vec.len()"}
+step_over             {"sessionId": "<id>"}
+continue_execution    {"sessionId": "<id>"}
+close_debug_session   {"sessionId": "<id>"}
+```
+
+- `scriptPath` may be the **source file** (`.rs`): the adapter locates the enclosing Cargo project, resolves the default binary, and rebuilds it if stale. Passing the compiled binary path (`target/debug/my_program` or `target/x86_64-pc-windows-gnu/debug/my_program.exe`) also works.
+- Breakpoints always reference the **`.rs` source file**, never the binary. Use absolute paths.
+- Select a specific target or pass env via `dapLaunchArgs`; program args go in top-level `args`:
+
+```json
+start_debugging {
+  "sessionId": "<id>",
+  "scriptPath": "C:/proj/src/main.rs",
+  "args": ["--verbose", "input.txt"],
+  "dapLaunchArgs": {
+    "cargo": {"bin": "my_program", "release": false},
+    "env": {"RUST_BACKTRACE": "1", "RUST_LOG": "debug"}
+  }
+}
+```
+
+The `cargo` object also accepts `example` and `test` target names. To debug a unit test, `cargo test --no-run`, then pass the test executable from `target/debug/deps/` as `scriptPath` with `args: ["test_name", "--nocapture"]`.
+
+## Attach / remote
+
+Not supported. The Rust adapter implements launch mode only — `attach_to_process` has no Rust backend. To debug a long-running program, launch it under the debugger instead.
+
+## Quirks
+
+- **Windows toolchain (critical):** MSVC-built binaries give control flow only — breakpoints/stepping work, but strings, Vecs, and structs show `<unavailable>` or corrupted values. `RUST_MSVC_BEHAVIOR` controls what happens when an MSVC binary is detected: `warn` (default — log and proceed), `error` (fail with `ENVIRONMENT_INVALID`), `continue` (silent). Check any binary first with `mcp-debugger check-rust-binary target/debug/app.exe` — it reports `Toolchain: GNU` or `MSVC`.
+- **Windows initial stop:** debugging may first stop in system functions (not user code). Issue one `continue_execution` to reach your breakpoint; auto-continue through these system stops is not yet implemented.
+- **KNOWN ISSUE — `get_output` may be empty (issue #223):** debuggee stdout may not appear in `get_output` due to a launch-config console/terminal mismatch. Do not rely on print debugging — inspect state with `evaluate_expression`, `get_local_variables`, and breakpoints instead.
+- Expression evaluation goes through LLDB: simple field access and method calls like `my_vec.len()` work, but Rust-specific syntax (closures, trait methods) may not.
+- Debug builds only: release builds need `debug = true` in `[profile.release]` and still inline/optimize away variables. Prefer `opt-level = 0`.
+- GNU builds of crates that import Windows DLLs (`tokio`, `windows-sys`, `parking_lot_core`, ...) need full MinGW binutils — rustup's self-contained toolchain lacks `as.exe`, so `dlltool` fails. Install via MSYS2 (`mingw-w64-x86_64-binutils`, `-gcc`) and prepend `C:\msys64\mingw64\bin` to PATH.
+- Macro-generated and generic code can behave oddly: step targets may land in expansions, and generic fns need a concrete instantiation for breakpoints. For async (tokio), set breakpoints inside async blocks, not on the `async fn` line.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Breakpoints never hit | Release/optimized build lacks usable debug info | `cargo build` (debug profile), `opt-level = 0`; absolute source paths |
+| Variables `<unavailable>` / garbage strings (Windows) | MSVC toolchain — PDB symbols | Rebuild: `cargo +stable-gnu build --target x86_64-pc-windows-gnu`; verify with `check-rust-binary` |
+| "Can't find CodeLLDB" | Adapter not vendored / npx package on non-Linux | Run `pnpm --filter @debugmcp/adapter-rust run build:adapter`, or set `CODELLDB_PATH` |
+| First stop is in system/ntdll frames | Windows initial system breakpoint | `continue_execution` once, then you land on your breakpoint |
+| `dlltool ... CreateProcess` build error | rustup GNU toolchain missing `as.exe` | Install MSYS2 mingw-w64 binutils/gcc; prepend `C:\msys64\mingw64\bin` to PATH |
+| `get_output` returns no stdout | Issue #223 (console/terminal launch mismatch) | Use `evaluate_expression` / variables at breakpoints instead |

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,10 +10,13 @@ import {
   ReadResourceRequestSchema,
   SubscribeRequestSchema,
   UnsubscribeRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
   ErrorCode as McpErrorCode,
   McpError,
   ServerResult,
 } from '@modelcontextprotocol/sdk/types.js';
+import { SERVER_INSTRUCTIONS, DEBUGGING_WORKFLOW_PROMPT } from './skill-content.js';
 import {
   SessionNotFoundError,
   SessionTerminatedError,
@@ -509,7 +512,10 @@ export class DebugMcpServer {
 
     this.server = new Server(
       { name: 'debug-mcp-server', version: '0.1.0' },
-      { capabilities: { tools: {}, resources: { subscribe: true, listChanged: true } } }
+      {
+        capabilities: { tools: {}, resources: { subscribe: true, listChanged: true }, prompts: {} },
+        instructions: SERVER_INSTRUCTIONS
+      }
     );
 
     const sessionManagerConfig: SessionManagerConfig = {
@@ -520,6 +526,7 @@ export class DebugMcpServer {
 
     this.registerTools();
     this.registerResources();
+    this.registerPrompts();
     this.sessionManager.on('output-captured', this.handleOutputCaptured);
     this.server.onerror = (error) => {
       this.logger.error('Server error', { error });
@@ -1353,6 +1360,39 @@ export class DebugMcpServer {
       this.subscribedUris.delete(uri);
       this.clearOutputUpdateTimer(uri);
       return {};
+    });
+  }
+
+  /**
+   * Registers MCP prompt handlers. The single `debugging-workflow` prompt
+   * serves the condensed debugging skill in-band so any connected agent can
+   * pull workflow guidance without a separate skill install (the full skill
+   * with per-language references ships in skills/debugging/).
+   */
+  private registerPrompts(): void {
+    const promptDescriptor = {
+      name: 'debugging-workflow',
+      description:
+        'How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks.'
+    };
+
+    this.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+      prompts: [promptDescriptor]
+    }));
+
+    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      if (request.params.name !== promptDescriptor.name) {
+        throw new McpError(McpErrorCode.InvalidParams, `Unknown prompt: ${request.params.name}`);
+      }
+      return {
+        description: promptDescriptor.description,
+        messages: [
+          {
+            role: 'user' as const,
+            content: { type: 'text' as const, text: DEBUGGING_WORKFLOW_PROMPT }
+          }
+        ]
+      };
     });
   }
 

--- a/src/skill-content.ts
+++ b/src/skill-content.ts
@@ -1,0 +1,73 @@
+/**
+ * In-band agent guidance served over MCP.
+ *
+ * SERVER_INSTRUCTIONS is sent once in the initialize handshake (the MCP
+ * `instructions` field); DEBUGGING_WORKFLOW_PROMPT backs the
+ * `debugging-workflow` prompt. Both are condensed views of the full agent
+ * skill in skills/debugging/ — when editing one, check the other and the
+ * skill for drift.
+ */
+
+export const SERVER_INSTRUCTIONS = `mcp-debugger drives real step-through debuggers (Python, JavaScript/TypeScript, Ruby, Rust, Go, Java, .NET) as MCP tools.
+
+Golden path: create_debug_session -> set_breakpoint (ABSOLUTE file path) -> start_debugging (ABSOLUTE scriptPath) -> get_stack_trace -> get_scopes(frameId from the stack frame's "id" field) -> get_variables / get_local_variables / evaluate_expression -> step_* or continue_execution -> get_output -> close_debug_session (always, even on failure).
+
+Key rules:
+- Stepping/evaluation/variable reads require the session to be PAUSED; the stop reason on each pause tells you why it stopped.
+- If a variable entry has a variablesReference, call get_variables with it to expand children.
+- Breakpoints may report unverified until the module/class loads — that is normal.
+- get_output returns buffered debuggee stdout/stderr with a cursor; pass nextCursor back to read only new output.
+- attach_to_process connects to running/remote targets (debugpy --listen, rdbg --open, JVM JDWP), including pods via port-forward.
+
+For the full debugging workflow (root-cause discipline, per-language quirks), request the "debugging-workflow" prompt or install the agent skill from skills/debugging/ in the repo.`;
+
+export const DEBUGGING_WORKFLOW_PROMPT = `# Debugging workflow (mcp-debugger)
+
+Prefer the debugger over print-debugging whenever you would need more than one edit-run cycle to see program state.
+
+## Golden path (launch)
+1. create_debug_session {language} -> sessionId
+2. set_breakpoint {sessionId, file: ABSOLUTE path, line}
+3. start_debugging {sessionId, scriptPath: ABSOLUTE path}
+4. get_stack_trace {sessionId} — use each frame's "id" field; it is adapter-assigned, never assume 0
+5. get_scopes {sessionId, frameId} -> variablesReference per scope
+6. get_variables {sessionId, scope: variablesReference} or get_local_variables {sessionId}
+7. evaluate_expression {sessionId, expression}
+8. step_over / step_into / step_out / continue_execution
+9. get_output {sessionId} — cursor-based; pass nextCursor back for only-new output
+10. close_debug_session {sessionId} — ALWAYS, even after errors
+
+## Root-cause discipline
+- State a hypothesis before setting breakpoints.
+- Set two breakpoints: last-known-good and first-known-bad; run, inspect, halve the interval (bisection beats line-by-line stepping).
+- At each pause record what you learned, not just where you are.
+- When you find the diverging line, inspect every operand before concluding.
+- After fixing, re-run the same recipe to confirm the state changed as predicted.
+
+## Session state rules
+- PAUSED is required for stepping, evaluation, and variable reads; RUNNING follows continue_execution.
+- Each pause carries a stop reason (breakpoint, step, entry, exception...).
+- Variable entries with a variablesReference are containers — expand them with get_variables.
+- Breakpoints may verify late (debugpy, JDI defer until load) — not an error.
+
+## Attach / remote
+attach_to_process {sessionId, host, port, localRoot, remoteRoot}
+- Python: target started with "python -m debugpy --listen host:port ..."
+- Ruby: target started with "rdbg --open --port N ..." (works via kubectl port-forward)
+- Java: JVM flag -agentlib:jdwp=transport=dt_socket,server=y,address=*:PORT (breakpoints defer until class load)
+detach_from_process leaves the target running.
+
+## Per-language quirks (one-liners)
+- Python: expand the "special variables" container; breakpoints verify after module load.
+- JavaScript/TS: internals are filtered from stacks; entry pause auto-continues when stopOnEntry=false.
+- Ruby: launch always pauses at load then auto-continues; stdout capture currently has gaps (#222) — verify state via evaluate_expression.
+- Rust: scriptPath is the source file (adapter resolves the Cargo project); Windows needs the GNU toolchain.
+- Go: Delve native DAP; stdout capture gap (#225) — verify via evaluate_expression.
+- Java: compile with javac -g; FQCN accepted as breakpoint "file"; redefine_classes hot-swaps changed classes.
+- .NET: scriptPath is the compiled .dll; PDBs must be Portable format.
+
+## Current limitations
+- No exception breakpoints yet (#220): uncaught exceptions terminate the session — breakpoint the raise path instead.
+- No breakpoint list/remove tools yet: track what you set.
+
+The full skill (with per-language reference files) lives in skills/debugging/ of the mcp-debugger repo.`;

--- a/tests/core/unit/server/server-initialization.test.ts
+++ b/tests/core/unit/server/server-initialization.test.ts
@@ -53,7 +53,10 @@ describe('Server Initialization Tests', () => {
       
       expect(Server).toHaveBeenCalledWith(
         { name: 'debug-mcp-server', version: '0.1.0' },
-        { capabilities: { tools: {}, resources: { subscribe: true, listChanged: true } } }
+        {
+          capabilities: { tools: {}, resources: { subscribe: true, listChanged: true }, prompts: {} },
+          instructions: expect.stringContaining('mcp-debugger drives real step-through debuggers')
+        }
       );
       
       expect(createProductionDependencies).toHaveBeenCalledWith({
@@ -91,8 +94,9 @@ describe('Server Initialization Tests', () => {
     it('should register tool and resource handlers', () => {
       debugServer = new DebugMcpServer();
 
-      // ListTools + CallTool, plus ListResources/ReadResource/Subscribe/Unsubscribe (issue #218)
-      expect(mockServer.setRequestHandler).toHaveBeenCalledTimes(6);
+      // ListTools + CallTool, ListResources/ReadResource/Subscribe/Unsubscribe (issue #218),
+      // plus ListPrompts/GetPrompt for the debugging-workflow prompt
+      expect(mockServer.setRequestHandler).toHaveBeenCalledTimes(8);
     });
 
     it('should set error handler', () => {

--- a/tests/core/unit/server/server-prompts.test.ts
+++ b/tests/core/unit/server/server-prompts.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Prompt handler tests: the debugging-workflow prompt serves the condensed
+ * agent skill in-band (prompts/list + prompts/get).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { DebugMcpServer } from '../../../../src/server.js';
+import { SessionManager } from '../../../../src/session/session-manager.js';
+import { createProductionDependencies } from '../../../../src/container/dependencies.js';
+import { DEBUGGING_WORKFLOW_PROMPT } from '../../../../src/skill-content.js';
+import {
+  createMockDependencies,
+  createMockServer,
+  createMockSessionManager,
+  createMockStdioTransport,
+  getPromptHandlers
+} from './server-test-helpers.js';
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js');
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js');
+vi.mock('../../../../src/session/session-manager.js');
+vi.mock('../../../../src/container/dependencies.js');
+
+describe('Server Prompts Tests', () => {
+  let debugServer: DebugMcpServer;
+  let mockServer: any;
+
+  beforeEach(() => {
+    const mockDependencies = createMockDependencies();
+    vi.mocked(createProductionDependencies).mockReturnValue(mockDependencies);
+
+    mockServer = createMockServer();
+    vi.mocked(Server).mockImplementation(function() { return mockServer as any; });
+
+    const mockStdioTransport = createMockStdioTransport();
+    vi.mocked(StdioServerTransport).mockImplementation(function() { return mockStdioTransport as any; });
+
+    const mockSessionManager = createMockSessionManager(mockDependencies.adapterRegistry);
+    vi.mocked(SessionManager).mockImplementation(function() { return mockSessionManager as any; });
+
+    debugServer = new DebugMcpServer();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists the debugging-workflow prompt', async () => {
+    const { listPromptsHandler } = getPromptHandlers(mockServer);
+    const result = await listPromptsHandler({ method: 'prompts/list', params: {} });
+
+    expect(result.prompts).toHaveLength(1);
+    expect(result.prompts[0].name).toBe('debugging-workflow');
+    expect(result.prompts[0].description).toContain('debug');
+  });
+
+  it('serves the workflow content for prompts/get', async () => {
+    const { getPromptHandler } = getPromptHandlers(mockServer);
+    const result = await getPromptHandler({
+      method: 'prompts/get',
+      params: { name: 'debugging-workflow' }
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+    expect(result.messages[0].content.text).toBe(DEBUGGING_WORKFLOW_PROMPT);
+    expect(result.messages[0].content.text).toContain('close_debug_session');
+  });
+
+  it('rejects unknown prompt names', async () => {
+    const { getPromptHandler } = getPromptHandlers(mockServer);
+    await expect(
+      getPromptHandler({ method: 'prompts/get', params: { name: 'nope' } })
+    ).rejects.toThrow(McpError);
+  });
+});

--- a/tests/core/unit/server/server-test-helpers.ts
+++ b/tests/core/unit/server/server-test-helpers.ts
@@ -135,3 +135,11 @@ export function getResourceHandlers(mockServer: any) {
     unsubscribeHandler: handlers[5]?.[1]
   };
 }
+
+export function getPromptHandlers(mockServer: any) {
+  const handlers = mockServer.setRequestHandler.mock.calls;
+  return {
+    listPromptsHandler: handlers[6]?.[1],
+    getPromptHandler: handlers[7]?.[1]
+  };
+}


### PR DESCRIPTION
## What

Adds the procedural-knowledge layer on top of the tool surface — the thing that turns 22 debugging tools into effective agent debugging:

- **`skills/debugging/`** — an installable [agent skill](https://agentskills.io): `SKILL.md` (when to debug, session golden path, root-cause bisection discipline, attach/remote recipes, honest current limitations) plus per-language references for all seven languages, distilled from `docs/` and real dogfooding transcripts. Install into `~/.claude/skills/`, `~/.agents/skills/`, or `~/.copilot/skills/`.
- **MCP `instructions`** — a condensed golden path served in the initialize handshake, so every connected client gets baseline guidance with zero setup.
- **`debugging-workflow` prompt** — the condensed skill retrievable in-band via `prompts/list` / `prompts/get` by any MCP client.
- **README positioning** — 'No IDE required' framing, an honest when-to-use-which comparison vs [microsoft/DebugMCP](https://github.com/microsoft/DebugMCP), and skill install instructions.

## Why

Tools tell an agent *what* it can do; a skill teaches it *how to debug well*. The skill also states current limitations with issue links (#220 exception breakpoints, #222/#223/#225 output-capture gaps) so agents route around them instead of flailing.

## Tests

- New `server-prompts.test.ts` (list/get/unknown-name) and updated initialization expectations (capabilities now include `prompts`, 8 request handlers).
- All 115 server unit tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)