### PR TITLE
chore: make ownership and backing explicit (Sycamore LLC) + release SBOMs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -470,6 +470,27 @@ jobs:
         echo "$CHANGELOG" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
     
+    # SBOMs (SPDX + CycloneDX) are generated from the exact release ref and
+    # attached to the GitHub release — required by many corporate/government
+    # procurement processes (EO 14028) and useful for downstream scanners.
+    - name: Generate SBOM (SPDX)
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+      with:
+        path: .
+        format: spdx-json
+        output-file: sbom.spdx.json
+        upload-artifact: false
+        upload-release-assets: false
+
+    - name: Generate SBOM (CycloneDX)
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+      with:
+        path: .
+        format: cyclonedx-json
+        output-file: sbom.cyclonedx.json
+        upload-artifact: false
+        upload-release-assets: false
+
     - name: Create Release with GitHub CLI
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -529,4 +550,6 @@ jobs:
           $PRERELEASE_FLAG \
           release-artifacts/*.tgz \
           provenance/multiple.intoto.jsonl \
-          provenance/multiple.sigstore.json
+          provenance/multiple.sigstore.json \
+          sbom.spdx.json \
+          sbom.cyclonedx.json

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,33 @@
+# Governance
+
+This document describes how decisions are made in mcp-debugger. It exists so that users — including corporate and government adopters — can see exactly who is accountable for what.
+
+## Ownership
+
+mcp-debugger is stewarded by **Sycamore LLC**, which holds the GitHub organization, the `@debugmcp` npm scope, the `debugmcp` Docker Hub organization, and the PyPI project. The project is MIT-licensed; the license grant is irrevocable and does not depend on the steward.
+
+## Roles
+
+- **Maintainers** (listed in [MAINTAINERS.md](MAINTAINERS.md)) — merge authority, release authority, security-response authority.
+- **Contributors** — anyone submitting issues or pull requests under [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## How changes land
+
+mcp-debugger uses an **agent-first development model with human accountability**: AI coding agents produce most implementation work, while humans retain all trust decisions.
+
+1. All changes go through pull requests — no direct pushes to `main` (enforced server-side by branch protection).
+2. CI is the primary quality gate: required status checks (build/test on Linux and Windows, lint, container tests) must pass.
+3. **A human maintainer makes every merge decision and every release decision.** Agents cannot merge, publish, or modify branch protection.
+4. Releases are tagged by a maintainer and built/published by CI with pinned actions, OIDC trusted publishing, sigstore provenance, and SBOMs (see [SUPPLY-CHAIN-SECURITY.md](SUPPLY-CHAIN-SECURITY.md)).
+
+## Decision-making
+
+Day-to-day decisions are made by the lead maintainer. Significant directional changes (new language adapters, protocol-surface changes, deprecations) are proposed and discussed in GitHub issues before implementation — the issue tracker is the project's decision record.
+
+## Security decisions
+
+Vulnerability handling follows [SECURITY.md](SECURITY.md): private disclosure via GitHub Security Advisories or debug@sycamore.llc, coordinated release of fixes, and public advisories after patches ship.
+
+## Changes to this document
+
+Changes to governance require a pull request approved by the lead maintainer.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Debug MCP Server Contributors
+Copyright (c) 2025 Sycamore LLC and mcp-debugger contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,26 @@
+# Maintainers
+
+mcp-debugger is maintained by [Sycamore LLC](mailto:debug@sycamore.llc).
+
+| Name | GitHub | Affiliation | Role |
+|---|---|---|---|
+| John Franklin | [@debugmcpdev](https://github.com/debugmcpdev) | Sycamore LLC | Lead maintainer, release authority |
+
+## Responsibilities
+
+Maintainers review and merge pull requests, cut releases, hold publishing access for the distribution channels below, and triage security reports per [SECURITY.md](SECURITY.md).
+
+| Channel | Identity |
+|---|---|
+| npm | [`@debugmcp` scope](https://www.npmjs.com/org/debugmcp) (OIDC trusted publishing — no personal tokens) |
+| Docker Hub | [`debugmcp` org](https://hub.docker.com/r/debugmcp/mcp-debugger) |
+| PyPI | [`debug-mcp-server-launcher`](https://pypi.org/project/debug-mcp-server-launcher/) |
+| GitHub | [`debugmcp` org](https://github.com/debugmcp) |
+
+## Continuity
+
+Publishing is tied to the GitHub repository via OIDC where supported, not to individual accounts; organization-level GitHub access provides continuity if any individual maintainer becomes unavailable. See [SUPPLY-CHAIN-SECURITY.md](SUPPLY-CHAIN-SECURITY.md#access-continuity) for the full access-continuity table.
+
+## Becoming a maintainer
+
+Sustained, high-quality contributions (code, adapters, triage) are the path. Open an issue or email debug@sycamore.llc if you're interested in taking on a language adapter or subsystem.

--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ See [tests/README.md](./tests/README.md) for detailed testing instructions.
 - 🟢 **Runtime**: Node.js 22+
 - 📈 **Active Development**: Regular updates and improvements
 
+## 🏛️ Who Maintains This
+
+mcp-debugger is stewarded by **Sycamore LLC** and led by John Franklin ([@debugmcpdev](https://github.com/debugmcpdev)). The project uses an agent-first development model with human accountability: AI agents write most of the code; a human maintainer makes every merge, release, and security decision. See [MAINTAINERS.md](./MAINTAINERS.md), [GOVERNANCE.md](./GOVERNANCE.md), and [SUPPORT.md](./SUPPORT.md) (including commercial support).
+
+Supply-chain posture: pinned CI actions, OIDC trusted publishing, sigstore provenance on every npm package, SBOMs attached to releases, and an [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/debugmcp/mcp-debugger) score we actively maintain — details in [SUPPLY-CHAIN-SECURITY.md](./SUPPLY-CHAIN-SECURITY.md). Report vulnerabilities via [SECURITY.md](./SECURITY.md).
+
 ## 📄 License
 
 MIT License - see [LICENSE](./LICENSE) for details.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,19 @@
+# Support
+
+## Community support (free)
+
+- **Bug reports & feature requests**: [GitHub Issues](https://github.com/debugmcp/mcp-debugger/issues) — please include the language adapter, transport mode, and a minimal reproduction. Issues are triaged regularly.
+- **Questions**: open an issue with the `question` label.
+- **Documentation**: [README](README.md), [docs/](docs/), and the [agent skill](skills/debugging/) for per-language debugging guidance.
+
+## Security issues
+
+Never file public issues for vulnerabilities — see [SECURITY.md](SECURITY.md) for the private disclosure process and response timelines.
+
+## Commercial support
+
+For organizations that need guaranteed response times, private support, integration help, or custom adapter development, contact **debug@sycamore.llc** with subject `[SUPPORT] <your topic>`. Sycamore LLC, the project steward, offers commercial arrangements on request.
+
+## Supported versions
+
+See the version support table in [SECURITY.md](SECURITY.md#supported-versions). In general the latest minor release line receives fixes; older lines receive security fixes at the maintainers' discretion.

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "step-through",
     "python"
   ],
-  "author": "debugmcp <debug@sycamore.llc>",
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/debugmcp/mcp-debugger/issues"

--- a/packages/adapter-dotnet/package.json
+++ b/packages/adapter-dotnet/package.json
@@ -40,5 +40,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-go/package.json
+++ b/packages/adapter-go/package.json
@@ -42,7 +42,7 @@
     "delve",
     "dap"
   ],
-  "author": "mcp-debugger team",
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/adapter-java/package.json
+++ b/packages/adapter-java/package.json
@@ -44,7 +44,7 @@
     "jdi-bridge",
     "dap"
   ],
-  "author": "mcp-debugger team",
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/adapter-javascript/package.json
+++ b/packages/adapter-javascript/package.json
@@ -48,5 +48,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -37,5 +37,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-python/package.json
+++ b/packages/adapter-python/package.json
@@ -39,5 +39,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-ruby/package.json
+++ b/packages/adapter-ruby/package.json
@@ -39,5 +39,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -40,5 +40,6 @@
   },
   "engines": {
     "node": ">=22.0.0"
-  }
+  },
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
 }

--- a/packages/mcp-debugger/package.json
+++ b/packages/mcp-debugger/package.json
@@ -40,5 +40,6 @@
     "@debugmcp/adapter-ruby": "workspace:*",
     "@debugmcp/adapter-rust": "workspace:*",
     "@debugmcp/shared": "workspace:*"
-  }
+  },
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     "dap",
     "debug-adapter-protocol"
   ],
-  "author": "debugmcp <debug@sycamore.llc>",
+  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/debugmcp/mcp-debugger/issues"


### PR DESCRIPTION
## What

Firms up the ownership/responsibility/backing picture for corporate and government adopters. Build-integrity signals (sigstore provenance, Scorecard, pinned actions) were already strong — this PR adds the **accountable identity** and **procurement artifacts** side:

- **MAINTAINERS.md** — named lead maintainer (John Franklin, Sycamore LLC), channel-identity table, continuity statement
- **GOVERNANCE.md** — Sycamore LLC stewardship; the agent-first development model paired with explicit human accountability (a human makes every merge/release/security decision); decision record = issue tracker
- **SUPPORT.md** — community channels + commercial support via debug@sycamore.llc
- **LICENSE** — copyright line now names Sycamore LLC (was the anonymous 'Debug MCP Server Contributors')
- **README** — 'Who Maintains This' section tying it together
- **package.json** (root + all packages) — `author: Sycamore LLC`
- **Release workflow** — SPDX + CycloneDX SBOMs generated from the release ref and attached to every GitHub release (EO 14028-friendly), via SHA-pinned anchore/sbom-action

The GitHub org profile (name/email/description) was updated alongside this PR. Remaining manual steps tracked separately: project domain purchase + org domain verification, OpenSSF Best Practices silver, Tidelift listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)