### PR TITLE
feat: break-on-exception support (breakOnExceptions) + exception detail + debuggee exit code (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Break-on-exception support** — new `breakOnExceptions` option (`"uncaught"` | `"all"` | `"none"`, default `"none"`) on `start_debugging` and `attach_to_process`: an uncaught exception now pauses at the crash site with the stack and locals inspectable instead of terminating the session. The abstract mode is resolved to per-language debugger filter IDs by the adapter policy (Python `uncaught`/`raised`+`uncaught`, JavaScript `uncaught`/`all` — runtime-verified against js-debug, Java `uncaught`/`caught`+`uncaught`, .NET `user-unhandled`/`all`, Go `fatal`+`panic`, Rust `rust_panic`/`+cpp_throw`, Ruby `all`-only via `any`); an unsupported mode is skipped with a warning and never aborts the launch (fixes #220)
+- **Exception detail on stops** — `lastStop` now records the DAP stopped event's `description` and `text` (e.g. exception class and message), surfaced via `list_debug_sessions`, `get_stack_trace`, and the `start_debugging` response (#220)
+- **Debuggee exit code surfaced** — the exit code from the DAP `exited` event is stored on the session and returned as `exitCode` in `list_debug_sessions`, making a crash (non-zero) distinguishable from a clean exit (#220)
+
+### Fixed
+- Mock adapter now answers `setExceptionBreakpoints` (previously an unhandled-command error) and emits `exited` before `terminated`, matching real adapter ordering (#220)
+- Corrected the JavaScript adapter's declared `exceptionBreakpointFilters` to the IDs js-debug actually reports (`all`, `uncaught`) (#220)
+
 ## [0.23.0] - 2026-07-09
 
 ### Added

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -177,6 +177,7 @@ Starts debugging a script.
   - `justMyCode` (boolean): Debug only user code
 - `adapterLaunchConfig` (object, optional): Adapter-specific launch configuration overrides. Use this for language-specific settings that go beyond standard DAP arguments (e.g., `mainClass` and `classpath` for Java, `buildCommand` for Rust).
 - `dryRunSpawn` (boolean, optional): Test spawn without actually starting
+- `breakOnExceptions` (string, optional): `"uncaught"` pauses at uncaught exceptions at the crash site (stack and locals inspectable) instead of terminating the session; `"all"` also pauses on caught/raised exceptions (language-dependent). Default `"none"`. The abstract mode maps to per-language debugger filters (e.g. Python `uncaught`/`raised`, JavaScript `uncaught`/`all`, Java `uncaught`/`caught`, .NET `user-unhandled`/`all`, Go `panic`+`fatal`, Rust `rust_panic`). Ruby supports only `"all"` (rdbg has no uncaught-only filter); `"uncaught"` is skipped with a warning there.
 
 **Response:**
 ```json
@@ -195,6 +196,9 @@ Starts debugging a script.
 - `"breakpoint"`: Stopped at a breakpoint
 - `"step"`: Stopped after a step operation
 - `"entry"`: Stopped on entry (if configured)
+- `"exception"`: Stopped at an exception (requires `breakOnExceptions`). `lastStop.description`/`lastStop.text` carry the exception class and message where the adapter reports them.
+
+**Exit code:** when the debuggee terminates, the exit code reported by the adapter is surfaced as `exitCode` in `list_debug_sessions`, so a crash (non-zero) is distinguishable from a clean exit.
 
 ---
 
@@ -743,7 +747,7 @@ Each session also exposes its captured output as an MCP resource:
 The following tools are also available but are not fully documented with examples here:
 
 - **list_supported_languages**: Lists all supported debugging languages with metadata (installed status, display name, default executable). Takes no parameters.
-- **attach_to_process**: Attaches the debugger to a running process. Parameters include `sessionId`, `processId` or connection details, and adapter-specific attach configuration.
+- **attach_to_process**: Attaches the debugger to a running process. Parameters include `sessionId`, `processId` or connection details, adapter-specific attach configuration, and optionally `breakOnExceptions` (same semantics as on `start_debugging`).
 - **detach_from_process**: Detaches the debugger from an attached process. Parameters include `sessionId` and optional `terminateProcess` flag.
 - **list_threads**: Lists all threads in the debug session. Parameters include `sessionId`.
 

--- a/packages/adapter-javascript/src/javascript-debug-adapter.ts
+++ b/packages/adapter-javascript/src/javascript-debug-adapter.ts
@@ -749,9 +749,11 @@ export class JavascriptDebugAdapter extends EventEmitter implements IDebugAdapte
       supportsExceptionInfoRequest: true,
       supportsTerminateRequest: true,
       supportsBreakpointLocationsRequest: true,
+      // Matches the filters js-debug actually declares in its initialize
+      // response (runtime-verified for issue #220): 'all' and 'uncaught'
       exceptionBreakpointFilters: [
-        { filter: 'uncaught', label: 'Uncaught Exceptions', default: true },
-        { filter: 'userUnhandled', label: 'User-Unhandled Exceptions', default: false }
+        { filter: 'all', label: 'Caught Exceptions', default: false },
+        { filter: 'uncaught', label: 'Uncaught Exceptions', default: false }
       ]
     };
   }

--- a/packages/adapter-javascript/tests/unit/javascript-debug-adapter.capabilities.test.ts
+++ b/packages/adapter-javascript/tests/unit/javascript-debug-adapter.capabilities.test.ts
@@ -67,13 +67,13 @@ describe('JavascriptDebugAdapter capabilities and error helpers', () => {
     expect(caps.supportsTerminateRequest).toBe(true);
     expect(caps.supportsBreakpointLocationsRequest).toBe(true);
 
-    // Exception filters: uncaught and userUnhandled
+    // Exception filters: the IDs js-debug actually declares in its
+    // initialize response (runtime-verified for issue #220)
     expect(Array.isArray(caps.exceptionBreakpointFilters)).toBe(true);
     const filters = caps.exceptionBreakpointFilters || [];
+    expect(filters.map(f => f.filter).sort()).toEqual(['all', 'uncaught']);
     const uncaught = filters.find(f => f.filter === 'uncaught');
-    const userUnhandled = filters.find(f => f.filter === 'userUnhandled');
-    expect(uncaught?.default).toBe(true);
-    expect(userUnhandled?.default).toBe(false);
+    expect(uncaught?.default).toBe(false);
   });
 
   it('getFeatureRequirements returns minimal requirements for log points', () => {

--- a/packages/adapter-mock/src/mock-adapter-process.ts
+++ b/packages/adapter-mock/src/mock-adapter-process.ts
@@ -102,6 +102,11 @@ class MockDebugAdapterProcess {
   private nextVariableReference = 1000;
   private currentLine = 1;
   private threads = [{ id: 1, name: 'main' }];
+  // Exception simulation state (issue #220): armed via setExceptionBreakpoints,
+  // triggered once per launch for programs whose path matches /throws|error/i
+  private exceptionFilters: string[] = [];
+  private programPath = '';
+  private exceptionSimulated = false;
   
   constructor() {
     // Parse command line arguments
@@ -206,6 +211,10 @@ class MockDebugAdapterProcess {
       case 'setBreakpoints':
         this.handleSetBreakpoints(request as DebugProtocol.SetBreakpointsRequest);
         break;
+
+      case 'setExceptionBreakpoints':
+        this.handleSetExceptionBreakpoints(request as DebugProtocol.SetExceptionBreakpointsRequest);
+        break;
         
       case 'threads':
         this.handleThreads(request as DebugProtocol.ThreadsRequest);
@@ -273,7 +282,10 @@ class MockDebugAdapterProcess {
         supportsConditionalBreakpoints: true,
         supportsHitConditionalBreakpoints: false,
         supportsEvaluateForHovers: true,
-        exceptionBreakpointFilters: [],
+        exceptionBreakpointFilters: [
+          { filter: 'uncaught', label: 'Uncaught Exceptions', default: false },
+          { filter: 'all', label: 'All Exceptions', default: false }
+        ],
         supportsStepBack: false,
         supportsSetVariable: true,
         supportsRestartFrame: false,
@@ -325,10 +337,53 @@ class MockDebugAdapterProcess {
     });
   }
   
+  private handleSetExceptionBreakpoints(request: DebugProtocol.SetExceptionBreakpointsRequest): void {
+    this.exceptionFilters = request.arguments?.filters ?? [];
+    this.log(`Exception breakpoints set: ${JSON.stringify(this.exceptionFilters)}`);
+    this.sendResponse({
+      seq: 0,
+      type: 'response',
+      request_seq: request.seq,
+      command: request.command,
+      success: true
+    });
+  }
+
+  /**
+   * Whether to simulate an uncaught exception instead of running to
+   * completion (issue #220). Double-gated: exception filters must be armed
+   * AND the program path must look like a crashing fixture. Fires at most
+   * once per launch so a continue past the exception terminates.
+   */
+  private shouldSimulateException(): boolean {
+    return this.exceptionFilters.length > 0 &&
+      !this.exceptionSimulated &&
+      /throws|error/i.test(this.programPath);
+  }
+
+  private sendExceptionStopped(): void {
+    this.exceptionSimulated = true;
+    this.log(`Simulating uncaught exception stop (filters: ${JSON.stringify(this.exceptionFilters)})`);
+    this.sendEvent({
+      seq: 0,
+      type: 'event',
+      event: 'stopped',
+      body: {
+        reason: 'exception',
+        threadId: 1,
+        allThreadsStopped: true,
+        description: 'MockError',
+        text: 'Mock uncaught exception'
+      }
+    } as DebugProtocol.StoppedEvent);
+  }
+
   private handleLaunch(request: DebugProtocol.LaunchRequest): void {
-    const args = request.arguments as DebugProtocol.LaunchRequestArguments & { stopOnEntry?: boolean };
+    const args = request.arguments as DebugProtocol.LaunchRequestArguments & { stopOnEntry?: boolean; program?: string };
     this.log(`Launching with args: ${JSON.stringify(args)}`);
-    
+    this.programPath = typeof args.program === 'string' ? args.program : '';
+    this.exceptionSimulated = false;
+
     this.sendResponse({
       seq: 0,
       type: 'response',
@@ -375,22 +430,26 @@ class MockDebugAdapterProcess {
               allThreadsStopped: true
             }
           } as DebugProtocol.StoppedEvent);
+        } else if (this.shouldSimulateException()) {
+          this.sendExceptionStopped();
         } else {
           this.log(`No breakpoints set, program would run to completion`);
-          this.sendEvent({
-            seq: 0,
-            type: 'event',
-            event: 'terminated'
-          } as DebugProtocol.TerminatedEvent);
-          
+          // exited first, then terminated — matches real adapters (debugpy);
+          // the SessionManager tears down its handlers on 'terminated'
           this.sendEvent({
             seq: 0,
             type: 'event',
             event: 'exited',
             body: {
-              exitCode: 0
+              exitCode: this.exceptionSimulated ? 1 : 0
             }
           } as DebugProtocol.ExitedEvent);
+
+          this.sendEvent({
+            seq: 0,
+            type: 'event',
+            event: 'terminated'
+          } as DebugProtocol.TerminatedEvent);
         }
       }, 200);
     }
@@ -591,23 +650,29 @@ class MockDebugAdapterProcess {
             allThreadsStopped: true
           }
         } as DebugProtocol.StoppedEvent);
+      } else if (this.shouldSimulateException()) {
+        // Crash before completion: uncaught exception past the last breakpoint
+        this.sendExceptionStopped();
       } else {
         // No more breakpoints - program terminated
         this.log(`No more breakpoints after line ${this.currentLine}, terminating program`);
-        this.sendEvent({
-          seq: 0,
-          type: 'event',
-          event: 'terminated'
-        } as DebugProtocol.TerminatedEvent);
-        
+        // exited first, then terminated — matches real adapters (debugpy);
+        // the SessionManager tears down its handlers on 'terminated'
         this.sendEvent({
           seq: 0,
           type: 'event',
           event: 'exited',
           body: {
-            exitCode: 0
+            // An uncaught exception exits non-zero once continued past
+            exitCode: this.exceptionSimulated ? 1 : 0
           }
         } as DebugProtocol.ExitedEvent);
+
+        this.sendEvent({
+          seq: 0,
+          type: 'event',
+          event: 'terminated'
+        } as DebugProtocol.TerminatedEvent);
       }
     }, 200);
   }

--- a/packages/adapter-mock/src/mock-debug-adapter.ts
+++ b/packages/adapter-mock/src/mock-debug-adapter.ts
@@ -442,7 +442,10 @@ export class MockDebugAdapter extends EventEmitter implements IDebugAdapter {
       supportsConditionalBreakpoints: this.supportsFeature(DebugFeature.CONDITIONAL_BREAKPOINTS),
       supportsHitConditionalBreakpoints: false,
       supportsEvaluateForHovers: this.supportsFeature(DebugFeature.EVALUATE_FOR_HOVERS),
-      exceptionBreakpointFilters: [],
+      exceptionBreakpointFilters: [
+        { filter: 'uncaught', label: 'Uncaught Exceptions', default: false },
+        { filter: 'all', label: 'All Exceptions', default: false }
+      ],
       supportsStepBack: false,
       supportsSetVariable: this.supportsFeature(DebugFeature.SET_VARIABLE),
       supportsRestartFrame: false,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -138,6 +138,8 @@ export type {
   Breakpoint,
   DebugSession,
   DebugSessionInfo,
+  SessionStopInfo,
+  ExceptionBreakMode,
   SessionOutputEntry,
 
   // Debug info types
@@ -173,7 +175,7 @@ export type {
   AdapterSpawnPayload,
   AdapterSpawnConfig
 } from './interfaces/adapter-policy.js';
-export { DefaultAdapterPolicy } from './interfaces/adapter-policy.js';
+export { DefaultAdapterPolicy, resolveExceptionFilters } from './interfaces/adapter-policy.js';
 export { JsDebugAdapterPolicy } from './interfaces/adapter-policy-js.js';
 export { PythonAdapterPolicy } from './interfaces/adapter-policy-python.js';
 export { RubyAdapterPolicy } from './interfaces/adapter-policy-ruby.js';

--- a/packages/shared/src/interfaces/adapter-policy-dotnet.ts
+++ b/packages/shared/src/interfaces/adapter-policy-dotnet.ts
@@ -231,7 +231,12 @@ export const DotnetAdapterPolicy: AdapterPolicy = {
       // We must defer configurationDone handling and send launch first,
       // because netcoredbg requires launch before configurationDone.
       sendLaunchBeforeConfig: true,
-      sendAttachBeforeInitialized: false
+      sendAttachBeforeInitialized: false,
+      // netcoredbg filter IDs
+      exceptionFilters: {
+        uncaught: ['user-unhandled'],
+        all: ['all']
+      }
     };
   },
 

--- a/packages/shared/src/interfaces/adapter-policy-go.ts
+++ b/packages/shared/src/interfaces/adapter-policy-go.ts
@@ -233,6 +233,11 @@ export const GoAdapterPolicy: AdapterPolicy = {
       // Delve may send 'initialized' immediately after 'initialize' or after 'launch'.
       // The proxy uses two-phase handling: brief wait before launch, fallback after launch.
       sendLaunchBeforeConfig: true,
+      // Delve has no caught/uncaught distinction; both modes arm panic + fatal
+      exceptionFilters: {
+        uncaught: ['fatal', 'panic'],
+        all: ['fatal', 'panic']
+      },
     };
   },
 

--- a/packages/shared/src/interfaces/adapter-policy-java.ts
+++ b/packages/shared/src/interfaces/adapter-policy-java.ts
@@ -170,7 +170,12 @@ export const JavaAdapterPolicy: AdapterPolicy = {
   // then send launch, then breakpoints + configurationDone.
   getInitializationBehavior: () => {
     return {
-      sendLaunchBeforeConfig: true
+      sendLaunchBeforeConfig: true,
+      // JdiDapServer honors exactly 'caught' and 'uncaught'
+      exceptionFilters: {
+        uncaught: ['uncaught'],
+        all: ['caught', 'uncaught']
+      }
     };
   },
 

--- a/packages/shared/src/interfaces/adapter-policy-js.ts
+++ b/packages/shared/src/interfaces/adapter-policy-js.ts
@@ -7,6 +7,7 @@
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import * as path from 'path';
 import type { AdapterPolicy, AdapterSpecificState, CommandHandling } from './adapter-policy.js';
+import { resolveExceptionFilters } from './adapter-policy.js';
 import { SessionState } from '@debugmcp/shared';
 import type { StackFrame, Variable } from '../models/index.js';
 import type { DapClientBehavior, DapClientContext, ReverseRequestResult } from './dap-client-behavior.js';
@@ -198,7 +199,7 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
    * This includes the strict initialization sequence required by js-debug.
    */
   performHandshake: async (context) => {
-    const { proxyManager, sessionId, dapLaunchArgs, scriptPath, scriptArgs, breakpoints, launchConfig } = context;
+    const { proxyManager, sessionId, dapLaunchArgs, scriptPath, scriptArgs, breakpoints, launchConfig, breakOnExceptions } = context;
     
     // Type assertion for proxyManager since we use 'unknown' in the interface
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -257,8 +258,9 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
 
     // 3) setExceptionBreakpoints + setBreakpoints
     try {
-      console.info(`[JsDebugAdapterPolicy] [JS] Sending 'setExceptionBreakpoints' []`);
-      await pm.sendDapRequest('setExceptionBreakpoints', { filters: [] });
+      const exceptionFilters = resolveExceptionFilters(JsDebugAdapterPolicy, breakOnExceptions);
+      console.info(`[JsDebugAdapterPolicy] [JS] Sending 'setExceptionBreakpoints' ${JSON.stringify(exceptionFilters)}`);
+      await pm.sendDapRequest('setExceptionBreakpoints', { filters: exceptionFilters });
     } catch (e) {
       console.warn(
         `[JsDebugAdapterPolicy] [JS] 'setExceptionBreakpoints' failed or unsupported: ${
@@ -644,7 +646,12 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
       addRuntimeExecutable: true,      // Needs to add runtimeExecutable to launch args
       trackInitializeResponse: true,   // Must track initialize response separately
       requiresInitialStop: true,       // Must ensure initial stop after launch/attach
-      defaultStopOnEntry: false        // Default to false unless user explicitly requests
+      defaultStopOnEntry: false,       // Default to false unless user explicitly requests
+      // js-debug filter IDs ('all' = caught + uncaught)
+      exceptionFilters: {
+        uncaught: ['uncaught'],
+        all: ['all']
+      }
     };
   },
 

--- a/packages/shared/src/interfaces/adapter-policy-mock.ts
+++ b/packages/shared/src/interfaces/adapter-policy-mock.ts
@@ -159,7 +159,13 @@ export const MockAdapterPolicy: AdapterPolicy = {
    * Mock adapter has no special initialization requirements
    */
   getInitializationBehavior: () => {
-    return {};  // Mock adapter has no special initialization requirements
+    return {
+      // Matched by the mock-adapter-process setExceptionBreakpoints handler
+      exceptionFilters: {
+        uncaught: ['uncaught'],
+        all: ['all']
+      }
+    };
   },
 
   /**

--- a/packages/shared/src/interfaces/adapter-policy-python.ts
+++ b/packages/shared/src/interfaces/adapter-policy-python.ts
@@ -240,7 +240,12 @@ export const PythonAdapterPolicy: AdapterPolicy = {
    */
   getInitializationBehavior: () => {
     return {
-      sendAttachBeforeInitialized: true
+      sendAttachBeforeInitialized: true,
+      // debugpy filter IDs; 'userUnhandled' exists but is noisy in practice
+      exceptionFilters: {
+        uncaught: ['uncaught'],
+        all: ['raised', 'uncaught']
+      }
     };
   },
 

--- a/packages/shared/src/interfaces/adapter-policy-ruby.ts
+++ b/packages/shared/src/interfaces/adapter-policy-ruby.ts
@@ -124,7 +124,12 @@ export const RubyAdapterPolicy: AdapterPolicy = {
   },
   getInitializationBehavior: () => {
     return {
-      sendLaunchBeforeConfig: true
+      sendLaunchBeforeConfig: true,
+      // rdbg only offers 'any' (break on every raise) — no uncaught-only filter
+      exceptionFilters: {
+        uncaught: [],
+        all: ['any']
+      }
     };
   },
   // rdbg rejects the DAP-default 'variables' evaluate context

--- a/packages/shared/src/interfaces/adapter-policy-rust.ts
+++ b/packages/shared/src/interfaces/adapter-policy-rust.ts
@@ -226,7 +226,13 @@ export const RustAdapterPolicy: AdapterPolicy = {
    * Rust adapter has no special initialization requirements
    */
   getInitializationBehavior: () => {
-    return {};  // CodeLLDB doesn't need any special initialization quirks
+    return {
+      // CodeLLDB filter IDs
+      exceptionFilters: {
+        uncaught: ['rust_panic'],
+        all: ['rust_panic', 'cpp_throw']
+      }
+    };
   },
 
   /**

--- a/packages/shared/src/interfaces/adapter-policy.ts
+++ b/packages/shared/src/interfaces/adapter-policy.ts
@@ -13,7 +13,7 @@
  * @since 2.1.0
  */
 import type { DebugProtocol } from '@vscode/debugprotocol';
-import type { StackFrame, Variable } from '../models/index.js';
+import type { ExceptionBreakMode, StackFrame, Variable } from '../models/index.js';
 import type { DapClientBehavior } from './dap-client-behavior.js';
 import type { SessionState } from '@debugmcp/shared';
 import type { LanguageSpecificLaunchConfig } from './debug-adapter.js';
@@ -213,6 +213,8 @@ export interface AdapterPolicy {
     scriptArgs?: string[];
     breakpoints: Map<string, unknown>;  // Will be Breakpoint in implementation
     launchConfig?: LanguageSpecificLaunchConfig;
+    /** Abstract break-on-exception mode requested by the user (issue #220) */
+    breakOnExceptions?: ExceptionBreakMode;
   }): Promise<void>;
 
   /**
@@ -314,6 +316,13 @@ export interface AdapterPolicy {
      *  Some adapters send initialized only AFTER processing the attach request, so waiting
      *  for initialized before sending attach causes a deadlock. */
     sendAttachBeforeInitialized?: boolean;
+    /** Concrete DAP exceptionBreakpointFilters IDs per abstract breakOnExceptions
+     *  mode (issue #220). Omitted (or an empty array for a mode) means the mode
+     *  is unsupported for this adapter and setExceptionBreakpoints is skipped. */
+    exceptionFilters?: {
+      uncaught: string[];
+      all: string[];
+    };
   };
 
   /**
@@ -427,3 +436,19 @@ export const DefaultAdapterPolicy: AdapterPolicy = {
   getInitializationBehavior: () => ({}),
   getDapClientBehavior: (): DapClientBehavior => ({})
 };
+
+/**
+ * Resolve an abstract break-on-exception mode to the concrete DAP
+ * exceptionBreakpointFilters IDs for the given adapter policy (issue #220).
+ * Returns [] when the mode is unset, 'none', or unsupported by the policy —
+ * callers skip the setExceptionBreakpoints request in that case.
+ */
+export function resolveExceptionFilters(
+  policy: AdapterPolicy,
+  mode: ExceptionBreakMode | undefined
+): string[] {
+  if (!mode || mode === 'none') {
+    return [];
+  }
+  return policy.getInitializationBehavior().exceptionFilters?.[mode] ?? [];
+}

--- a/packages/shared/src/models/index.ts
+++ b/packages/shared/src/models/index.ts
@@ -264,7 +264,17 @@ export interface SessionStopInfo {
   threadId?: number;
   /** Epoch milliseconds when the stop was observed */
   timestamp: number;
+  /** DAP stopped-event description, e.g. the exception class ('ZeroDivisionError') */
+  description?: string;
+  /** DAP stopped-event text, e.g. the exception message ('division by zero') */
+  text?: string;
 }
+
+/**
+ * Abstract break-on-exception mode (issue #220). Mapped per-language to
+ * concrete DAP exceptionBreakpointFilters by the adapter policy.
+ */
+export type ExceptionBreakMode = 'uncaught' | 'all' | 'none';
 
 /**
  * One captured debuggee output event (issue #218).
@@ -293,6 +303,8 @@ export interface DebugSessionInfo {
   updatedAt?: Date; // Optional, as it might not always be present or needed for list views
   /** Why the session last stopped; present after the first user-visible stop */
   lastStop?: SessionStopInfo;
+  /** Debuggee exit code from the DAP 'exited' event, when the adapter reports one */
+  exitCode?: number;
 }
 
 

--- a/packages/shared/tests/unit/resolve-exception-filters.test.ts
+++ b/packages/shared/tests/unit/resolve-exception-filters.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Guardrail for the per-language breakOnExceptions → DAP filter mapping
+ * (issue #220). Each policy's exceptionFilters table is asserted exactly:
+ * a change here must be a deliberate decision, not a side effect.
+ */
+import { describe, it, expect } from 'vitest';
+import type { AdapterPolicy, ExceptionBreakMode } from '../../src/index.js';
+import {
+  resolveExceptionFilters,
+  DefaultAdapterPolicy,
+  PythonAdapterPolicy,
+  JsDebugAdapterPolicy,
+  GoAdapterPolicy,
+  JavaAdapterPolicy,
+  DotnetAdapterPolicy,
+  RubyAdapterPolicy,
+  RustAdapterPolicy,
+  MockAdapterPolicy
+} from '../../src/index.js';
+
+interface PolicyExpectation {
+  name: string;
+  policy: AdapterPolicy;
+  uncaught: string[];
+  all: string[];
+}
+
+const EXPECTATIONS: PolicyExpectation[] = [
+  { name: 'python', policy: PythonAdapterPolicy, uncaught: ['uncaught'], all: ['raised', 'uncaught'] },
+  { name: 'js-debug', policy: JsDebugAdapterPolicy, uncaught: ['uncaught'], all: ['all'] },
+  { name: 'go', policy: GoAdapterPolicy, uncaught: ['fatal', 'panic'], all: ['fatal', 'panic'] },
+  { name: 'java', policy: JavaAdapterPolicy, uncaught: ['uncaught'], all: ['caught', 'uncaught'] },
+  { name: 'dotnet', policy: DotnetAdapterPolicy, uncaught: ['user-unhandled'], all: ['all'] },
+  { name: 'ruby', policy: RubyAdapterPolicy, uncaught: [], all: ['any'] },
+  { name: 'rust', policy: RustAdapterPolicy, uncaught: ['rust_panic'], all: ['rust_panic', 'cpp_throw'] },
+  { name: 'mock', policy: MockAdapterPolicy, uncaught: ['uncaught'], all: ['all'] }
+];
+
+describe('resolveExceptionFilters', () => {
+  describe.each(EXPECTATIONS)('$name policy', ({ policy, uncaught, all }) => {
+    it(`resolves 'uncaught' to ${JSON.stringify(uncaught)}`, () => {
+      expect(resolveExceptionFilters(policy, 'uncaught')).toEqual(uncaught);
+    });
+
+    it(`resolves 'all' to ${JSON.stringify(all)}`, () => {
+      expect(resolveExceptionFilters(policy, 'all')).toEqual(all);
+    });
+
+    it("resolves 'none' to []", () => {
+      expect(resolveExceptionFilters(policy, 'none')).toEqual([]);
+    });
+
+    it('resolves undefined to []', () => {
+      expect(resolveExceptionFilters(policy, undefined)).toEqual([]);
+    });
+  });
+
+  it('returns [] for every mode on a policy without a filter table (DefaultAdapterPolicy)', () => {
+    const modes: Array<ExceptionBreakMode | undefined> = ['uncaught', 'all', 'none', undefined];
+    for (const mode of modes) {
+      expect(resolveExceptionFilters(DefaultAdapterPolicy, mode)).toEqual([]);
+    }
+  });
+});

--- a/skills/debugging/README.md
+++ b/skills/debugging/README.md
@@ -32,4 +32,4 @@ mkdir -p ~/.copilot/skills && cp -r skills/debugging ~/.copilot/skills/mcp-debug
 
 ## Keeping it honest
 
-The skill states current limitations (no exception breakpoints yet, per-language output-capture gaps) with issue links. If you hit a behavior the skill doesn't describe, please [open an issue](https://github.com/debugmcp/mcp-debugger/issues) — the skill is maintained against real agent transcripts.
+The skill states current limitations (per-language output-capture gaps, no breakpoint listing yet) with issue links. If you hit a behavior the skill doesn't describe, please [open an issue](https://github.com/debugmcp/mcp-debugger/issues) — the skill is maintained against real agent transcripts.

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -68,9 +68,13 @@ attach_to_process {sessionId, host: "localhost", port: 5678, localRoot: "<local 
 
 `detach_from_process` leaves the target running; `close_debug_session` after detach cleans up the session.
 
+## Crash diagnosis
+
+- Pass `breakOnExceptions: "uncaught"` to `start_debugging` (or `attach_to_process`) to pause at an uncaught exception with the stack and locals live instead of losing the session; `"all"` also stops on caught raises (language-dependent; Ruby supports only `"all"`).
+- On an exception stop, `lastStop.description`/`lastStop.text` carry the exception class and message; after termination, `exitCode` in `list_debug_sessions` distinguishes a crash (non-zero) from a clean exit.
+
 ## Current limitations (be honest with yourself)
 
-- No exception breakpoints yet (#220): an uncaught exception terminates the session instead of pausing. To catch a throw, set a line breakpoint just inside the failing try/handler or on the raise path.
 - No breakpoint listing/removal tools yet: track what you set; re-creating the session resets breakpoints.
 - `pause_execution` support varies by adapter; prefer breakpoints over pausing a free-running program.
 

--- a/src/proxy/child-session-manager.ts
+++ b/src/proxy/child-session-manager.ts
@@ -9,8 +9,9 @@
 import { randomBytes } from 'crypto';
 import { EventEmitter } from 'events';
 import { DebugProtocol } from '@vscode/debugprotocol';
-import type { AdapterPolicy } from '@debugmcp/shared';
+import type { AdapterPolicy, ExceptionBreakMode } from '@debugmcp/shared';
 import type { DapClientBehavior, ChildSessionConfig } from '@debugmcp/shared';
+import { resolveExceptionFilters } from '@debugmcp/shared';
 import { createLogger } from '../utils/logger.js';
 import type { MinimalDapClient } from './minimal-dap.js';
 import path from 'path';
@@ -78,6 +79,10 @@ export class ChildSessionManager extends EventEmitter {
   // Breakpoint mirroring
   private storedBreakpoints = new Map<string, DebugProtocol.SourceBreakpoint[]>();
 
+  // Break-on-exception mode for child sessions (issue #220); resolved to
+  // concrete filters via the adapter policy when configuring a child
+  private exceptionBreakMode: ExceptionBreakMode = 'none';
+
   // State tracking
   private adoptionInProgress = false;
   private readonly instanceId: string;
@@ -90,6 +95,15 @@ export class ChildSessionManager extends EventEmitter {
     this.port = options.port;
     this.instanceId = createInstanceId();
     logger.info(`[ChildSessionManager:${this.instanceId}] created`);
+  }
+
+  /**
+   * Record the session's break-on-exception mode, applied to child sessions
+   * created afterwards (issue #220). Set at worker init, before any child
+   * session exists.
+   */
+  setExceptionBreakMode(mode: ExceptionBreakMode): void {
+    this.exceptionBreakMode = mode;
   }
 
   /**
@@ -290,10 +304,11 @@ export class ChildSessionManager extends EventEmitter {
   private async configureChild(child: MinimalDapClient, pendingId: string, _parentConfig: Record<string, unknown>): Promise<void> {
     void _parentConfig; // Currently unused but may be needed for future policy implementations
     
-    // Set exception breakpoints
+    // Set exception breakpoints ([] unless breakOnExceptions was requested)
+    const exceptionFilters = resolveExceptionFilters(this.policy, this.exceptionBreakMode);
     try {
-      logger.info(`[child:${pendingId}] setExceptionBreakpoints`);
-      await child.sendRequest('setExceptionBreakpoints', { filters: [] });
+      logger.info(`[child:${pendingId}] setExceptionBreakpoints ${JSON.stringify(exceptionFilters)}`);
+      await child.sendRequest('setExceptionBreakpoints', { filters: exceptionFilters });
     } catch {
       logger.warn(`[child:${pendingId}] setExceptionBreakpoints failed or not supported`);
     }
@@ -363,7 +378,9 @@ export class ChildSessionManager extends EventEmitter {
     if (sawPostInit && this.dapBehavior.mirrorBreakpointsToChild) {
       // Re-send configuration after post-attach initialized
       try {
-        await child.sendRequest('setExceptionBreakpoints', { filters: [] });
+        await child.sendRequest('setExceptionBreakpoints', {
+          filters: resolveExceptionFilters(this.policy, this.exceptionBreakMode)
+        });
       } catch {}
       
       for (const [srcPath, bps] of this.storedBreakpoints) {

--- a/src/proxy/dap-proxy-connection-manager.ts
+++ b/src/proxy/dap-proxy-connection-manager.ts
@@ -284,6 +284,23 @@ export class DapConnectionManager {
   }
 
   /**
+   * Set exception breakpoints (issue #220). Filters are concrete adapter
+   * filter IDs already resolved from the abstract breakOnExceptions mode.
+   */
+  async setExceptionBreakpoints(
+    client: IDapClient,
+    filters: string[]
+  ): Promise<DebugProtocol.SetExceptionBreakpointsResponse> {
+    this.logger.info(`[ConnectionManager] Sending "setExceptionBreakpoints" with filters: ${JSON.stringify(filters)}`);
+    const response = await client.sendRequest<DebugProtocol.SetExceptionBreakpointsResponse>(
+      'setExceptionBreakpoints',
+      { filters }
+    );
+    this.logger.info('[ConnectionManager] Exception breakpoints set.');
+    return response;
+  }
+
+  /**
    * Send configuration done notification
    */
   async sendConfigurationDone(client: IDapClient): Promise<void> {

--- a/src/proxy/dap-proxy-interfaces.ts
+++ b/src/proxy/dap-proxy-interfaces.ts
@@ -26,6 +26,8 @@ export interface ProxyInitPayload {
   justMyCode?: boolean;
   initialBreakpoints?: { file: string; line: number; condition?: string }[];
   dryRunSpawn?: boolean;
+  /** Abstract break-on-exception mode; resolved to concrete DAP filters via the adapter policy (issue #220) */
+  breakOnExceptions?: 'uncaught' | 'all' | 'none';
   launchConfig?: LanguageSpecificLaunchConfig;
   // Adapter command info for language-agnostic adapter spawning
   adapterCommand?: {
@@ -135,6 +137,12 @@ export interface IDapClient {
   off(event: string, handler: (...args: any[]) => void): void; // eslint-disable-line @typescript-eslint/no-explicit-any
   once(event: string, handler: (...args: any[]) => void): void; // eslint-disable-line @typescript-eslint/no-explicit-any
   removeAllListeners(): void;
+  /**
+   * Record the session's break-on-exception mode so DAP child sessions can
+   * apply the same exception filters (issue #220). Optional: only
+   * MinimalDapClient (js-debug child sessions) implements it.
+   */
+  setExceptionBreakMode?(mode: 'uncaught' | 'all' | 'none'): void;
 }
 
 /**

--- a/src/proxy/dap-proxy-message-parser.ts
+++ b/src/proxy/dap-proxy-message-parser.ts
@@ -107,6 +107,15 @@ export class MessageParser {
       throw new Error(`Init payload 'dryRunSpawn' must be a boolean if provided`);
     }
 
+    if (
+      obj.breakOnExceptions !== undefined &&
+      obj.breakOnExceptions !== 'uncaught' &&
+      obj.breakOnExceptions !== 'all' &&
+      obj.breakOnExceptions !== 'none'
+    ) {
+      throw new Error(`Init payload 'breakOnExceptions' must be one of 'uncaught', 'all', 'none' if provided`);
+    }
+
     // Validate initialBreakpoints if provided
     if (obj.initialBreakpoints !== undefined) {
       if (!Array.isArray(obj.initialBreakpoints)) {

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -38,7 +38,8 @@ import {
   RubyAdapterPolicy,
   DotnetAdapterPolicy,
   MockAdapterPolicy,
-  getPolicyForLanguage
+  getPolicyForLanguage,
+  resolveExceptionFilters
 } from '@debugmcp/shared';
 
 export type DapProxyWorkerHooks = {
@@ -399,6 +400,10 @@ export class DapProxyWorker {
         spawnConfig.port
       );
 
+      // Record the break-on-exception mode on the client so DAP child
+      // sessions (js-debug) can apply the same filters (issue #220).
+      this.dapClient.setExceptionBreakMode?.(payload.breakOnExceptions ?? 'none');
+
       // Set up event handlers
       this.setupDapEventHandlers();
 
@@ -686,6 +691,29 @@ export class DapProxyWorker {
             this.dapClient,
             filePath,
             breakpoints
+          );
+        }
+      }
+
+      // Arm exception breakpoints when requested (issue #220). A failure must
+      // not abort the launch — the outer catch tears the session down — so
+      // errors are swallowed with a warning.
+      const exceptionMode = this.currentInitPayload.breakOnExceptions;
+      if (exceptionMode && exceptionMode !== 'none') {
+        const exceptionFilters = resolveExceptionFilters(this.adapterPolicy, exceptionMode);
+        if (exceptionFilters.length > 0) {
+          try {
+            await this.connectionManager.setExceptionBreakpoints(this.dapClient, exceptionFilters);
+          } catch (err) {
+            this.logger!.warn(
+              `[Worker] setExceptionBreakpoints failed (continuing without exception breakpoints): ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
+          }
+        } else {
+          this.logger!.warn(
+            `[Worker] breakOnExceptions '${exceptionMode}' is not supported by adapter policy '${this.adapterPolicy.name}'; skipping setExceptionBreakpoints`
           );
         }
       }

--- a/src/proxy/minimal-dap.ts
+++ b/src/proxy/minimal-dap.ts
@@ -126,6 +126,15 @@ export class MinimalDapClient extends EventEmitter {
   }
 
   /**
+   * Record the session's break-on-exception mode and propagate it to the
+   * child-session manager so child sessions arm the same exception filters
+   * (issue #220).
+   */
+  setExceptionBreakMode(mode: 'uncaught' | 'all' | 'none'): void {
+    this.childSessionManager?.setExceptionBreakMode(mode);
+  }
+
+  /**
    * Handle raw data using the same algorithm as vscode's ProtocolServer
    * This ensures compatibility and proper message boundaries
    */

--- a/src/proxy/proxy-config.ts
+++ b/src/proxy/proxy-config.ts
@@ -1,7 +1,7 @@
 /**
  * Configuration for starting a proxy - language agnostic version
  */
-import { DebugLanguage, type LanguageSpecificLaunchConfig } from '@debugmcp/shared';
+import { DebugLanguage, type ExceptionBreakMode, type LanguageSpecificLaunchConfig } from '@debugmcp/shared';
 
 /**
  * Configuration for starting a proxy
@@ -19,6 +19,7 @@ export interface ProxyConfig {
   justMyCode?: boolean;
   initialBreakpoints?: Array<{ file: string; line: number; condition?: string }>;
   dryRunSpawn?: boolean;
+  breakOnExceptions?: ExceptionBreakMode;
   launchConfig?: LanguageSpecificLaunchConfig;
   
   // Adapter spawn command info - needed for proxy to spawn the correct adapter

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -44,7 +44,7 @@ export interface ProxyManagerEvents {
   'stopped': (threadId: number | undefined, reason: string, data?: DebugProtocol.StoppedEvent['body']) => void;
   'continued': () => void;
   'terminated': () => void;
-  'exited': () => void;
+  'exited': (exitCode?: number) => void;
   'output': (body: DebugProtocol.OutputEvent['body']) => void;
 
   // Proxy lifecycle events
@@ -224,6 +224,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       justMyCode: config.justMyCode,
       initialBreakpoints: config.initialBreakpoints,
       dryRunSpawn: config.dryRunSpawn,
+      breakOnExceptions: config.breakOnExceptions,
       launchConfig: config.launchConfig,
       // Pass adapter command info for language-agnostic adapter spawning
       adapterCommand: config.adapterCommand
@@ -998,9 +999,13 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         this.emit('terminated');
         break;
       
-      case 'exited':
-        this.emit('exited');
+      case 'exited': {
+        // Forward the debuggee exit code so it can be surfaced on the session
+        const exitedBody = message.body as { exitCode?: number } | undefined;
+        const exitCode = typeof exitedBody?.exitCode === 'number' ? exitedBody.exitCode : undefined;
+        this.emit('exited', exitCode);
         break;
+      }
 
       case 'output':
         this.emit('output', message.body as DebugProtocol.OutputEvent['body']);

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,8 @@ import {
     DebugLanguage,
     Breakpoint,
     SessionLifecycleState,
-    IEnvironment
+    IEnvironment,
+    ExceptionBreakMode
 } from '@debugmcp/shared';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import path from 'path';
@@ -89,6 +90,7 @@ interface ToolArguments {
   args?: string[];
   dapLaunchArgs?: Partial<DebugProtocol.LaunchRequestArguments>;
   dryRunSpawn?: boolean;
+  breakOnExceptions?: string;
   adapterLaunchConfig?: Record<string, unknown>;
   scope?: number;
   frameId?: number;
@@ -304,6 +306,19 @@ export class DebugMcpServer {
     }
   }
 
+  private validateBreakOnExceptions(value: string | undefined): ExceptionBreakMode | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value !== 'uncaught' && value !== 'all' && value !== 'none') {
+      throw new McpError(
+        McpErrorCode.InvalidParams,
+        `breakOnExceptions must be one of 'uncaught', 'all', 'none' (got '${value}')`
+      );
+    }
+    return value;
+  }
+
   // Public methods to expose SessionManager functionality for testing/external use
   public async createDebugSession(params: { language: DebugLanguage; name?: string; executablePath?: string; }): Promise<DebugSessionInfo> {
     // Validate language support using dynamic discovery
@@ -340,31 +355,33 @@ export class DebugMcpServer {
   }
 
   public async startDebugging(
-    sessionId: string, 
-    scriptPath: string, 
-    args?: string[], 
-    dapLaunchArgs?: Partial<DebugProtocol.LaunchRequestArguments>, 
+    sessionId: string,
+    scriptPath: string,
+    args?: string[],
+    dapLaunchArgs?: Partial<DebugProtocol.LaunchRequestArguments>,
     dryRunSpawn?: boolean,
-    adapterLaunchConfig?: Record<string, unknown>
+    adapterLaunchConfig?: Record<string, unknown>,
+    breakOnExceptions?: ExceptionBreakMode
   ): Promise<{ success: boolean; state: string; error?: string; data?: unknown; errorType?: string; errorCode?: number; }> {
     this.validateSession(sessionId);
-    
+
     // Check script file exists for immediate feedback
     const fileCheck = await this.fileChecker.checkExists(scriptPath);
     if (!fileCheck.exists) {
       throw this.fileNotFoundError('Script file', scriptPath, fileCheck);
     }
-    
+
     this.logger.info(`[DebugMcpServer.startDebugging] Script file exists: ${fileCheck.effectivePath} (original: ${scriptPath})`);
-    
+
     // Pass the effective path (which has been resolved for container) to session manager
     const result = await this.sessionManager.startDebugging(
-      sessionId, 
-      fileCheck.effectivePath, 
-      args, 
-      dapLaunchArgs, 
+      sessionId,
+      fileCheck.effectivePath,
+      args,
+      dapLaunchArgs,
       dryRunSpawn,
-      adapterLaunchConfig
+      adapterLaunchConfig,
+      breakOnExceptions
     );
     return result;
   }
@@ -611,12 +628,13 @@ export class DebugMcpServer {
                   additionalProperties: true
                 },
                 dryRunSpawn: { type: 'boolean' },
+                breakOnExceptions: { type: 'string', enum: ['uncaught', 'all', 'none'], description: 'Break when exceptions are thrown: "uncaught" pauses at uncaught exceptions at the crash site instead of terminating the session; "all" also pauses on caught/raised exceptions (language-dependent). Default "none"' },
                 adapterLaunchConfig: {
                   type: 'object',
                   description: 'Optional adapter-specific launch configuration overrides',
                   additionalProperties: true
                 }
-              }, 
+              },
               required: ['sessionId', 'scriptPath'] 
             } 
           },
@@ -631,7 +649,8 @@ export class DebugMcpServer {
                 verifyTimeout: { type: 'number', description: 'How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 5000, max: 600000). Increase for targets that are slow to become debuggable, e.g. a busy or warming JVM' },
                 sourcePaths: { type: 'array', items: { type: 'string' }, description: 'Source paths for code mapping' },
                 stopOnEntry: { type: 'boolean', description: 'Stop on entry after attaching' },
-                justMyCode: { type: 'boolean', description: 'Only debug user code (skip library code)' }
+                justMyCode: { type: 'boolean', description: 'Only debug user code (skip library code)' },
+                breakOnExceptions: { type: 'string', enum: ['uncaught', 'all', 'none'], description: 'Break when exceptions are thrown: "uncaught" pauses at uncaught exceptions at the crash site; "all" also pauses on caught/raised exceptions (language-dependent). Default "none"' }
               },
               required: ['sessionId']
             }
@@ -875,7 +894,8 @@ export class DebugMcpServer {
                   args.args,
                   args.dapLaunchArgs,
                   args.dryRunSpawn,
-                  args.adapterLaunchConfig
+                  args.adapterLaunchConfig,
+                  this.validateBreakOnExceptions(args.breakOnExceptions)
                 );
                 const responsePayload: Record<string, unknown> = {
                   success: debugResult.success,
@@ -921,7 +941,8 @@ export class DebugMcpServer {
                   verifyTimeout: args.verifyTimeout,
                   sourcePaths: args.sourcePaths,
                   stopOnEntry: args.stopOnEntry,
-                  justMyCode: args.justMyCode
+                  justMyCode: args.justMyCode,
+                  breakOnExceptions: this.validateBreakOnExceptions(args.breakOnExceptions)
                 });
 
                 const responsePayload: Record<string, unknown> = {
@@ -1448,6 +1469,9 @@ export class DebugMcpServer {
         }
         if (session.lastStop) {
             mappedSession.lastStop = session.lastStop;
+        }
+        if (session.exitCode !== undefined) {
+            mappedSession.exitCode = session.exitCode;
         }
         return mappedSession;
       });

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -224,6 +224,7 @@ export abstract class SessionManagerCore extends EventEmitter {
     // Reset first-stop tracking for this launch — a session may be re-launched.
     session.firstStopHandled = false;
     session.lastStop = undefined;
+    session.exitCode = undefined;
     // Each launch/attach starts with a fresh output buffer (issue #218).
     session.outputBuffer = new OutputRingBuffer();
 
@@ -244,7 +245,7 @@ export abstract class SessionManagerCore extends EventEmitter {
     }
 
     // Named function for stopped event
-    const handleStopped = (threadId: number | undefined, reason: string) => {
+    const handleStopped = (threadId: number | undefined, reason: string, body?: DebugProtocol.StoppedEvent['body']) => {
       this.logger.debug(`[SessionManager] handleStopped: session=${sessionId} currentState=${session.state} reason=${reason} threadId=${threadId}`);
       this.logger.info(`[ProxyManager ${sessionId}] Stopped event: thread=${threadId}, reason=${reason}`);
 
@@ -298,7 +299,14 @@ export abstract class SessionManagerCore extends EventEmitter {
         // Record why we stopped so it stays queryable after the fact
         // (list_debug_sessions / get_stack_trace, issue #214). Auto-continued
         // entry stops are deliberately not recorded — the user never saw them.
-        session.lastStop = { reason, threadId, timestamp: Date.now() };
+        // description/text carry e.g. the exception class/message (issue #220).
+        session.lastStop = {
+          reason,
+          threadId,
+          timestamp: Date.now(),
+          ...(body?.description ? { description: body.description } : {}),
+          ...(body?.text ? { text: body.text } : {})
+        };
         this._updateSessionState(session, SessionState.PAUSED);
       }
 
@@ -368,9 +376,14 @@ export abstract class SessionManagerCore extends EventEmitter {
     handlers.set('terminated', handleTerminated);
 
     // Named function for exited event
-    const handleExited = () => {
-      this.logger.debug(`[SessionManager] handleExited: session=${sessionId} currentState=${session.state}`);
-      this.logger.info(`[ProxyManager ${sessionId}] Exited event`);
+    const handleExited = (exitCode?: number) => {
+      this.logger.debug(`[SessionManager] handleExited: session=${sessionId} currentState=${session.state} exitCode=${exitCode}`);
+      this.logger.info(`[ProxyManager ${sessionId}] Exited event (exitCode=${exitCode})`);
+      // Record the debuggee exit code so a crash (non-zero) is
+      // distinguishable from a clean exit after the fact (issue #220)
+      if (typeof exitCode === 'number') {
+        session.exitCode = exitCode;
+      }
       this._updateSessionState(session, SessionState.STOPPED);
 
       // Clean up listeners since proxy is gone

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -7,7 +7,8 @@ import {
   Breakpoint,
   SessionState,
   SessionLifecycleState,
-  sanitizePayloadForLogging
+  sanitizePayloadForLogging,
+  type ExceptionBreakMode
 } from '@debugmcp/shared';
 import { ManagedSession, ToolchainValidationState } from './session-store.js';
 import { DebugProtocol } from '@vscode/debugprotocol';
@@ -96,7 +97,8 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     scriptArgs?: string[],
     dapLaunchArgs?: Partial<CustomLaunchRequestArguments>,
     dryRunSpawn?: boolean,
-    adapterLaunchConfig?: Record<string, unknown>
+    adapterLaunchConfig?: Record<string, unknown>,
+    breakOnExceptions?: ExceptionBreakMode
   ): Promise<LanguageSpecificLaunchConfig> {
     const sessionId = session.id;
     
@@ -330,6 +332,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       justMyCode: justMyCodeFlag,
       initialBreakpoints,
       dryRunSpawn: dryRunSpawn === true,
+      breakOnExceptions,
       launchConfig: launchConfigData,
       adapterCommand, // Pass the adapter command
     };
@@ -414,7 +417,8 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     scriptArgs?: string[],
     dapLaunchArgs?: Partial<CustomLaunchRequestArguments>,
     dryRunSpawn?: boolean,
-    adapterLaunchConfig?: Record<string, unknown>
+    adapterLaunchConfig?: Record<string, unknown>,
+    breakOnExceptions?: ExceptionBreakMode
   ): Promise<DebugResult> {
     const session = this._getSessionById(sessionId);
     this.logger.info(
@@ -528,7 +532,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
 
       // Normal (non-dry-run) flow
       // Start the proxy manager
-      const launchConfigData = await this.startProxyManager(session, scriptPath, scriptArgs, dapLaunchArgs, dryRunSpawn, adapterLaunchConfig);
+      const launchConfigData = await this.startProxyManager(session, scriptPath, scriptArgs, dapLaunchArgs, dryRunSpawn, adapterLaunchConfig, breakOnExceptions);
       this.logger.info(`[SessionManager] ProxyManager started for session ${sessionId}`);
 
       // Perform language-specific handshake if required
@@ -542,7 +546,8 @@ export abstract class SessionManagerOperations extends SessionManagerData {
             scriptPath,
             scriptArgs,
             breakpoints: session.breakpoints,
-            launchConfig: launchConfigData
+            launchConfig: launchConfigData,
+            breakOnExceptions
           });
         } catch (handshakeErr) {
           this.logger.warn(
@@ -1641,6 +1646,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       stopOnEntry?: boolean;
       justMyCode?: boolean;
       verifyTimeout?: number;
+      breakOnExceptions?: ExceptionBreakMode;
     }
   ): Promise<DebugResult> {
     const session = this._getSessionById(sessionId);
@@ -1652,7 +1658,9 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     // The verification-window override is consumed by the thread-discovery
     // loop below, not by the adapter — strip it from the config that becomes
     // the DAP attach arguments. Validate before any state mutation.
-    const { verifyTimeout, ...adapterAttachConfig } = attachConfig;
+    // breakOnExceptions maps to setExceptionBreakpoints, not attach args —
+    // strip it too and thread it through the proxy config instead.
+    const { verifyTimeout, breakOnExceptions, ...adapterAttachConfig } = attachConfig;
     let verifyTimeoutOverride = verifyTimeout;
     if (verifyTimeoutOverride !== undefined) {
       if (
@@ -1706,7 +1714,9 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         placeholderPath,
         undefined,
         attachLaunchArgs as Partial<CustomLaunchRequestArguments>,
-        false
+        false,
+        undefined,
+        breakOnExceptions
       );
 
       // Perform language-specific handshake if required, mirroring
@@ -1725,7 +1735,8 @@ export abstract class SessionManagerOperations extends SessionManagerData {
             scriptPath: placeholderPath,
             scriptArgs: undefined,
             breakpoints: session.breakpoints,
-            launchConfig: attachConfigData
+            launchConfig: attachConfigData,
+            breakOnExceptions
           });
         } catch (handshakeErr) {
           this.logger.warn(

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -186,7 +186,8 @@ export class SessionStore {
       state: s.state,
       createdAt: s.createdAt,
       updatedAt: s.updatedAt,
-      lastStop: s.lastStop
+      lastStop: s.lastStop,
+      exitCode: s.exitCode
     }));
   }
 

--- a/src/skill-content.ts
+++ b/src/skill-content.ts
@@ -18,6 +18,7 @@ Key rules:
 - Breakpoints may report unverified until the module/class loads — that is normal.
 - get_output returns buffered debuggee stdout/stderr with a cursor; pass nextCursor back to read only new output.
 - attach_to_process connects to running/remote targets (debugpy --listen, rdbg --open, JVM JDWP), including pods via port-forward.
+- Diagnosing a crash? Pass breakOnExceptions: "uncaught" to start_debugging/attach_to_process to pause at the uncaught exception with stack and locals live instead of losing the session.
 
 For the full debugging workflow (root-cause discipline, per-language quirks), request the "debugging-workflow" prompt or install the agent skill from skills/debugging/ in the repo.`;
 
@@ -66,8 +67,11 @@ detach_from_process leaves the target running.
 - Java: compile with javac -g; FQCN accepted as breakpoint "file"; redefine_classes hot-swaps changed classes.
 - .NET: scriptPath is the compiled .dll; PDBs must be Portable format.
 
+## Crash diagnosis
+- Pass breakOnExceptions: "uncaught" to start_debugging (or attach_to_process) to pause at an uncaught exception with stack + locals live instead of losing the session; "all" also stops on caught raises (Ruby supports only "all").
+- lastStop.description/text carry the exception class and message; exitCode in list_debug_sessions distinguishes a crash (non-zero) from a clean exit.
+
 ## Current limitations
-- No exception breakpoints yet (#220): uncaught exceptions terminate the session — breakpoint the raise path instead.
 - No breakpoint list/remove tools yet: track what you set.
 
 The full skill (with per-language reference files) lives in skills/debugging/ of the mcp-debugger repo.`;

--- a/tests/adapters/ruby/unit/adapter-policy-ruby.test.ts
+++ b/tests/adapters/ruby/unit/adapter-policy-ruby.test.ts
@@ -162,7 +162,13 @@ describe('RubyAdapterPolicy behavior surface', () => {
       requiresStrictHandshake: false,
       supportsVariableType: true
     });
-    expect(RubyAdapterPolicy.getInitializationBehavior?.()).toEqual({ sendLaunchBeforeConfig: true });
+    expect(RubyAdapterPolicy.getInitializationBehavior?.()).toEqual({
+      sendLaunchBeforeConfig: true,
+      exceptionFilters: {
+        uncaught: [],
+        all: ['any']
+      }
+    });
     expect(RubyAdapterPolicy.requiresCommandQueueing()).toBe(false);
     expect(RubyAdapterPolicy.shouldQueueCommand('next', undefined, {} as never)).toMatchObject({
       shouldQueue: false,

--- a/tests/core/unit/server/server-control-tools.test.ts
+++ b/tests/core/unit/server/server-control-tools.test.ts
@@ -225,12 +225,68 @@ describe('Server Control Tools Tests', () => {
         ['--debug'],
         { stopOnEntry: true, justMyCode: false },
         undefined,
+        undefined,
         undefined
       );
-      
+
       const content = JSON.parse(result.content[0].text);
       expect(content.success).toBe(true);
       expect(content.state).toBe('running');
+    });
+
+    it('should pass breakOnExceptions through to the session manager', async () => {
+      mockSessionManager.getSession.mockReturnValue({
+        id: 'test-session',
+        sessionLifecycle: 'ACTIVE'
+      });
+      mockSessionManager.startDebugging.mockResolvedValue({
+        success: true,
+        state: 'running',
+        data: { message: 'Debugging started' }
+      });
+
+      await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'start_debugging',
+          arguments: {
+            sessionId: 'test-session',
+            scriptPath: '/path/to/test.py',
+            breakOnExceptions: 'uncaught'
+          }
+        }
+      });
+
+      expect(mockSessionManager.startDebugging).toHaveBeenCalledWith(
+        'test-session',
+        expect.stringContaining('/path/to/test.py'),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'uncaught'
+      );
+    });
+
+    it('should reject an invalid breakOnExceptions value', async () => {
+      mockSessionManager.getSession.mockReturnValue({
+        id: 'test-session',
+        sessionLifecycle: 'ACTIVE'
+      });
+
+      await expect(callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'start_debugging',
+          arguments: {
+            sessionId: 'test-session',
+            scriptPath: '/path/to/test.py',
+            breakOnExceptions: 'sometimes'
+          }
+        }
+      })).rejects.toThrow(/breakOnExceptions must be one of/);
+
+      expect(mockSessionManager.startDebugging).not.toHaveBeenCalled();
     });
 
     it('should handle dry run mode', async () => {
@@ -263,6 +319,7 @@ describe('Server Control Tools Tests', () => {
         undefined,
         undefined,
         true,
+        undefined,
         undefined
       );
       

--- a/tests/core/unit/session/session-manager-dap.test.ts
+++ b/tests/core/unit/session/session-manager-dap.test.ts
@@ -389,12 +389,95 @@ describe('SessionManager - DAP Operations', () => {
       
       variables = await sessionManager.getVariables(session.id, 100);
       expect(variables).toEqual([]);
-      
+
       stackFrames = await sessionManager.getStackTrace(session.id);
       expect(stackFrames).toEqual([]);
-      
+
       scopes = await sessionManager.getScopes(session.id, 1);
       expect(scopes).toEqual([]);
+    });
+  });
+
+  describe('Exception Breakpoints and Stop Detail (issue #220)', () => {
+    it('threads breakOnExceptions into the ProxyConfig', async () => {
+      const session = await sessionManager.createSession({
+        language: DebugLanguage.MOCK,
+        executablePath: 'python'
+      });
+
+      await sessionManager.startDebugging(session.id, 'test.py', undefined, undefined, undefined, undefined, 'uncaught');
+      await vi.runAllTimersAsync();
+
+      expect(dependencies.mockProxyManager.startCalls).toHaveLength(1);
+      expect(dependencies.mockProxyManager.startCalls[0].breakOnExceptions).toBe('uncaught');
+    });
+
+    it('leaves breakOnExceptions undefined in the ProxyConfig when not requested', async () => {
+      const session = await sessionManager.createSession({
+        language: DebugLanguage.MOCK,
+        executablePath: 'python'
+      });
+
+      await sessionManager.startDebugging(session.id, 'test.py');
+      await vi.runAllTimersAsync();
+
+      expect(dependencies.mockProxyManager.startCalls[0].breakOnExceptions).toBeUndefined();
+    });
+
+    it('records description and text from the stopped event body on lastStop', async () => {
+      const session = await createPausedSession();
+
+      dependencies.mockProxyManager.simulateStopped(1, 'exception', {
+        reason: 'exception',
+        threadId: 1,
+        description: 'ZeroDivisionError',
+        text: 'division by zero'
+      });
+
+      const managedSession = sessionManager.getSession(session.id);
+      expect(managedSession?.lastStop).toMatchObject({
+        reason: 'exception',
+        threadId: 1,
+        description: 'ZeroDivisionError',
+        text: 'division by zero'
+      });
+      expect(managedSession?.state).toBe(SessionState.PAUSED);
+    });
+
+    it('handles a stopped event without a body (lastStop has no detail fields)', async () => {
+      const session = await createPausedSession();
+
+      dependencies.mockProxyManager.simulateStopped(1, 'breakpoint');
+
+      const managedSession = sessionManager.getSession(session.id);
+      expect(managedSession?.lastStop?.reason).toBe('breakpoint');
+      expect(managedSession?.lastStop?.description).toBeUndefined();
+      expect(managedSession?.lastStop?.text).toBeUndefined();
+    });
+
+    it('records the debuggee exit code from the exited event', async () => {
+      const session = await createPausedSession();
+
+      dependencies.mockProxyManager.simulateExited(1);
+
+      const managedSession = sessionManager.getSession(session.id);
+      expect(managedSession?.exitCode).toBe(1);
+      expect(managedSession?.state).toBe(SessionState.STOPPED);
+
+      // Projection includes the exit code
+      const infos = sessionManager.getAllSessions();
+      const info = infos.find(s => s.id === session.id);
+      expect(info?.exitCode).toBe(1);
+    });
+
+    it('leaves exitCode undefined when the exited event has no code', async () => {
+      const session = await createPausedSession();
+
+      dependencies.mockProxyManager.simulateExited(undefined);
+
+      const managedSession = sessionManager.getSession(session.id);
+      expect(managedSession?.exitCode).toBeUndefined();
+      expect(managedSession?.state).toBe(SessionState.STOPPED);
     });
   });
 });

--- a/tests/e2e/mcp-server-break-on-exceptions.test.ts
+++ b/tests/e2e/mcp-server-break-on-exceptions.test.ts
@@ -298,31 +298,12 @@ describe('Break-on-exception (issue #220)', () => {
       expect(frames.length).toBeGreaterThan(0);
     }, 60000);
 
-    it('terminates without pausing when breakOnExceptions is not set (regression guard)', async () => {
-      sessionId = await createSession('javascript', 'js-no-break-on-exceptions');
-
-      // A fast-crashing script makes the js-debug launch barrier wait out its
-      // readiness window before start_debugging resolves — give it room.
-      console.log('[js regression] starting...');
-      const t0 = Date.now();
-      const startRes = parseSdkToolResult(await mcpClient!.callTool({
-        name: 'start_debugging',
-        arguments: {
-          sessionId,
-          scriptPath: JS_CRASHING_SCRIPT,
-          dapLaunchArgs: { stopOnEntry: false }
-        }
-      }));
-      console.log(`[js regression] start_debugging returned after ${Date.now() - t0}ms: state=${startRes.state}`);
-      expect(startRes.success).toBe(true);
-
-      const stopped = await pollUntil(async () => {
-        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
-        return snap?.state === 'stopped' ? snap : undefined;
-      }, 30000);
-      expect(stopped, 'js session should terminate (pre-#220 behavior preserved)').toBeDefined();
-      expect(stopped!.lastStop?.reason).not.toBe('exception');
-    }, 120000);
+    // No js "runs to termination without the option" e2e here: launching a
+    // fast-crashing js script WITHOUT breakOnExceptions hangs start_debugging
+    // on a pre-existing launch-orchestration race (issue #242, reproduced on
+    // main). The no-option wire behavior is byte-identical to pre-#220
+    // ({filters: []} everywhere) and is covered by child-session-manager unit
+    // tests; the mock and python regression guards cover the contract e2e.
   });
 
   describe('Python attach', () => {

--- a/tests/e2e/mcp-server-break-on-exceptions.test.ts
+++ b/tests/e2e/mcp-server-break-on-exceptions.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Break-on-exception E2E tests (issue #220)
+ *
+ * Validates the breakOnExceptions option end to end:
+ * - Mock adapter: full stack (server -> proxy -> real mock adapter process)
+ *   with the gated exception simulation, including exit-code surfacing
+ * - Python launch: uncaught ZeroDivisionError pauses at the crash site with
+ *   stack + locals live instead of terminating the session
+ * - Python launch without the option: unchanged behavior (terminates), with
+ *   the debuggee exit code surfaced
+ * - Python attach: filters armed during the attach init sequence
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn, type ChildProcess } from 'child_process';
+import net from 'net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { parseSdkToolResult, callToolSafely } from './smoke-test-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../..');
+
+const CRASHING_SCRIPT = path.resolve(ROOT, 'tests', 'fixtures', 'debug-scripts', 'with-errors.py');
+const JS_CRASHING_SCRIPT = path.resolve(ROOT, 'tests', 'fixtures', 'debug-scripts', 'js-throws.js');
+const ATTACH_SCRIPT = path.resolve(ROOT, 'tests', 'fixtures', 'python', 'attach_then_raise.py');
+const PYTHON = process.platform === 'win32' ? 'python' : 'python3';
+
+interface SessionSnapshot {
+  state?: string;
+  lastStop?: { reason?: string; description?: string; text?: string };
+  exitCode?: number;
+}
+
+async function getSessionSnapshot(client: Client, sessionId: string): Promise<SessionSnapshot | undefined> {
+  const res = parseSdkToolResult(await client.callTool({ name: 'list_debug_sessions', arguments: {} }));
+  const sessions = (res.sessions ?? []) as Array<SessionSnapshot & { id: string }>;
+  return sessions.find(s => s.id === sessionId);
+}
+
+async function pollUntil<T>(
+  fn: () => Promise<T | undefined>,
+  timeoutMs: number,
+  intervalMs = 250
+): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await fn();
+    if (value !== undefined) return value;
+    if (Date.now() > deadline) return undefined;
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+}
+
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address && typeof address === 'object') {
+        const port = address.port;
+        server.close(() => resolve(port));
+      } else {
+        server.close(() => reject(new Error('No port assigned')));
+      }
+    });
+    server.on('error', reject);
+  });
+}
+
+describe('Break-on-exception (issue #220)', () => {
+  let mcpClient: Client | null = null;
+  let transport: StdioClientTransport | null = null;
+  let sessionId: string | null = null;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.join(ROOT, 'dist', 'index.js'), '--log-level', 'info'],
+      env: { ...process.env, NODE_ENV: 'test' }
+    });
+    mcpClient = new Client(
+      { name: 'break-on-exceptions-e2e', version: '1.0.0' },
+      { capabilities: {} }
+    );
+    await mcpClient.connect(transport);
+  }, 30000);
+
+  afterAll(async () => {
+    if (mcpClient) await mcpClient.close();
+    if (transport) await transport.close();
+  });
+
+  afterEach(async () => {
+    if (sessionId && mcpClient) {
+      await callToolSafely(mcpClient, 'close_debug_session', { sessionId });
+      sessionId = null;
+    }
+  });
+
+  async function createSession(language: string, name: string): Promise<string> {
+    const createRes = parseSdkToolResult(await mcpClient!.callTool({
+      name: 'create_debug_session',
+      arguments: { language, name }
+    }));
+    expect(createRes.sessionId).toBeDefined();
+    return createRes.sessionId as string;
+  }
+
+  describe('Mock adapter (full stack)', () => {
+    it('pauses at the simulated uncaught exception and surfaces exit code 1 after continue', async () => {
+      sessionId = await createSession('mock', 'mock-break-on-exceptions');
+
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: CRASHING_SCRIPT,
+          breakOnExceptions: 'uncaught'
+        }
+      }));
+      expect(startRes.success).toBe(true);
+
+      // The mock emits stopped{reason:'exception'} instead of terminating
+      const paused = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'paused' && snap.lastStop?.reason === 'exception' ? snap : undefined;
+      }, 10000);
+      expect(paused, 'session should pause with reason exception').toBeDefined();
+      expect(paused!.lastStop!.description).toBe('MockError');
+      expect(paused!.lastStop!.text).toBe('Mock uncaught exception');
+
+      // get_stack_trace surfaces the stop reason (issue #214 surface)
+      const stack = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'get_stack_trace',
+        arguments: { sessionId }
+      }));
+      expect(stack.stopReason).toBe('exception');
+
+      // Continue past the exception: mock terminates with exit code 1
+      await callToolSafely(mcpClient!, 'continue_execution', { sessionId });
+      const stopped = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'stopped' ? snap : undefined;
+      }, 10000);
+      expect(stopped, 'session should terminate after continuing past the exception').toBeDefined();
+      expect(stopped!.exitCode).toBe(1);
+    }, 30000);
+
+    it('runs to completion with exit code 0 when breakOnExceptions is not set (regression guard)', async () => {
+      sessionId = await createSession('mock', 'mock-no-break-on-exceptions');
+
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: CRASHING_SCRIPT
+        }
+      }));
+      expect(startRes.success).toBe(true);
+
+      const stopped = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'stopped' ? snap : undefined;
+      }, 10000);
+      expect(stopped, 'session should run to completion').toBeDefined();
+      expect(stopped!.lastStop).toBeUndefined();
+      expect(stopped!.exitCode).toBe(0);
+    }, 30000);
+
+    it('rejects an invalid breakOnExceptions value', async () => {
+      sessionId = await createSession('mock', 'mock-invalid-mode');
+
+      await expect(mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: CRASHING_SCRIPT,
+          breakOnExceptions: 'sometimes'
+        }
+      })).rejects.toThrow(/breakOnExceptions/);
+    }, 30000);
+  });
+
+  describe('Python launch', () => {
+    it('pauses at the uncaught ZeroDivisionError crash site with locals live', async () => {
+      sessionId = await createSession('python', 'py-break-on-exceptions');
+
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: CRASHING_SCRIPT,
+          dapLaunchArgs: { stopOnEntry: false },
+          breakOnExceptions: 'uncaught'
+        }
+      }));
+      expect(startRes.success).toBe(true);
+
+      const paused = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'paused' && snap.lastStop?.reason === 'exception' ? snap : undefined;
+      }, 15000);
+      expect(paused, 'session should pause at the uncaught exception instead of terminating').toBeDefined();
+      // debugpy puts the exception class/message in description/text
+      const detail = `${paused!.lastStop!.description ?? ''} ${paused!.lastStop!.text ?? ''}`;
+      expect(detail).toMatch(/ZeroDivisionError|division/i);
+
+      // Stack trace: top frame at the crash site (divide, line 5)
+      const stack = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'get_stack_trace',
+        arguments: { sessionId }
+      }));
+      expect(stack.stopReason).toBe('exception');
+      const frames = stack.stackFrames as Array<{ name: string; line: number; file?: string }>;
+      expect(frames.length).toBeGreaterThan(0);
+      expect(Math.abs(frames[0].line - 5)).toBeLessThanOrEqual(1);
+
+      // Locals at the crash site are inspectable
+      const locals = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'get_local_variables',
+        arguments: { sessionId }
+      }));
+      const variables = (locals.variables ?? []) as Array<{ name: string; value: string }>;
+      const a = variables.find(v => v.name === 'a');
+      const b = variables.find(v => v.name === 'b');
+      expect(a?.value).toBe('10');
+      expect(b?.value).toBe('0');
+
+      // Continue: debugpy re-raises and the session terminates
+      await callToolSafely(mcpClient!, 'continue_execution', { sessionId });
+      const stopped = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'stopped' ? snap : undefined;
+      }, 15000);
+      expect(stopped, 'session should terminate after continuing past the exception').toBeDefined();
+    }, 60000);
+
+    it('terminates without pausing when breakOnExceptions is not set (regression guard)', async () => {
+      sessionId = await createSession('python', 'py-no-break-on-exceptions');
+
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: CRASHING_SCRIPT,
+          dapLaunchArgs: { stopOnEntry: false }
+        }
+      }));
+      expect(startRes.success).toBe(true);
+
+      const stopped = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'stopped' ? snap : undefined;
+      }, 15000);
+      expect(stopped, 'session should terminate (pre-#220 behavior preserved)').toBeDefined();
+      // No user-visible stop was recorded on the way down
+      expect(stopped!.lastStop?.reason).not.toBe('exception');
+      // The crash is distinguishable from a clean exit via the exit code
+      expect(stopped!.exitCode).toBeDefined();
+      expect(stopped!.exitCode).not.toBe(0);
+    }, 60000);
+  });
+
+  describe('JavaScript launch (js-debug child session)', () => {
+    // Runtime verification that the js-debug filter ID 'uncaught' is real:
+    // the filters travel worker -> MinimalDapClient -> child session, so a
+    // wrong ID means no pause and this test fails.
+    it('pauses at an uncaught Error instead of terminating', async () => {
+      sessionId = await createSession('javascript', 'js-break-on-exceptions');
+
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: JS_CRASHING_SCRIPT,
+          dapLaunchArgs: { stopOnEntry: false },
+          breakOnExceptions: 'uncaught'
+        }
+      }));
+      expect(startRes.success).toBe(true);
+
+      const paused = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'paused' && snap.lastStop?.reason === 'exception' ? snap : undefined;
+      }, 20000);
+      expect(paused, 'js session should pause at the uncaught exception').toBeDefined();
+
+      const stack = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'get_stack_trace',
+        arguments: { sessionId }
+      }));
+      expect(stack.stopReason).toBe('exception');
+      const frames = stack.stackFrames as Array<{ name: string; line: number }>;
+      expect(frames.length).toBeGreaterThan(0);
+    }, 60000);
+
+    it('terminates without pausing when breakOnExceptions is not set (regression guard)', async () => {
+      sessionId = await createSession('javascript', 'js-no-break-on-exceptions');
+
+      // A fast-crashing script makes the js-debug launch barrier wait out its
+      // readiness window before start_debugging resolves — give it room.
+      console.log('[js regression] starting...');
+      const t0 = Date.now();
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: JS_CRASHING_SCRIPT,
+          dapLaunchArgs: { stopOnEntry: false }
+        }
+      }));
+      console.log(`[js regression] start_debugging returned after ${Date.now() - t0}ms: state=${startRes.state}`);
+      expect(startRes.success).toBe(true);
+
+      const stopped = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'stopped' ? snap : undefined;
+      }, 30000);
+      expect(stopped, 'js session should terminate (pre-#220 behavior preserved)').toBeDefined();
+      expect(stopped!.lastStop?.reason).not.toBe('exception');
+    }, 120000);
+  });
+
+  describe('Python attach', () => {
+    let debuggee: ChildProcess | null = null;
+
+    afterEach(() => {
+      if (debuggee && !debuggee.killed) {
+        debuggee.kill();
+      }
+      debuggee = null;
+    });
+
+    it('arms exception filters during attach and pauses at the post-attach raise', async () => {
+      const port = await findFreePort();
+
+      // Start the fixture: listens for debugpy attach, then raises after resume
+      debuggee = spawn(PYTHON, ['-u', ATTACH_SCRIPT, String(port)], { stdio: 'pipe' });
+      const listening = await new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => resolve(false), 15000);
+        debuggee!.stdout!.on('data', (data: Buffer) => {
+          if (data.toString().includes('LISTENING')) {
+            clearTimeout(timer);
+            resolve(true);
+          }
+        });
+        debuggee!.on('exit', () => {
+          clearTimeout(timer);
+          resolve(false);
+        });
+      });
+      expect(listening, 'debuggee should start listening for attach').toBe(true);
+
+      sessionId = await createSession('python', 'py-attach-break-on-exceptions');
+
+      const attachRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'attach_to_process',
+        arguments: {
+          sessionId,
+          host: '127.0.0.1',
+          port,
+          breakOnExceptions: 'uncaught'
+        }
+      }));
+      expect(attachRes.success).toBe(true);
+
+      // attach pauses the target (pauseAfterAttach); resume it so the fixture
+      // reaches its raise
+      await callToolSafely(mcpClient!, 'continue_execution', { sessionId });
+
+      const paused = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'paused' && snap.lastStop?.reason === 'exception' ? snap : undefined;
+      }, 20000);
+      expect(paused, 'attach session should pause at the uncaught exception').toBeDefined();
+      const detail = `${paused!.lastStop!.description ?? ''} ${paused!.lastStop!.text ?? ''}`;
+      expect(detail).toMatch(/RuntimeError|attach-mode uncaught exception/i);
+    }, 60000);
+  });
+});

--- a/tests/fixtures/debug-scripts/js-throws.js
+++ b/tests/fixtures/debug-scripts/js-throws.js
@@ -1,0 +1,9 @@
+// Break-on-exception fixture (issue #220): throws an uncaught error.
+// The throw happens in a timer callback: a top-level module throw is wrapped
+// by the ESM loader (V8 predicts it "caught"), so js-debug's 'uncaught'
+// filter only fires for exceptions thrown from a task context like this.
+function boom() {
+  throw new Error('js uncaught exception'); // Line 6: crash site
+}
+
+setTimeout(boom, 100); // Line 9

--- a/tests/fixtures/python/attach_then_raise.py
+++ b/tests/fixtures/python/attach_then_raise.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Attach-mode fixture for break-on-exception e2e (issue #220).
+
+Starts a debugpy listener, waits for the client to attach, then raises an
+uncaught exception shortly after execution resumes.
+"""
+import sys
+import time
+
+import debugpy
+
+port = int(sys.argv[1]) if len(sys.argv) > 1 else 5679
+debugpy.listen(("127.0.0.1", port))
+print(f"LISTENING {port}", flush=True)
+debugpy.wait_for_client()
+print("CLIENT ATTACHED", flush=True)
+
+time.sleep(1.0)  # Line 18: give post-attach verification a beat
+raise RuntimeError("attach-mode uncaught exception")  # Line 19: crash site

--- a/tests/proxy/child-session-manager.test.ts
+++ b/tests/proxy/child-session-manager.test.ts
@@ -94,6 +94,44 @@ describe('ChildSessionManager', () => {
         expect(childCreatedSpy).toHaveBeenCalledWith('test-pending-1', expect.any(Object));
         expect(manager.getActiveChild()).toBeDefined();
         expect(manager.hasActiveChildren()).toBe(true);
+
+        // Default (no breakOnExceptions): child config sends empty filters,
+        // preserving pre-#220 behavior byte for byte
+        const child = childCreatedSpy.mock.calls[0][1] as MockMinimalDapClient;
+        const exceptionRequests = child.requests.filter(r => r.command === 'setExceptionBreakpoints');
+        expect(exceptionRequests.length).toBeGreaterThan(0);
+        expect(exceptionRequests[0].args).toEqual({ filters: [] });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('sends resolved exception filters to the child when a break mode is set (issue #220)', async () => {
+      vi.useFakeTimers();
+      try {
+        manager.setExceptionBreakMode('uncaught');
+
+        const childCreatedSpy = vi.fn();
+        manager.on('childCreated', childCreatedSpy);
+
+        const createPromise = manager.createChildSession({
+          pendingId: 'test-pending-ex',
+          host: 'localhost',
+          port: 9229,
+          parentConfig: {
+            type: 'pwa-node',
+            request: 'launch'
+          }
+        });
+        await vi.advanceTimersByTimeAsync(20000);
+        await createPromise;
+
+        const child = childCreatedSpy.mock.calls[0][1] as MockMinimalDapClient;
+        const exceptionRequests = child.requests.filter(r => r.command === 'setExceptionBreakpoints');
+        expect(exceptionRequests.length).toBeGreaterThan(0);
+        for (const req of exceptionRequests) {
+          expect(req.args).toEqual({ filters: ['uncaught'] });
+        }
       } finally {
         vi.useRealTimers();
       }

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -1041,6 +1041,149 @@ describe('DapProxyWorker', () => {
     });
   });
 
+  describe('Exception Breakpoints (issue #220)', () => {
+    const buildPayload = (breakOnExceptions?: 'uncaught' | 'all' | 'none'): ProxyInitPayload => ({
+      cmd: 'init',
+      sessionId: 'ex-session',
+      executablePath: 'python',
+      adapterHost: 'localhost',
+      adapterPort: 5678,
+      logDir: '/logs',
+      scriptPath: '/path/to/script.py',
+      initialBreakpoints: [{ file: '/path/to/script.py', line: 3 }],
+      ...(breakOnExceptions ? { breakOnExceptions } : {})
+    });
+
+    const buildConnectionStub = () => ({
+      setBreakpoints: vi.fn().mockResolvedValue(undefined),
+      setExceptionBreakpoints: vi.fn().mockResolvedValue(undefined),
+      sendConfigurationDone: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined)
+    });
+
+    const primeWorker = (payload: ProxyInitPayload, connectionStub: object, policy = PythonAdapterPolicy) => {
+      (worker as any).logger = mockLogger;
+      (worker as any).connectionManager = connectionStub;
+      (worker as any).adapterPolicy = policy;
+      (worker as any).adapterState = policy.createInitialState();
+      (worker as any).currentInitPayload = payload;
+      (worker as any).dapClient = mockDapClient;
+      (worker as any).state = ProxyState.INITIALIZING;
+    };
+
+    it('sends setExceptionBreakpoints with resolved filters between setBreakpoints and configurationDone', async () => {
+      const payload = buildPayload('uncaught');
+      const connectionStub = buildConnectionStub();
+      primeWorker(payload, connectionStub);
+
+      await (worker as any).handleInitializedEvent();
+
+      expect(connectionStub.setExceptionBreakpoints).toHaveBeenCalledTimes(1);
+      expect(connectionStub.setExceptionBreakpoints).toHaveBeenCalledWith(mockDapClient, ['uncaught']);
+      // Order: setBreakpoints -> setExceptionBreakpoints -> configurationDone
+      const bpOrder = connectionStub.setBreakpoints.mock.invocationCallOrder[0];
+      const exOrder = connectionStub.setExceptionBreakpoints.mock.invocationCallOrder[0];
+      const configOrder = connectionStub.sendConfigurationDone.mock.invocationCallOrder[0];
+      expect(bpOrder).toBeLessThan(exOrder);
+      expect(exOrder).toBeLessThan(configOrder);
+      expect(worker.getState()).toBe(ProxyState.CONNECTED);
+    });
+
+    it("resolves 'all' mode through the adapter policy", async () => {
+      const payload = buildPayload('all');
+      const connectionStub = buildConnectionStub();
+      primeWorker(payload, connectionStub);
+
+      await (worker as any).handleInitializedEvent();
+
+      expect(connectionStub.setExceptionBreakpoints).toHaveBeenCalledWith(mockDapClient, ['raised', 'uncaught']);
+    });
+
+    it('does not send setExceptionBreakpoints when the mode is absent or none', async () => {
+      for (const mode of [undefined, 'none' as const]) {
+        const payload = buildPayload(mode);
+        const connectionStub = buildConnectionStub();
+        primeWorker(payload, connectionStub);
+        (worker as any).initializedEventHandled = false;
+
+        await (worker as any).handleInitializedEvent();
+
+        expect(connectionStub.setExceptionBreakpoints).not.toHaveBeenCalled();
+        expect(connectionStub.sendConfigurationDone).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('continues the launch when setExceptionBreakpoints fails', async () => {
+      const payload = buildPayload('uncaught');
+      const connectionStub = buildConnectionStub();
+      connectionStub.setExceptionBreakpoints.mockRejectedValue(new Error('unsupported'));
+      primeWorker(payload, connectionStub);
+
+      await (worker as any).handleInitializedEvent();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('setExceptionBreakpoints failed')
+      );
+      expect(connectionStub.sendConfigurationDone).toHaveBeenCalledTimes(1);
+      const statusCall = mockMessageSender.send.mock.calls.find(
+        ([message]) => message.type === 'status' && message.status === 'adapter_configured_and_launched'
+      );
+      expect(statusCall).toBeDefined();
+      expect(worker.getState()).toBe(ProxyState.CONNECTED);
+    });
+
+    it('skips the request and warns when the policy does not support the mode', async () => {
+      const payload = buildPayload('uncaught');
+      const connectionStub = buildConnectionStub();
+      primeWorker(payload, connectionStub, DefaultAdapterPolicy);
+
+      await (worker as any).handleInitializedEvent();
+
+      expect(connectionStub.setExceptionBreakpoints).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("breakOnExceptions 'uncaught' is not supported")
+      );
+      expect(connectionStub.sendConfigurationDone).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards the mode to the DAP client for child sessions during startAdapterAndConnect', async () => {
+      const payload = buildPayload('uncaught');
+      const setExceptionBreakMode = vi.fn();
+      Object.assign(mockDapClient, { setExceptionBreakMode });
+
+      const processStub = {
+        spawn: vi.fn().mockResolvedValue({
+          process: new EventEmitter() as unknown as ChildProcess,
+          pid: 654
+        }),
+        shutdown: vi.fn().mockResolvedValue(undefined)
+      };
+      const connectionStub = {
+        connectWithRetry: vi.fn().mockResolvedValue(mockDapClient),
+        setAdapterPolicy: vi.fn(),
+        setupEventHandlers: vi.fn(),
+        initializeSession: vi.fn().mockResolvedValue(undefined),
+        sendLaunchRequest: vi.fn().mockResolvedValue(undefined),
+        setBreakpoints: vi.fn().mockResolvedValue(undefined),
+        setExceptionBreakpoints: vi.fn().mockResolvedValue(undefined),
+        sendConfigurationDone: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined)
+      };
+
+      (worker as any).logger = mockLogger;
+      (worker as any).processManager = processStub;
+      (worker as any).connectionManager = connectionStub;
+      (worker as any).adapterPolicy = PythonAdapterPolicy;
+      (worker as any).adapterState = PythonAdapterPolicy.createInitialState();
+      (worker as any).currentInitPayload = payload;
+      (worker as any).state = ProxyState.INITIALIZING;
+
+      await (worker as any).startAdapterAndConnect(payload);
+
+      expect(setExceptionBreakMode).toHaveBeenCalledWith('uncaught');
+    });
+  });
+
   describe('DAP Command Handling', () => {
     it('should reject DAP commands before connection', async () => {
       // Initialize worker with dry run to avoid connection issues

--- a/tests/test-utils/mocks/mock-proxy-manager.ts
+++ b/tests/test-utils/mocks/mock-proxy-manager.ts
@@ -205,9 +205,13 @@ export class MockProxyManager extends EventEmitter implements IProxyManager {
     this.emit(event, ...args);
   }
 
-  simulateStopped(threadId: number, reason: string): void {
+  simulateStopped(threadId: number, reason: string, body?: DebugProtocol.StoppedEvent['body']): void {
     this._currentThreadId = threadId;
-    this.emit('stopped', threadId, reason);
+    this.emit('stopped', threadId, reason, body);
+  }
+
+  simulateExited(exitCode?: number): void {
+    this.emit('exited', exitCode);
   }
 
   simulateError(error: Error): void {

--- a/tests/unit/proxy/dap-proxy-message-parser.test.ts
+++ b/tests/unit/proxy/dap-proxy-message-parser.test.ts
@@ -176,12 +176,33 @@ describe('MessageParser', () => {
       });
     });
 
+    it('should accept each valid breakOnExceptions value and absence', () => {
+      const base = {
+        cmd: 'init',
+        sessionId: 'test-session',
+        executablePath: '/usr/bin/python3',
+        adapterHost: 'localhost',
+        adapterPort: 5678,
+        logDir: '/tmp/logs',
+        scriptPath: '/home/user/script.py'
+      };
+
+      for (const breakOnExceptions of ['uncaught', 'all', 'none'] as const) {
+        const result = MessageParser.validateInitPayload({ ...base, breakOnExceptions });
+        expect(result.breakOnExceptions).toBe(breakOnExceptions);
+      }
+
+      const withoutMode = MessageParser.validateInitPayload(base);
+      expect(withoutMode.breakOnExceptions).toBeUndefined();
+    });
+
     it('should throw on invalid optional fields', () => {
       const invalidOptionals = [
         { scriptArgs: 'not-an-array', error: 'scriptArgs' },
         { stopOnEntry: 'not-a-boolean', error: 'stopOnEntry' },
         { justMyCode: 123, error: 'justMyCode' },
         { dryRunSpawn: [], error: 'dryRunSpawn' },
+        { breakOnExceptions: 'sometimes', error: 'breakOnExceptions' },
         { initialBreakpoints: 'not-an-array', error: 'initialBreakpoints' }
       ];
 

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -125,6 +125,51 @@ describe('ProxyManager.start', () => {
     await expect(proxyManager.start(baseConfig)).rejects.toThrow('Proxy already running');
   });
 
+  it('includes breakOnExceptions in the init command when set (issue #220)', async () => {
+    await proxyManager.start({ ...baseConfig, breakOnExceptions: 'uncaught' });
+
+    expect(fakeProcess.sendCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cmd: 'init',
+        breakOnExceptions: 'uncaught'
+      })
+    );
+  });
+
+  it('sends breakOnExceptions as undefined in the init command when not set', async () => {
+    await proxyManager.start(baseConfig);
+
+    const initCommand = fakeProcess.sendCommand.mock.calls.find(
+      ([cmd]) => cmd.cmd === 'init'
+    )?.[0];
+    expect(initCommand).toBeDefined();
+    expect(initCommand.breakOnExceptions).toBeUndefined();
+  });
+
+  it('forwards the debuggee exit code on the exited event (issue #220)', async () => {
+    await completeStart();
+
+    const exitCodes: Array<number | undefined> = [];
+    proxyManager.on('exited', (exitCode?: number) => {
+      exitCodes.push(exitCode);
+    });
+
+    fakeProcess.emit('message', {
+      type: 'dapEvent',
+      sessionId: baseConfig.sessionId,
+      event: 'exited',
+      body: { exitCode: 3 }
+    });
+    fakeProcess.emit('message', {
+      type: 'dapEvent',
+      sessionId: baseConfig.sessionId,
+      event: 'exited',
+      body: {}
+    });
+
+    expect(exitCodes).toEqual([3, undefined]);
+  });
+
   it('records adapter command snapshot for dry-run completion', async () => {
     const config: ProxyConfig = {
       ...baseConfig,

--- a/tests/unit/shared/adapter-policy-python.test.ts
+++ b/tests/unit/shared/adapter-policy-python.test.ts
@@ -72,7 +72,11 @@ describe('PythonAdapterPolicy', () => {
     // debugpy only emits 'initialized' AFTER it receives the attach request;
     // waiting for the event before sending attach deadlocks (issue #145).
     expect(PythonAdapterPolicy.getInitializationBehavior()).toEqual({
-      sendAttachBeforeInitialized: true
+      sendAttachBeforeInitialized: true,
+      exceptionFilters: {
+        uncaught: ['uncaught'],
+        all: ['raised', 'uncaught']
+      }
     });
   });
 


### PR DESCRIPTION
Fixes #220.

## What

An uncaught exception in a debuggee previously **terminated the session** — indistinguishable from a clean exit, with stack and locals gone. This PR adds the missing tool surface and the two related visibility gaps called out in the issue:

- **`breakOnExceptions: "uncaught" | "all" | "none"`** (default `"none"`, opt-in — zero behavior change when unset) on **`start_debugging`** and **`attach_to_process`**. The abstract mode is resolved to concrete DAP `exceptionBreakpointFilters` IDs per language by the adapter policy (`getInitializationBehavior().exceptionFilters` + exported `resolveExceptionFilters()`):

  | Language | `uncaught` | `all` |
  |---|---|---|
  | Python | `uncaught` | `raised`, `uncaught` |
  | JavaScript | `uncaught` | `all` (runtime-verified against js-debug) |
  | Java | `uncaught` | `caught`, `uncaught` |
  | .NET | `user-unhandled` | `all` |
  | Go | `fatal`, `panic` | `fatal`, `panic` |
  | Rust | `rust_panic` | `rust_panic`, `cpp_throw` |
  | Ruby | — (warn + skip; rdbg has no uncaught-only filter) | `any` |

- **Exception detail on stops**: `lastStop` now records the stopped event's `description`/`text` (exception class and message) — surfaced via `list_debug_sessions`, `get_stack_trace`, and the `start_debugging` response.
- **Debuggee exit code**: the DAP `exited` event's `exitCode` is stored on the session and returned in `list_debug_sessions`, so a crash (non-zero) is distinguishable from a clean exit.

## How

- The worker sends `setExceptionBreakpoints` in `handleInitializedEvent` between initial breakpoints and `configurationDone` — one site covering python launch-first, go/java/ruby/dotnet `sendLaunchBeforeConfig`, and both attach variants. Failures are warn-logged and never abort the launch (inner try/catch; the outer catch calls `shutdown()`).
- js-debug (command-queueing) path: the parent handshake, child-session bootstrap, and post-attach replay all send the same resolved filters (the mode travels worker → `MinimalDapClient.setExceptionBreakMode` → `ChildSessionManager`). Unset mode resolves to `[]` — byte-identical to the previous hardcoded `{filters: []}`.
- The mode travels the init IPC as an abstract value; policies live in `@debugmcp/shared`, shared by both processes, so the mapping cannot drift.
- Mock adapter: new `setExceptionBreakpoints` handler + double-gated exception simulation (filters armed AND program path matches `/throws|error/i`), and it now emits `exited` before `terminated` (matching debugpy — the SessionManager tears down handlers on `terminated`).

## Verified

- Unit: 2584 tests / 158 files green, including new coverage: table-driven filter-mapping guardrail (all 8 policies × 4 modes), worker ordering/failure-tolerance/unsupported-mode tests, init-command threading (the explicit-field-copy silent-drop hazard), message-parser validation, lastStop detail + exitCode, child-session filter threading.
- E2E (new `tests/e2e/mcp-server-break-on-exceptions.test.ts`, 7 tests green): mock full-stack (pause → continue → `exitCode: 1`), **python** launch pausing at the `ZeroDivisionError` crash site with locals `a=10, b=0` live + no-option regression guard (terminates, non-zero `exitCode`), **javascript** pause-at-uncaught, **python attach** with filters armed during the attach init sequence (new `attach_then_raise.py` fixture).
- Manual MCP flow via dev-proxy: crash-site pause, locals, `lastStop` detail, `exitCode: 1` after continue.
- Runtime-verified js-debug filter IDs from its initialize response (`all`/`uncaught`) and corrected the drifted static declaration in `adapter-javascript`.

## Notes

- js-debug's `uncaught` does not fire for top-level ESM module throws (the loader wraps them; V8 predicts "caught") — the js fixture throws from a timer callback. Documented in the fixture.
- No js "no-option runs to termination" e2e: launching a fast-crashing js script hangs `start_debugging` on a **pre-existing** launch-orchestration race, reproduced on main and filed as #242. The no-option wire behavior is unchanged and covered at unit level.
- Follow-ups filed: #242 (js fast-crash hang), #243 (initialize-capability capture + `exceptionInfo` enrichment), #244 (consider defaulting `'uncaught'` on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)