### PR TITLE
fix: js-debug launch barrier settles on debuggee death (fixes #242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Debuggee exit code surfaced** — the exit code from the DAP `exited` event is stored on the session and returned as `exitCode` in `list_debug_sessions`, making a crash (non-zero) distinguishable from a clean exit (#220)
 
 ### Fixed
+- **js-debug launch no longer hangs on fast-exiting scripts** — the launch barrier now settles when the debuggee emits `terminated`/`exited` during the launch window, and `dispose()` rejects a still-pending wait as a structural backstop; `start_debugging` for a JavaScript script that crashes (or completes) within seconds of launch now returns promptly with state `stopped` instead of hanging past the MCP client timeout. Also removes an intermittent ~10s stall when js-debug's `initialized` event raced the handshake listener (fixes #242)
 - Mock adapter now answers `setExceptionBreakpoints` (previously an unhandled-command error) and emits `exited` before `terminated`, matching real adapter ordering (#220)
 - Corrected the JavaScript adapter's declared `exceptionBreakpointFilters` to the IDs js-debug actually reports (`all`, `uncaught`) (#220)
 

--- a/packages/adapter-javascript/src/utils/js-debug-launch-barrier.ts
+++ b/packages/adapter-javascript/src/utils/js-debug-launch-barrier.ts
@@ -28,6 +28,10 @@ export class JsDebugLaunchBarrier implements AdapterLaunchBarrier {
       this.resolve = resolve;
       this.reject = reject;
     });
+    // ProxyManager can dispose the barrier before waitUntilReady() is ever
+    // awaited (sendCommand-throw path); pre-attach a handler so the
+    // dispose-time rejection never surfaces as an unhandled rejection.
+    this.promise.catch(() => {});
 
     this.timeoutHandle = setTimeout(() => {
       if (this.settled) {
@@ -67,11 +71,23 @@ export class JsDebugLaunchBarrier implements AdapterLaunchBarrier {
   }
 
   onDapEvent(event: string, _body: DebugProtocol.Event['body'] | undefined): void {
-    if (this.settled || event !== 'stopped') {
+    if (this.settled) {
       return;
     }
-    this.logger?.info?.('[JavascriptAdapter] js-debug launch confirmed by stopped event');
-    this.resolveBarrier();
+    if (event === 'stopped') {
+      this.logger?.info?.('[JavascriptAdapter] js-debug launch confirmed by stopped event');
+      this.resolveBarrier();
+      return;
+    }
+    // A debuggee that dies during the launch window ends the launch phase too.
+    // Resolving (not rejecting) lets start_debugging return promptly with the
+    // session's stopped state and exit code, matching other adapters (#242).
+    if (event === 'terminated' || event === 'exited') {
+      this.logger?.info?.(
+        `[JavascriptAdapter] js-debug debuggee ${event} during launch; treating launch phase as complete`
+      );
+      this.resolveBarrier();
+    }
   }
 
   onProxyExit(code: number | null, signal: string | null): void {
@@ -96,6 +112,14 @@ export class JsDebugLaunchBarrier implements AdapterLaunchBarrier {
     if (this.adapterConnectedHandle) {
       clearTimeout(this.adapterConnectedHandle);
       this.adapterConnectedHandle = null;
+    }
+    // Backstop: a dispose with the promise still pending would otherwise
+    // orphan the awaiter forever (#242). Settle inline — resolveBarrier/
+    // rejectBarrier call dispose() after setting `settled`, so routing
+    // through rejectBarrier() here would re-enter.
+    if (!this.settled) {
+      this.settled = true;
+      this.reject(new Error('js-debug launch barrier disposed before readiness'));
     }
   }
 

--- a/packages/shared/src/interfaces/adapter-launch-barrier.ts
+++ b/packages/shared/src/interfaces/adapter-launch-barrier.ts
@@ -44,6 +44,13 @@ export interface AdapterLaunchBarrier {
   /**
    * Called when ProxyManager is cleaning up or when the barrier resolves.
    * Implementations should release timers/resources here.
+   *
+   * CONTRACT: dispose() MUST settle a still-pending waitUntilReady() promise
+   * (reject with a descriptive error). ProxyManager disposes barriers during
+   * cleanup and when a barrier is superseded — an awaiter must never be left
+   * hanging (#242). Implementations must also pre-attach a rejection handler
+   * to the promise so a dispose-time rejection that fires before any await
+   * does not become an unhandled rejection.
    */
   dispose(): void;
 }

--- a/packages/shared/src/interfaces/adapter-policy-js.ts
+++ b/packages/shared/src/interfaces/adapter-policy-js.ts
@@ -212,7 +212,25 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
       return;
     }
 
-    // 1) initialize with supportsStartDebuggingRequest
+    // 1) initialize with supportsStartDebuggingRequest.
+    // The 'initialized' listener is attached BEFORE the request goes out:
+    // js-debug can emit the event before the initialize response is processed,
+    // and a listener attached afterwards misses it and burns the full wait
+    // window below (#242).
+    let initializedSeen = false;
+    let notifyInitialized: (() => void) | null = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onInitialized = (event: any) => {
+      // Handle both event object and string formats
+      const eventName = typeof event === 'string' ? event : event?.event;
+      if (eventName === 'initialized') {
+        initializedSeen = true;
+        pm.removeListener('dap-event', onInitialized);
+        notifyInitialized?.();
+      }
+    };
+    pm.on('dap-event', onInitialized);
+
     try {
       console.info(`[JsDebugAdapterPolicy] [JS] Sending 'initialize' request`);
       await pm.sendDapRequest('initialize', {
@@ -232,29 +250,21 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
       );
     }
 
-    // 2) wait for DAP 'initialized'
-    await new Promise<void>((resolve) => {
-      let done = false;
-      const timer = setTimeout(() => {
-        if (done) return;
-        done = true;
-        console.warn(`[JsDebugAdapterPolicy] [JS] Timeout waiting for DAP 'initialized' event`);
-        resolve();
-      }, 10000);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const onHandler = (event: any) => {
-        if (done) return;
-        // Handle both event object and string formats
-        const eventName = typeof event === 'string' ? event : event?.event;
-        if (eventName === 'initialized') {
-          done = true;
-          clearTimeout(timer);
-          pm.removeListener('dap-event', onHandler);
+    // 2) wait for DAP 'initialized'. The timeout is armed only now so a slow
+    // initialize round-trip does not consume the wait window.
+    if (!initializedSeen) {
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+          pm.removeListener('dap-event', onInitialized);
+          console.warn(`[JsDebugAdapterPolicy] [JS] Timeout waiting for DAP 'initialized' event`);
           resolve();
-        }
-      };
-      pm.on('dap-event', onHandler);
-    });
+        }, 10000);
+        notifyInitialized = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+      });
+    }
 
     // 3) setExceptionBreakpoints + setBreakpoints
     try {

--- a/tests/e2e/mcp-server-break-on-exceptions.test.ts
+++ b/tests/e2e/mcp-server-break-on-exceptions.test.ts
@@ -298,12 +298,30 @@ describe('Break-on-exception (issue #220)', () => {
       expect(frames.length).toBeGreaterThan(0);
     }, 60000);
 
-    // No js "runs to termination without the option" e2e here: launching a
-    // fast-crashing js script WITHOUT breakOnExceptions hangs start_debugging
-    // on a pre-existing launch-orchestration race (issue #242, reproduced on
-    // main). The no-option wire behavior is byte-identical to pre-#220
-    // ({filters: []} everywhere) and is covered by child-session-manager unit
-    // tests; the mock and python regression guards cover the contract e2e.
+    // Regression guard for issue #242: launching a fast-crashing js script
+    // WITHOUT breakOnExceptions used to hang start_debugging (the js-debug
+    // launch barrier was disposed unsettled when the debuggee died mid-launch).
+    it('terminates without pausing when breakOnExceptions is not set (regression guard, issue #242)', async () => {
+      sessionId = await createSession('javascript', 'js-no-break-on-exceptions');
+
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: JS_CRASHING_SCRIPT,
+          dapLaunchArgs: { stopOnEntry: false }
+        }
+      }));
+      expect(startRes.success).toBe(true);
+
+      const stopped = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'stopped' ? snap : undefined;
+      }, 20000);
+      expect(stopped, 'js session should terminate promptly instead of hanging (issue #242)').toBeDefined();
+      // No user-visible stop was recorded on the way down
+      expect(stopped!.lastStop?.reason).not.toBe('exception');
+    }, 60000);
   });
 
   describe('Python attach', () => {

--- a/tests/unit/adapters/js-debug-launch-barrier.test.ts
+++ b/tests/unit/adapters/js-debug-launch-barrier.test.ts
@@ -65,6 +65,76 @@ describe('JsDebugLaunchBarrier', () => {
     barrier.dispose();
   });
 
+  it('resolves when a terminated event arrives (issue #242)', async () => {
+    const barrier = new JsDebugLaunchBarrier(logger, 5000);
+    const waitPromise = barrier.waitUntilReady();
+    let state = 'pending';
+    waitPromise.then(() => { state = 'resolved'; }, () => { state = 'rejected'; });
+
+    barrier.onDapEvent('terminated', undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(state).toBe('resolved');
+    await expect(waitPromise).resolves.toBeUndefined();
+    barrier.dispose();
+  });
+
+  it('resolves when an exited event arrives (issue #242)', async () => {
+    const barrier = new JsDebugLaunchBarrier(logger, 5000);
+    const waitPromise = barrier.waitUntilReady();
+    let state = 'pending';
+    waitPromise.then(() => { state = 'resolved'; }, () => { state = 'rejected'; });
+
+    barrier.onDapEvent('exited', { exitCode: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(state).toBe('resolved');
+    await expect(waitPromise).resolves.toBeUndefined();
+    barrier.dispose();
+  });
+
+  it('rejects a still-pending wait when disposed before readiness (issue #242)', async () => {
+    const barrier = new JsDebugLaunchBarrier(logger, 5000);
+    const waitPromise = barrier.waitUntilReady();
+    let state = 'pending';
+    waitPromise.then(() => { state = 'resolved'; }, () => { state = 'rejected'; });
+
+    barrier.dispose();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(state).toBe('rejected');
+    await expect(waitPromise).rejects.toThrow(/disposed before readiness/);
+  });
+
+  it('dispose after settlement does not reject the resolved wait', async () => {
+    const barrier = new JsDebugLaunchBarrier(logger, 2000);
+    const waitPromise = barrier.waitUntilReady();
+
+    barrier.onDapEvent('stopped', undefined);
+    await waitPromise;
+
+    barrier.dispose();
+    await expect(barrier.waitUntilReady()).resolves.toBeUndefined();
+  });
+
+  it('dispose is idempotent', async () => {
+    const barrier = new JsDebugLaunchBarrier(logger, 5000);
+    const waitPromise = barrier.waitUntilReady();
+
+    barrier.dispose();
+    barrier.dispose();
+
+    await expect(waitPromise).rejects.toThrow(/disposed before readiness/);
+  });
+
+  it('does not produce an unhandled rejection when disposed without an awaiter', () => {
+    // Mirrors the ProxyManager sendCommand-throw path: the barrier is disposed
+    // before waitUntilReady() is ever awaited. Vitest fails the run on
+    // unhandled rejections, so finishing cleanly is the assertion.
+    const barrier = new JsDebugLaunchBarrier(logger, 5000);
+    barrier.dispose();
+  });
+
   it('ignores duplicate readiness signals after settlement', async () => {
     const barrier = new JsDebugLaunchBarrier(logger, 2000);
     const waitPromise = barrier.waitUntilReady();

--- a/tests/unit/shared/adapter-policy-js.test.ts
+++ b/tests/unit/shared/adapter-policy-js.test.ts
@@ -184,6 +184,81 @@ describe('JsDebugAdapterPolicy', () => {
       expect(sendDapRequest.mock.calls.some(([cmd]) => cmd === 'launch')).toBe(true);
     });
 
+    it('does not miss an initialized event emitted before the initialize response settles (issue #242)', async () => {
+      vi.useFakeTimers();
+      try {
+        const events = new EventEmitter();
+        // js-debug can emit 'initialized' before the initialize response is
+        // processed; the handshake must not burn its 10s window when that happens.
+        const sendDapRequest = vi.fn().mockImplementation((cmd: string) => {
+          if (cmd === 'initialize') {
+            events.emit('dap-event', { event: 'initialized' });
+          }
+          return Promise.resolve({});
+        });
+
+        const proxyManager = Object.assign(events, {
+          isRunning: () => true,
+          sendDapRequest,
+          removeListener: events.removeListener.bind(events)
+        });
+
+        const context = {
+          proxyManager,
+          sessionId: 'session-3',
+          dapLaunchArgs: { stopOnEntry: false },
+          scriptPath: '/workspace/app.js',
+          scriptArgs: [],
+          breakpoints: new Map()
+        };
+
+        const handshakePromise = JsDebugAdapterPolicy.performHandshake(context as any);
+        let done = false;
+        handshakePromise.then(() => { done = true; });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(done).toBe(true);
+        expect(events.listenerCount('dap-event')).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('removes the initialized listener when the wait times out (issue #242)', async () => {
+      vi.useFakeTimers();
+      try {
+        const events = new EventEmitter();
+        const sendDapRequest = vi.fn().mockResolvedValue({});
+
+        const proxyManager = Object.assign(events, {
+          isRunning: () => true,
+          sendDapRequest,
+          removeListener: events.removeListener.bind(events)
+        });
+
+        const context = {
+          proxyManager,
+          sessionId: 'session-4',
+          dapLaunchArgs: { stopOnEntry: false },
+          scriptPath: '/workspace/app.js',
+          scriptArgs: [],
+          breakpoints: new Map()
+        };
+
+        const handshakePromise = JsDebugAdapterPolicy.performHandshake(context as any);
+        let done = false;
+        handshakePromise.then(() => { done = true; });
+        // Never emit 'initialized' — the 10s timeout path must still complete
+        // the handshake and must not leak the dap-event listener.
+        await vi.advanceTimersByTimeAsync(10000);
+
+        expect(done).toBe(true);
+        expect(events.listenerCount('dap-event')).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('uses attach flow when attach port provided', async () => {
       vi.useFakeTimers();
       const events = new EventEmitter();


### PR DESCRIPTION
## Problem

`start_debugging` for a JavaScript script that crashes shortly after launch (e.g. an uncaught throw from a ~100ms timer callback) could hang past the 60s MCP client timeout, or return late (~17s), while the session itself correctly reached `state: 'stopped'`. Fixes #242.

## Root cause

js-debug launches take ProxyManager's fire-and-forget path: the `launch` request never enters `pendingDapRequests` and instead awaits `JsDebugLaunchBarrier.waitUntilReady()`. The barrier only resolved on a `stopped` event (or its 5s timer), and **`dispose()` cleared the timers without settling the promise**. When the debuggee died during the launch window, its `terminated`/`exited` events were ignored by the barrier but drove `SessionManagerCore` → `proxyManager.stop()` → `cleanup()` → `barrier.dispose()` — orphaning the awaited launch forever, upstream of every timeout. A **healthy** script that exits 0 in under 5s hit the same hang.

The ~17s slow variant additionally included an intermittent 10s stall: the handshake attached its `initialized` listener only after the initialize response resolved, missing an early event (and leaking the listener on timeout).

## Fix

- **Barrier settles on debuggee death**: `onDapEvent` now resolves on `terminated`/`exited` — the launch phase is over; resolving lets `start_debugging` return promptly with the stopped state, matching other adapters.
- **`dispose()` is a structural backstop**: it now rejects a still-pending wait (inline, avoiding re-entry through `rejectBarrier()`), with a pre-attached rejection handler so a dispose before any await can't become an unhandled rejection. Contract documented on `AdapterLaunchBarrier`.
- **`initialized` listener attached before the initialize request**; the 10s window is armed only after initialize settles; the timeout path removes the listener.

No ProxyManager changes — it already forwards DAP events to the barrier before emitting them, which is exactly what makes the barrier fix sufficient.

## Tests

- Barrier unit tests: resolve on `terminated`/`exited`, dispose-before-settle rejects, dispose idempotent, no unhandled rejection without an awaiter.
- Handshake unit tests: early `initialized` event not missed; timeout path unhooks the listener.
- New e2e regression guard (the case previously omitted and documented as blocked on #242): fast-crashing js script without `breakOnExceptions` → `start_debugging` succeeds and the session reaches `stopped` promptly. Passes 4/4 runs at ~1.3s (was: hang/60s timeout). The guard mirrors the python one minus the `exitCode` assertion — js-debug's child session doesn't surface the debuggee exit code (verified manually); follow-up to be filed.
- Manually verified via dev proxy: the issue's exact repro returns promptly with `state: 'stopped'`; the with-`breakOnExceptions` path still pauses at the exception.
- Full unit suite green (158 files / 2592 tests), js smoke e2e green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)