### PR TITLE
fix: death-aware, retryable js-debug child adoption; remove dead configDone deferral

### DIFF
--- a/docs/architecture/adapter-policy-pattern.md
+++ b/docs/architecture/adapter-policy-pattern.md
@@ -34,7 +34,6 @@ export interface AdapterPolicy {
   // === Child Session / Multi-session Support ===
   supportsReverseStartDebugging: boolean;
   childSessionStrategy: ChildSessionStrategy; // 'none' | 'launchWithPendingTarget' | 'attachByPort' | 'adoptInParent'
-  shouldDeferParentConfigDone(parentConfig: Record<string, unknown>): boolean;
   buildChildStartArgs(pendingId: string, parentConfig: Record<string, unknown>):
     { command: 'launch' | 'attach'; args: Record<string, unknown> };
   isChildReadyEvent(evt: DebugProtocol.Event): boolean;

--- a/packages/shared/src/interfaces/adapter-policy-dotnet.ts
+++ b/packages/shared/src/interfaces/adapter-policy-dotnet.ts
@@ -43,7 +43,6 @@ export const DotnetAdapterPolicy: AdapterPolicy = {
   name: 'dotnet',
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
-  shouldDeferParentConfigDone: () => false,
   buildChildStartArgs: () => {
     throw new Error('DotnetAdapterPolicy does not support child sessions');
   },
@@ -252,7 +251,6 @@ export const DotnetAdapterPolicy: AdapterPolicy = {
 
       childRoutedCommands: undefined,
       mirrorBreakpointsToChild: false,
-      deferParentConfigDone: false,
       pauseAfterChildAttach: false,
       normalizeAdapterId: undefined,
       childInitTimeout: 5000,

--- a/packages/shared/src/interfaces/adapter-policy-go.ts
+++ b/packages/shared/src/interfaces/adapter-policy-go.ts
@@ -14,7 +14,6 @@ export const GoAdapterPolicy: AdapterPolicy = {
   name: 'go',
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
-  shouldDeferParentConfigDone: () => false,
   buildChildStartArgs: () => {
     throw new Error('GoAdapterPolicy does not support child sessions');
   },
@@ -261,7 +260,6 @@ export const GoAdapterPolicy: AdapterPolicy = {
       
       // Go-specific behaviors
       mirrorBreakpointsToChild: false,
-      deferParentConfigDone: false,
       pauseAfterChildAttach: false,
       
       // No adapter ID normalization needed

--- a/packages/shared/src/interfaces/adapter-policy-java.ts
+++ b/packages/shared/src/interfaces/adapter-policy-java.ts
@@ -15,7 +15,6 @@ export const JavaAdapterPolicy: AdapterPolicy = {
   name: 'java',
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
-  shouldDeferParentConfigDone: () => false,
   buildChildStartArgs: () => {
     throw new Error('JavaAdapterPolicy does not support child sessions');
   },
@@ -191,7 +190,6 @@ export const JavaAdapterPolicy: AdapterPolicy = {
 
       childRoutedCommands: undefined,
       mirrorBreakpointsToChild: false,
-      deferParentConfigDone: false,
       pauseAfterChildAttach: false,
       normalizeAdapterId: undefined,
       childInitTimeout: 5000,

--- a/packages/shared/src/interfaces/adapter-policy-js.ts
+++ b/packages/shared/src/interfaces/adapter-policy-js.ts
@@ -25,7 +25,6 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
   name: 'js-debug',
   supportsReverseStartDebugging: true,
   childSessionStrategy: 'launchWithPendingTarget',
-  shouldDeferParentConfigDone: () => true,
   buildChildStartArgs: (pendingId: string, parentConfig: Record<string, unknown>) => {
     const type = typeof parentConfig?.type === 'string' ? (parentConfig.type as string) : 'pwa-node';
     return {
@@ -733,7 +732,6 @@ export const JsDebugAdapterPolicy: AdapterPolicy = {
       
       // JavaScript-specific child session behaviors
       mirrorBreakpointsToChild: true,
-      deferParentConfigDone: true,
       pauseAfterChildAttach: true,
       stackTraceRequiresChild: true,
       

--- a/packages/shared/src/interfaces/adapter-policy-mock.ts
+++ b/packages/shared/src/interfaces/adapter-policy-mock.ts
@@ -12,7 +12,6 @@ export const MockAdapterPolicy: AdapterPolicy = {
   name: 'mock',
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
-  shouldDeferParentConfigDone: () => false,
   buildChildStartArgs: () => {
     throw new Error('MockAdapterPolicy does not support child sessions');
   },
@@ -181,7 +180,6 @@ export const MockAdapterPolicy: AdapterPolicy = {
       
       // Mock-specific behaviors (all disabled)
       mirrorBreakpointsToChild: false,
-      deferParentConfigDone: false,
       pauseAfterChildAttach: false,
       
       // No adapter ID normalization needed

--- a/packages/shared/src/interfaces/adapter-policy-python.ts
+++ b/packages/shared/src/interfaces/adapter-policy-python.ts
@@ -13,7 +13,6 @@ export const PythonAdapterPolicy: AdapterPolicy = {
   name: 'python',
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
-  shouldDeferParentConfigDone: () => false,
   buildChildStartArgs: () => {
     throw new Error('PythonAdapterPolicy does not support child sessions');
   },
@@ -274,7 +273,6 @@ export const PythonAdapterPolicy: AdapterPolicy = {
       
       // Python-specific behaviors
       mirrorBreakpointsToChild: false,
-      deferParentConfigDone: false,
       pauseAfterChildAttach: false,
       
       // No adapter ID normalization needed

--- a/packages/shared/src/interfaces/adapter-policy-ruby.ts
+++ b/packages/shared/src/interfaces/adapter-policy-ruby.ts
@@ -8,7 +8,6 @@ export const RubyAdapterPolicy: AdapterPolicy = {
   name: 'ruby',
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
-  shouldDeferParentConfigDone: () => false,
   buildChildStartArgs: () => {
     throw new Error('RubyAdapterPolicy does not support child sessions');
   },
@@ -152,7 +151,6 @@ export const RubyAdapterPolicy: AdapterPolicy = {
       },
       childRoutedCommands: undefined,
       mirrorBreakpointsToChild: false,
-      deferParentConfigDone: false,
       pauseAfterChildAttach: false,
       normalizeAdapterId: undefined,
       childInitTimeout: 5000,

--- a/packages/shared/src/interfaces/adapter-policy-rust.ts
+++ b/packages/shared/src/interfaces/adapter-policy-rust.ts
@@ -14,7 +14,6 @@ export const RustAdapterPolicy: AdapterPolicy = {
   name: 'rust',
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
-  shouldDeferParentConfigDone: () => false,
   buildChildStartArgs: () => {
     throw new Error('RustAdapterPolicy does not support child sessions');
   },
@@ -255,7 +254,6 @@ export const RustAdapterPolicy: AdapterPolicy = {
       
       // Rust-specific behaviors
       mirrorBreakpointsToChild: false,
-      deferParentConfigDone: false,
       pauseAfterChildAttach: false,
       
       // No adapter ID normalization needed

--- a/packages/shared/src/interfaces/adapter-policy.ts
+++ b/packages/shared/src/interfaces/adapter-policy.ts
@@ -59,13 +59,6 @@ export interface AdapterPolicy {
   childSessionStrategy: ChildSessionStrategy;
 
   /**
-   * Whether to defer sending configurationDone in the parent session temporarily
-   * to ensure the child session is fully configured before the target resumes.
-   * This should return true only for adapters that require it (e.g., js-debug).
-   */
-  shouldDeferParentConfigDone(parentConfig: Record<string, unknown>): boolean;
-
-  /**
    * Build the child start request (launch or attach) for a given pending target ID.
    * This should include just the necessary args; consumers may sanitize/augment further.
    */
@@ -408,7 +401,6 @@ export const DefaultAdapterPolicy: AdapterPolicy = {
   name: 'default',
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
-  shouldDeferParentConfigDone: () => false,
   buildChildStartArgs: (pendingId: string) => {
     throw new Error(
       `DefaultAdapterPolicy is a placeholder and cannot start child sessions (pendingId=${pendingId}).`

--- a/packages/shared/src/interfaces/dap-client-behavior.ts
+++ b/packages/shared/src/interfaces/dap-client-behavior.ts
@@ -58,11 +58,6 @@ export interface DapClientBehavior {
   mirrorBreakpointsToChild?: boolean;
   
   /**
-   * Whether to defer parent's configurationDone until child is configured
-   */
-  deferParentConfigDone?: boolean;
-  
-  /**
    * Whether to attempt pause after launching/attaching child
    */
   pauseAfterChildAttach?: boolean;

--- a/src/proxy/child-session-manager.ts
+++ b/src/proxy/child-session-manager.ts
@@ -31,14 +31,12 @@ function createChildSafePolicy(policy: AdapterPolicy): AdapterPolicy {
     ...policy,
     supportsReverseStartDebugging: false,
     childSessionStrategy: 'none',
-    shouldDeferParentConfigDone: () => false,
     getDapClientBehavior: (): DapClientBehavior => {
       const baseBehavior = policy.getDapClientBehavior();
       const behavior: DapClientBehavior = {
         ...baseBehavior,
         childRoutedCommands: new Set<string>(),
         mirrorBreakpointsToChild: false,
-        deferParentConfigDone: false,
         pauseAfterChildAttach: false,
         stackTraceRequiresChild: false,
       };

--- a/src/proxy/child-session-manager.ts
+++ b/src/proxy/child-session-manager.ts
@@ -63,6 +63,57 @@ export interface ChildSessionOptions {
   port: number;
 }
 
+/**
+ * Settle-once death signal for a child client during adoption (issue #248).
+ * Modeled on JsDebugLaunchBarrier: pre-caught so an unused latch never becomes
+ * an unhandled rejection, and disposed once adoption settles either way.
+ */
+interface ChildDeathLatch {
+  isDead(): boolean;
+  error(): Error | null;
+  /** Race a step against child death; rejects immediately once the child dies. */
+  race<T>(step: Promise<T>): Promise<T>;
+  dispose(): void;
+}
+
+function createChildDeathLatch(child: MinimalDapClient, pendingId: string): ChildDeathLatch {
+  let dead: Error | null = null;
+  let rejectDeath: ((err: Error) => void) | null = null;
+  const deathPromise = new Promise<never>((_, reject) => {
+    rejectDeath = reject;
+  });
+  // Pre-catch: if no race is in flight when death fires, nothing awaits this
+  deathPromise.catch(() => {});
+
+  const markDead = (why: string) => (cause?: Error) => {
+    if (dead) return;
+    const detail = cause?.message ? `: ${cause.message}` : '';
+    dead = new Error(`Child session ${pendingId} ${why} during adoption${detail}`);
+    rejectDeath?.(dead);
+  };
+  const onClose = markDead('closed');
+  const onError = markDead('errored');
+  child.on('close', onClose);
+  child.on('error', onError);
+
+  return {
+    isDead: () => dead !== null,
+    error: () => dead,
+    race<T>(step: Promise<T>): Promise<T> {
+      // A losing step may reject later (e.g. socket teardown); keep it handled
+      step.catch(() => {});
+      if (dead) {
+        return Promise.reject(dead);
+      }
+      return Promise.race([step, deathPromise]);
+    },
+    dispose: () => {
+      child.off('close', onClose);
+      child.off('error', onError);
+    }
+  };
+}
+
 export class ChildSessionManager extends EventEmitter {
   private policy: AdapterPolicy;
   private dapBehavior: DapClientBehavior;
@@ -213,36 +264,41 @@ export class ChildSessionManager extends EventEmitter {
     this.adoptionInProgress = true;
     logger.info(`[ChildSessionManager:${this.instanceId}] Setting adoptionInProgress = true for ${pendingId}`);
     this.adoptedTargets.add(pendingId);
-    
+
+    let child: MinimalDapClient | null = null;
+    let death: ChildDeathLatch | null = null;
     try {
       // Import MinimalDapClient dynamically to avoid circular dependency
       const { MinimalDapClient } = await import('./minimal-dap.js');
-      
+
       // Create child client with a policy that disables recursive reverse debugging
       const childPolicy = createChildSafePolicy(this.policy);
-      const child = new MinimalDapClient(this.host, this.port, childPolicy);
+      child = new MinimalDapClient(this.host, this.port, childPolicy);
       await child.connect();
-      
+
       // Wire up event forwarding
       this.wireChildEvents(child);
-      
+
+      // Abort remaining adoption steps the moment the child dies (issue #248)
+      death = createChildDeathLatch(child, pendingId);
+
       // Store and activate child
       this.childSessions.set(pendingId, child);
       this.activeChild = child;
       logger.info(`[ChildSessionManager:${this.instanceId}] *** ACTIVE CHILD SET *** for ${pendingId} at timestamp ${Date.now()}`);
-      
+
       // Initialize child session
-      await this.initializeChild(child, pendingId, parentConfig);
-      
+      await death.race(this.initializeChild(child, pendingId, parentConfig));
+
       // Configure child session
-      await this.configureChild(child, pendingId, parentConfig);
-      
+      await death.race(this.configureChild(child, pendingId, parentConfig));
+
       // Attach to pending target
-      await this.attachChild(child, pendingId, parentConfig);
-      
+      await this.attachChild(child, pendingId, parentConfig, death);
+
       // Handle post-attach initialization if needed
-      await this.handlePostAttachInit(child);
-      
+      await death.race(this.handlePostAttachInit(child));
+
       // Ensure initial stop if policy requires it.
       // Skip when the user explicitly requested stopOnEntry=false: forcing a
       // pause contradicts intent and the resulting 'pause'-reason stopped
@@ -255,23 +311,40 @@ export class ChildSessionManager extends EventEmitter {
       const wantsEntryStop = parentConfig?.stopOnEntry !== false;
       const attachModeParent = parentConfig?.request === 'attach';
       if (this.dapBehavior.pauseAfterChildAttach && wantsEntryStop && !attachModeParent) {
-        await this.ensureChildStopped(child);
+        await death.race(this.ensureChildStopped(child));
       }
-      
+
       this.adoptionInProgress = false;
       logger.info(`[ChildSessionManager:${this.instanceId}] Setting adoptionInProgress = false for ${pendingId} (success)`);
 
       logger.info(`[ChildSessionManager:${this.instanceId}] Child session created successfully for ${pendingId}`);
       this.emit('childCreated', pendingId, child);
-      
+
     } catch (error) {
       this.adoptionInProgress = false;
       this.adoptedTargets.delete(pendingId);
+      // Roll back registration so a later adoption attempt is not latched out
+      // by hasActiveChildren(), and release the half-adopted socket (issue #248)
+      if (child) {
+        if (this.childSessions.get(pendingId) === child) {
+          this.childSessions.delete(pendingId);
+        }
+        if (this.activeChild === child) {
+          this.activeChild = null;
+        }
+        try {
+          child.shutdown('adoption failed');
+        } catch {
+          // Best effort — the socket may already be gone
+        }
+      }
       logger.info(`[ChildSessionManager:${this.instanceId}] Setting adoptionInProgress = false for ${pendingId} (error)`);
       const msg = error instanceof Error ? error.message : String(error);
       logger.error(`[ChildSessionManager:${this.instanceId}] Failed to create child session for ${pendingId}: ${msg}`);
       this.emit('childError', pendingId, error);
       throw error;
+    } finally {
+      death?.dispose();
     }
   }
 
@@ -341,29 +414,73 @@ export class ChildSessionManager extends EventEmitter {
   /**
    * Attach child to pending target
    */
-  private async attachChild(child: MinimalDapClient, pendingId: string, parentConfig: Record<string, unknown>): Promise<void> {
+  private async attachChild(
+    child: MinimalDapClient,
+    pendingId: string,
+    parentConfig: Record<string, unknown>,
+    death: ChildDeathLatch
+  ): Promise<void> {
     const attachArgs = this.policy.buildChildStartArgs(pendingId, parentConfig);
-    
-    // Retry logic for attachment
+
+    // Retry logic for attachment, bounded by a total deadline so a live but
+    // unresponsive adapter cannot pin the worker for retries x timeout (#248)
     const maxRetries = 20;
+    const totalDeadlineMs = 60000;
+    const deadline = Date.now() + totalDeadlineMs;
     let adopted = false;
     let lastError: unknown;
-    
+
     for (let i = 0; i < maxRetries && !adopted; i++) {
+      if (death.isDead()) {
+        throw death.error();
+      }
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        break;
+      }
       try {
         logger.info(`[child:${pendingId}] ${attachArgs.command} attempt ${i + 1}`);
-        await child.sendRequest(attachArgs.command, attachArgs.args, 20000);
+        await death.race(
+          this.withTimeout(
+            child.sendRequest(attachArgs.command, attachArgs.args, 20000),
+            remainingMs,
+            `${attachArgs.command} deadline exceeded`
+          )
+        );
         adopted = true;
       } catch (e) {
+        if (death.isDead()) {
+          throw death.error();
+        }
         lastError = e;
         await this.sleep(200);
       }
     }
-    
+
     if (!adopted) {
       const msg = lastError instanceof Error ? lastError.message : String(lastError);
-      throw new Error(`Failed to attach child after ${maxRetries} attempts: ${msg}`);
+      throw new Error(`Failed to attach child after ${maxRetries} attempts or ${totalDeadlineMs}ms deadline: ${msg}`);
     }
+  }
+
+  /**
+   * Bound a step with its own timer (used to cap attach attempts at the
+   * remaining total deadline regardless of per-request timeouts)
+   */
+  private withTimeout<T>(step: Promise<T>, ms: number, message: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(message)), ms);
+      step.then(
+        value => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        err => {
+          clearTimeout(timer);
+          reject(err);
+        }
+      );
+    });
   }
 
   /**
@@ -410,15 +527,15 @@ export class ChildSessionManager extends EventEmitter {
           logger.info(`[child] Pausing thread ${threadId}`);
           
           try {
-            await child.sendRequest('pause', { threadId });
+            await child.sendRequest('pause', { threadId }, 5000);
           } catch {
             // Ignore pause errors
           }
-          
+
           // For js-debug quirk: also try threadId 1 if we got 0
           if (threadId === 0) {
             try {
-              await child.sendRequest('pause', { threadId: 1 });
+              await child.sendRequest('pause', { threadId: 1 }, 5000);
             } catch {}
           }
         }
@@ -455,35 +572,45 @@ export class ChildSessionManager extends EventEmitter {
    * Wait for a specific event with timeout
    */
   private waitForEvent(
-    client: MinimalDapClient, 
-    eventName: string, 
+    client: MinimalDapClient,
+    eventName: string,
     timeoutMs: number,
     required: boolean = true
   ): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       let done = false;
-      
-      const onEvent = (evt: DebugProtocol.Event) => {
-        if (done) return;
-        if (evt && evt.event === eventName) {
-          done = true;
-          client.off('event', onEvent);
-          clearTimeout(timer);
-          resolve(true);
-        }
-      };
-      
-      const timer = setTimeout(() => {
+
+      const settle = (value: boolean) => {
         if (done) return;
         done = true;
         client.off('event', onEvent);
-        if (required) {
+        client.off('close', onDeath);
+        client.off('error', onDeath);
+        clearTimeout(timer);
+        resolve(value);
+      };
+
+      const onEvent = (evt: DebugProtocol.Event) => {
+        if (evt && evt.event === eventName) {
+          settle(true);
+        }
+      };
+
+      // Don't wait out the timer against a dead client (issue #248)
+      const onDeath = () => {
+        settle(false);
+      };
+
+      const timer = setTimeout(() => {
+        if (required && !done) {
           logger.warn(`Timeout waiting for '${eventName}' event`);
         }
-        resolve(false);
+        settle(false);
       }, timeoutMs);
-      
+
       client.on('event', onEvent);
+      client.on('close', onDeath);
+      client.on('error', onDeath);
     });
   }
 

--- a/src/proxy/minimal-dap.ts
+++ b/src/proxy/minimal-dap.ts
@@ -60,19 +60,6 @@ export class MinimalDapClient extends EventEmitter {
   private dapBehavior: DapClientBehavior;
   private childSessionManager?: ChildSessionManager;
 
-  // When true, we defer parent's configurationDone (policy-driven, e.g. js-debug)
-  private deferParentConfigDoneActive = false;
-
-  // Defers parent's configurationDone to keep process paused until child is configured
-  private parentConfigDoneDeferred: {
-    resolve: (resp: DebugProtocol.Response) => void;
-    reject: (err: Error) => void;
-    args: unknown;
-    timer: NodeJS.Timeout;
-  } | null = null;
-
-  // When set, the very next configurationDone send will not be deferred
-  private suppressNextConfigDoneDeferral = false;
   private readonly timers: {
     setTimeout: typeof setTimeout;
     clearTimeout: typeof clearTimeout;
@@ -295,12 +282,7 @@ export class MinimalDapClient extends EventEmitter {
               logger.info(`[MinimalDapClient] Creating child session via ChildSessionManager`);
               try {
                 await this.childSessionManager.createChildSession(this.enrichChildConfig(result.childConfig));
-                
-                // Set up deferred config if needed
-                if (this.dapBehavior.deferParentConfigDone) {
-                  this.deferParentConfigDoneActive = true;
-                }
-                
+
                 // Update active child reference from manager
                 this.activeChild = this.childSessionManager.getActiveChild();
               } catch (err) {
@@ -454,40 +436,6 @@ export class MinimalDapClient extends EventEmitter {
       };
     }
 
-    // Defer parent's configurationDone briefly to allow child session to configure,
-    // avoiding immediate resume of the target before adoption completes.
-    if (command === 'configurationDone' && this.deferParentConfigDoneActive) {
-      if (this.suppressNextConfigDoneDeferral) {
-        // Consume the suppression for a single pass-through
-        this.suppressNextConfigDoneDeferral = false;
-      } else {
-        // Create a promise we will resolve once we actually send the deferred configDone
-        return new Promise<T>((resolve, reject) => {
-          // Clear any prior deferral
-          if (this.parentConfigDoneDeferred) {
-            this.timers.clearTimeout(this.parentConfigDoneDeferred.timer);
-            this.parentConfigDoneDeferred = null;
-          }
-          const timer = this.timers.setTimeout(() => {
-            // Time-bound deferral: if no child completed in time, send now
-            this.suppressNextConfigDoneDeferral = true;
-            void this.sendRequest<DebugProtocol.Response>('configurationDone', args)
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              .then(resolve as any)
-              .catch(reject);
-            this.parentConfigDoneDeferred = null;
-          }, 1500);
-          this.parentConfigDoneDeferred = {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            resolve: resolve as any,
-            reject,
-            args,
-            timer
-          };
-        });
-      }
-    }
-    
     // Route debuggee-scoped requests to active child session when present using policy
     const manager = this.childSessionManager;
     const shouldRouteToChild = manager?.shouldRouteToChild(command) ?? false;

--- a/src/proxy/minimal-dap.ts
+++ b/src/proxy/minimal-dap.ts
@@ -288,6 +288,14 @@ export class MinimalDapClient extends EventEmitter {
               } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
                 logger.error(`[MinimalDapClient] Failed to create child session: ${msg}`);
+                // The policy adds the pending target to adoptedTargets before
+                // adoption runs; roll that back so a re-sent startDebugging
+                // for the same target can retry instead of silently no-oping
+                // against a session with no debuggable child (issue #249)
+                const failedPendingId = result.childConfig.pendingId;
+                if (typeof failedPendingId === 'string') {
+                  this.adoptedTargets.delete(failedPendingId);
+                }
               }
             }
             return;
@@ -694,6 +702,7 @@ export class MinimalDapClient extends EventEmitter {
     } finally {
       this.childSessions.clear();
       this.activeChild = null;
+      this.adoptedTargets.clear();
     }
 
     // Also shut down the manager's own registry: it tracks children from the

--- a/src/proxy/minimal-dap.ts
+++ b/src/proxy/minimal-dap.ts
@@ -696,6 +696,15 @@ export class MinimalDapClient extends EventEmitter {
       this.activeChild = null;
     }
 
+    // Also shut down the manager's own registry: it tracks children from the
+    // moment adoption starts, so this reaches mid-adoption sockets that were
+    // never promoted into this.childSessions via childCreated (issue #248)
+    try {
+      void this.childSessionManager?.shutdown().catch(() => {});
+    } catch (e) {
+      logger.warn('[MinimalDapClient] Error shutting down child session manager:', getErrorMessage(e));
+    }
+
     // Use immediate cleanup when explicitly shutting down
     this.cleanup(true);
     

--- a/tests/adapters/java/unit/java-adapter-policy.test.ts
+++ b/tests/adapters/java/unit/java-adapter-policy.test.ts
@@ -203,12 +203,6 @@ describe('JavaAdapterPolicy', () => {
     });
   });
 
-  describe('shouldDeferParentConfigDone', () => {
-    it('should return false', () => {
-      expect(JavaAdapterPolicy.shouldDeferParentConfigDone()).toBe(false);
-    });
-  });
-
   describe('extractLocalVariables', () => {
     it('should return empty array when no stack frames', () => {
       const result = JavaAdapterPolicy.extractLocalVariables([], {}, {});
@@ -297,7 +291,6 @@ describe('JavaAdapterPolicy', () => {
     it('should return behavior configuration', () => {
       const behavior = JavaAdapterPolicy.getDapClientBehavior();
       expect(behavior.mirrorBreakpointsToChild).toBe(false);
-      expect(behavior.deferParentConfigDone).toBe(false);
       expect(behavior.pauseAfterChildAttach).toBe(false);
       expect(behavior.childInitTimeout).toBe(5000);
       expect(behavior.suppressPostAttachConfigDone).toBe(false);

--- a/tests/adapters/ruby/unit/adapter-policy-ruby.test.ts
+++ b/tests/adapters/ruby/unit/adapter-policy-ruby.test.ts
@@ -174,7 +174,6 @@ describe('RubyAdapterPolicy behavior surface', () => {
       shouldQueue: false,
       shouldDefer: false
     });
-    expect(RubyAdapterPolicy.shouldDeferParentConfigDone()).toBe(false);
     expect(RubyAdapterPolicy.isChildReadyEvent({ event: 'initialized' } as never)).toBe(true);
     expect(RubyAdapterPolicy.isChildReadyEvent({ event: 'stopped' } as never)).toBe(false);
     expect(() => RubyAdapterPolicy.buildChildStartArgs('x', {})).toThrow(/child sessions/);

--- a/tests/proxy/child-session-manager.test.ts
+++ b/tests/proxy/child-session-manager.test.ts
@@ -10,29 +10,47 @@ import { JsDebugAdapterPolicy, PythonAdapterPolicy, DefaultAdapterPolicy } from 
 import { ChildSessionManager } from '../../src/proxy/child-session-manager.js';
 // Mock MinimalDapClient
 class MockMinimalDapClient extends EventEmitter {
+  // Knobs for death-aware adoption tests (issue #248); reset in beforeEach
+  static lastInstance: MockMinimalDapClient | null = null;
+  static hangCommands = new Set<string>();
+  static failCommands = new Map<string, Error>();
+  static suppressInitialized = false;
+
   host: string;
   port: number;
   policy?: AdapterPolicy;
   connected = false;
   requests: Array<{ command: string; args: unknown }> = [];
-  
+  shutdownCalls: string[] = [];
+
   constructor(host: string, port: number, policy?: AdapterPolicy) {
     super();
     this.host = host;
     this.port = port;
     this.policy = policy;
+    MockMinimalDapClient.lastInstance = this;
   }
-  
+
   async connect(): Promise<void> {
     this.connected = true;
   }
-  
+
   async sendRequest(command: string, args?: unknown, _timeoutMs?: number): Promise<any> {
     this.requests.push({ command, args });
-    
+
+    if (MockMinimalDapClient.hangCommands.has(command)) {
+      return new Promise(() => {});
+    }
+    const failure = MockMinimalDapClient.failCommands.get(command);
+    if (failure) {
+      throw failure;
+    }
+
     // Simulate responses
     if (command === 'initialize') {
-      setTimeout(() => this.emit('event', { event: 'initialized' }), 10);
+      if (!MockMinimalDapClient.suppressInitialized) {
+        setTimeout(() => this.emit('event', { event: 'initialized' }), 10);
+      }
       return { body: { capabilities: {} } };
     }
     if (command === 'threads') {
@@ -40,11 +58,12 @@ class MockMinimalDapClient extends EventEmitter {
     }
     return {};
   }
-  
-  shutdown(_reason: string): void {
+
+  shutdown(reason: string): void {
+    this.shutdownCalls.push(reason);
     this.connected = false;
   }
-  
+
   disconnect(): void {
     this.connected = false;
   }
@@ -57,6 +76,13 @@ vi.mock('../../src/proxy/minimal-dap.js', () => ({
 
 describe('ChildSessionManager', () => {
   let manager: ChildSessionManager;
+
+  beforeEach(() => {
+    MockMinimalDapClient.lastInstance = null;
+    MockMinimalDapClient.hangCommands.clear();
+    MockMinimalDapClient.failCommands.clear();
+    MockMinimalDapClient.suppressInitialized = false;
+  });
 
   describe('JavaScript policy (multi-session)', () => {
     beforeEach(() => {
@@ -316,6 +342,132 @@ describe('ChildSessionManager', () => {
     
   });
   
+  describe('Death-aware adoption (issue #248)', () => {
+    const config = (pendingId: string) => ({
+      pendingId,
+      host: 'localhost',
+      port: 9229,
+      parentConfig: { type: 'pwa-node', request: 'launch' }
+    });
+
+    beforeEach(() => {
+      manager = new ChildSessionManager({
+        policy: JsDebugAdapterPolicy,
+        host: 'localhost',
+        port: 9229
+      });
+    });
+
+    it('aborts adoption promptly when the child connection closes mid-attach', async () => {
+      vi.useFakeTimers();
+      try {
+        MockMinimalDapClient.hangCommands.add('attach');
+
+        const guarded = manager
+          .createChildSession(config('dying-child'))
+          .then(() => null, (e: Error) => e);
+
+        // Let adoption progress into the hanging attach request
+        await vi.advanceTimersByTimeAsync(100);
+        const child = MockMinimalDapClient.lastInstance!;
+        expect(child.requests.some(r => r.command === 'attach')).toBe(true);
+
+        child.emit('close');
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Settles now — without burning the ~400s retry window
+        const err = await guarded;
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toMatch(/closed/i);
+        expect(manager.hasActiveChildren()).toBe(false);
+        expect(manager.isAdopted('dying-child')).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('aborts at the step boundary when the child dies while waiting for initialized', async () => {
+      vi.useFakeTimers();
+      try {
+        // initialize responds but the initialized event never arrives; the
+        // child then dies. Adoption must reject rather than march the
+        // remaining steps against a dead client.
+        MockMinimalDapClient.suppressInitialized = true;
+
+        const guarded = manager
+          .createChildSession(config('dead-at-init'))
+          .then(() => null, (e: Error) => e);
+
+        await vi.advanceTimersByTimeAsync(50);
+        const child = MockMinimalDapClient.lastInstance!;
+        expect(child.requests.some(r => r.command === 'initialize')).toBe(true);
+
+        child.emit('close');
+        await vi.advanceTimersByTimeAsync(0);
+
+        const err = await guarded;
+        expect(err).toBeInstanceOf(Error);
+        expect(manager.hasActiveChildren()).toBe(false);
+        expect(manager.isAdopted('dead-at-init')).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('fails attach after the total deadline instead of retrying forever', async () => {
+      vi.useFakeTimers();
+      try {
+        MockMinimalDapClient.hangCommands.add('attach');
+
+        const guarded = manager
+          .createChildSession(config('deadline-child'))
+          .then(() => null, (e: Error) => e);
+
+        await vi.advanceTimersByTimeAsync(100);
+        // No close event — the child is alive but never answers attach.
+        await vi.advanceTimersByTimeAsync(61000);
+
+        const err = await guarded;
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toMatch(/deadline|Failed to attach/i);
+        expect(manager.hasActiveChildren()).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('rolls back registration and shuts down the child when adoption fails, allowing retry', async () => {
+      vi.useFakeTimers();
+      try {
+        MockMinimalDapClient.failCommands.set('attach', new Error('ECONNREFUSED'));
+
+        const guarded = manager
+          .createChildSession(config('retry-target'))
+          .then(() => null, (e: Error) => e);
+        await vi.advanceTimersByTimeAsync(70000);
+
+        const err = await guarded;
+        expect(err).toBeInstanceOf(Error);
+
+        const failedChild = MockMinimalDapClient.lastInstance!;
+        expect(failedChild.shutdownCalls.length).toBeGreaterThan(0);
+        expect(manager.hasActiveChildren()).toBe(false);
+        expect(manager.isAdopted('retry-target')).toBe(false);
+
+        // A retry for the same pending target must be able to succeed
+        MockMinimalDapClient.failCommands.clear();
+        const retry = manager.createChildSession(config('retry-target'));
+        await vi.advanceTimersByTimeAsync(20000);
+        await retry;
+
+        expect(manager.hasActiveChildren()).toBe(true);
+        expect(manager.isAdopted('retry-target')).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('Python policy (single-session)', () => {
     beforeEach(() => {
       manager = new ChildSessionManager({

--- a/tests/proxy/dap-client-behavior.test.ts
+++ b/tests/proxy/dap-client-behavior.test.ts
@@ -123,7 +123,6 @@ describe('DapClientBehavior', () => {
     describe('configuration', () => {
       it('should have JavaScript-specific settings', () => {
         expect(behavior.mirrorBreakpointsToChild).toBe(true);
-        expect(behavior.deferParentConfigDone).toBe(true);
         expect(behavior.pauseAfterChildAttach).toBe(true);
         expect(behavior.childInitTimeout).toBe(12000);
         expect(behavior.suppressPostAttachConfigDone).toBe(false); // Child needs configurationDone
@@ -174,7 +173,6 @@ describe('DapClientBehavior', () => {
       it('should have Python-specific settings', () => {
         expect(behavior.childRoutedCommands).toBeUndefined();
         expect(behavior.mirrorBreakpointsToChild).toBe(false);
-        expect(behavior.deferParentConfigDone).toBe(false);
         expect(behavior.pauseAfterChildAttach).toBe(false);
         expect(behavior.normalizeAdapterId).toBeUndefined();
         expect(behavior.childInitTimeout).toBe(5000);
@@ -189,7 +187,6 @@ describe('DapClientBehavior', () => {
       expect(behavior.handleReverseRequest).toBeUndefined();
       expect(behavior.childRoutedCommands).toBeUndefined();
       expect(behavior.mirrorBreakpointsToChild).toBe(false);
-      expect(behavior.deferParentConfigDone).toBe(false);
       expect(behavior.pauseAfterChildAttach).toBe(false);
       expect(behavior.normalizeAdapterId).toBeUndefined();
       expect(behavior.childInitTimeout).toBe(1000);

--- a/tests/unit/proxy/minimal-dap.test.ts
+++ b/tests/unit/proxy/minimal-dap.test.ts
@@ -898,67 +898,6 @@ describe('MinimalDapClient', () => {
     });
   });
 
-  describe('Configuration deferral', () => {
-    it('should defer configurationDone when deferral is active and flush on timeout', async () => {
-      client.shutdown();
-
-      const realSetTimeout = global.setTimeout;
-      const fakeSetTimeout: typeof setTimeout = ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
-        const actualDelay = delay ?? 0;
-        if (actualDelay === 1500) {
-          return realSetTimeout(() => {
-            callback(...args);
-          }, 0);
-        }
-        return realSetTimeout(callback as (...cbArgs: unknown[]) => void, actualDelay, ...args);
-      }) as typeof setTimeout;
-      const fakeClearTimeout: typeof clearTimeout = ((timer: NodeJS.Timeout) => {
-        clearTimeout(timer);
-      }) as typeof clearTimeout;
-
-      client = new MinimalDapClient('localhost', 5678, undefined, {
-        timers: {
-          setTimeout: fakeSetTimeout,
-          clearTimeout: fakeClearTimeout
-        }
-      });
-
-      const requests: DebugProtocol.Request[] = [];
-      const fakeSocket = Object.assign(new EventEmitter(), {
-        destroyed: false,
-        write: vi.fn((raw: string, cb?: (err?: Error | null) => void) => {
-          const [, body] = raw.split('\r\n\r\n');
-          const request = JSON.parse(body) as DebugProtocol.Request;
-          requests.push(request);
-          cb?.(null);
-          setImmediate(() => {
-            void (client as any).handleProtocolMessage({
-              seq: request.seq,
-              type: 'response',
-              request_seq: request.seq,
-              command: request.command,
-              success: true
-            } satisfies DebugProtocol.Response);
-          });
-          return true;
-        }),
-        end: vi.fn(),
-        destroy: vi.fn()
-      }) as unknown as net.Socket;
-
-      (client as any).socket = fakeSocket;
-      (client as any).deferParentConfigDoneActive = true;
-
-      const result = await client.sendRequest<DebugProtocol.Response>('configurationDone', { foo: 'bar' });
-
-      expect(result.command).toBe('configurationDone');
-      expect(fakeSocket.write).toHaveBeenCalledTimes(1);
-      expect(requests[0]?.command).toBe('configurationDone');
-      expect((client as any).parentConfigDoneDeferred).toBeNull();
-      expect((client as any).suppressNextConfigDoneDeferral).toBe(false);
-    });
-  });
-
   describe('Child session integration', () => {
     it('tracks child lifecycle events reported by ChildSessionManager', () => {
       const stubManager = createChildSessionManagerStub();
@@ -1285,7 +1224,7 @@ describe('MinimalDapClient', () => {
       expect((client as any).sendResponse).not.toHaveBeenCalled();
     });
 
-    it('invokes child creation and defers configuration when policy demands', async () => {
+    it('invokes child creation when policy demands', async () => {
       const child = Object.assign(new EventEmitter(), {
         sendRequest: vi.fn().mockResolvedValue({})
       }) as unknown as MinimalDapClient;
@@ -1293,18 +1232,17 @@ describe('MinimalDapClient', () => {
       const childSessionManager = createChildSessionManagerStub();
       childSessionManager.getActiveChild.mockReturnValue(child);
 
-      const deferBehavior: DapClientBehavior = {
+      const adoptionBehavior: DapClientBehavior = {
         handleReverseRequest: vi.fn().mockResolvedValue({
           handled: true,
           createChildSession: true,
           childConfig: { pendingId: 'child-1', parentConfig: { __pendingTargetId: 'child-1' } }
-        } as ReverseRequestResult),
-        deferParentConfigDone: true
+        } as ReverseRequestResult)
       };
 
       const client = new MinimalDapClient('localhost', 5678);
 
-      (client as any).dapBehavior = deferBehavior;
+      (client as any).dapBehavior = adoptionBehavior;
       (client as any).socket = { destroyed: false, write: vi.fn() } as unknown as net.Socket;
       (client as any).childSessionManager = childSessionManager;
 
@@ -1321,7 +1259,6 @@ describe('MinimalDapClient', () => {
         pendingId: 'child-1',
         parentConfig: { __pendingTargetId: 'child-1' }
       });
-      expect((client as any).deferParentConfigDoneActive).toBe(true);
       expect((client as any).activeChild).toBe(child);
     });
 
@@ -1384,8 +1321,7 @@ describe('MinimalDapClient', () => {
           handled: true,
           createChildSession: true,
           childConfig: { pendingId: 'child-err', parentConfig: {} }
-        } as ReverseRequestResult),
-        deferParentConfigDone: true
+        } as ReverseRequestResult)
       };
 
       const client = new MinimalDapClient('localhost', 5678, JsDebugAdapterPolicy, {
@@ -1408,7 +1344,6 @@ describe('MinimalDapClient', () => {
         pendingId: 'child-err',
         parentConfig: {}
       });
-      expect((client as any).deferParentConfigDoneActive).toBe(false);
       expect(behavior.handleReverseRequest).toHaveBeenCalled();
     });
   });
@@ -1715,62 +1650,6 @@ describe('MinimalDapClient', () => {
       ).rejects.toThrow('adapter blew up');
 
       routedClient.shutdown();
-    });
-  });
-
-  describe('Configuration deferral edge cases', () => {
-    it('replaces an in-flight deferred configurationDone with a fresh deferral', () => {
-      client.shutdown();
-
-      let timerCounter = 0;
-      const setTimeoutSpy = vi.fn(
-        () => ({ id: ++timerCounter }) as unknown as NodeJS.Timeout
-      );
-      const clearTimeoutSpy = vi.fn();
-
-      client = new MinimalDapClient('localhost', 5678, undefined, {
-        timers: {
-          setTimeout: setTimeoutSpy as unknown as typeof setTimeout,
-          clearTimeout: clearTimeoutSpy as unknown as typeof clearTimeout
-        }
-      });
-      (client as any).socket = {
-        destroyed: false,
-        end: vi.fn(),
-        destroy: vi.fn(),
-        write: vi.fn()
-      } as unknown as net.Socket;
-      (client as any).deferParentConfigDoneActive = true;
-
-      const promise1 = client.sendRequest('configurationDone', { first: true });
-      promise1.catch(() => undefined);
-      const firstDeferred = (client as any).parentConfigDoneDeferred;
-      expect(firstDeferred).not.toBeNull();
-      expect(firstDeferred.timer).toEqual({ id: 1 });
-
-      const promise2 = client.sendRequest('configurationDone', { second: true });
-      promise2.catch(() => undefined);
-
-      expect(clearTimeoutSpy).toHaveBeenCalledWith({ id: 1 });
-      expect((client as any).parentConfigDoneDeferred).not.toBe(firstDeferred);
-      expect((client as any).parentConfigDoneDeferred.timer).toEqual({ id: 2 });
-
-      // Clean up dangling deferred to avoid lingering state.
-      (client as any).parentConfigDoneDeferred?.reject(new Error('test cleanup'));
-    });
-
-    it('passes configurationDone through immediately when suppressNextConfigDoneDeferral is set', async () => {
-      const captured: DebugProtocol.Request[] = [];
-      (client as any).socket = echoSocket(captured);
-      (client as any).deferParentConfigDoneActive = true;
-      (client as any).suppressNextConfigDoneDeferral = true;
-
-      await client.sendRequest('configurationDone', { go: true });
-
-      expect(captured).toHaveLength(1);
-      expect(captured[0].command).toBe('configurationDone');
-      expect((client as any).suppressNextConfigDoneDeferral).toBe(false);
-      expect((client as any).parentConfigDoneDeferred).toBeNull();
     });
   });
 

--- a/tests/unit/proxy/minimal-dap.test.ts
+++ b/tests/unit/proxy/minimal-dap.test.ts
@@ -46,6 +46,7 @@ describe('MinimalDapClient', () => {
     shouldRouteToChild: ReturnType<typeof vi.fn>;
     storeBreakpoints: ReturnType<typeof vi.fn>;
     isAdoptionInProgress: ReturnType<typeof vi.fn>;
+    shutdown: ReturnType<typeof vi.fn>;
   };
 
   const createChildSessionManagerStub = (): ChildSessionManagerStub => {
@@ -56,6 +57,7 @@ describe('MinimalDapClient', () => {
     emitter.shouldRouteToChild = vi.fn().mockReturnValue(false);
     emitter.storeBreakpoints = vi.fn();
     emitter.isAdoptionInProgress = vi.fn().mockReturnValue(false);
+    emitter.shutdown = vi.fn().mockResolvedValue(undefined);
     return emitter;
   };
 
@@ -885,6 +887,17 @@ describe('MinimalDapClient', () => {
       );
       expect((client as unknown as { childSessions: Map<string, MinimalDapClient> }).childSessions.size).toBe(0);
       expect((client as unknown as { activeChild: MinimalDapClient | null }).activeChild).toBeNull();
+    });
+
+    it('shuts down the ChildSessionManager so mid-adoption children are not orphaned (issue #248)', () => {
+      const childSessionManager = createChildSessionManagerStub();
+      const managed = new MinimalDapClient('localhost', 5678, JsDebugAdapterPolicy, {
+        childSessionManagerFactory: () => childSessionManager
+      });
+
+      managed.shutdown('test');
+
+      expect(childSessionManager.shutdown).toHaveBeenCalled();
     });
 
     it('logs debug when shutdown is invoked after disconnect has begun', () => {

--- a/tests/unit/proxy/minimal-dap.test.ts
+++ b/tests/unit/proxy/minimal-dap.test.ts
@@ -1326,6 +1326,63 @@ describe('MinimalDapClient', () => {
       expect(responseSpy).toHaveBeenCalledWith(request, {});
     });
 
+    it('allows a re-sent startDebugging to retry adoption after a failed child creation (issue #249)', async () => {
+      const childSessionManager = createChildSessionManagerStub();
+      childSessionManager.createChildSession.mockRejectedValueOnce(new Error('adoption failed'));
+
+      const client = new MinimalDapClient('localhost', 5678, JsDebugAdapterPolicy, {
+        childSessionManagerFactory: () => childSessionManager
+      });
+      (client as any).socket = {
+        destroyed: false,
+        write: vi.fn().mockReturnValue(true),
+        end: vi.fn(),
+        destroy: vi.fn()
+      } as unknown as net.Socket;
+
+      const startDebugging = (seq: number) => ({
+        seq,
+        type: 'request',
+        command: 'startDebugging',
+        arguments: { configuration: { __pendingTargetId: 'retry-me', type: 'pwa-node' } }
+      } as DebugProtocol.Request);
+
+      await (client as any).handleProtocolMessage(startDebugging(1));
+      expect(childSessionManager.createChildSession).toHaveBeenCalledTimes(1);
+
+      // js-debug re-sends startDebugging for the same pending target; the
+      // failed adoption must not leave the target permanently deduped
+      await (client as any).handleProtocolMessage(startDebugging(2));
+      expect(childSessionManager.createChildSession).toHaveBeenCalledTimes(2);
+
+      client.shutdown();
+    });
+
+    it('clears adoptedTargets on shutdown (issue #249 hygiene)', async () => {
+      const childSessionManager = createChildSessionManagerStub();
+      const client = new MinimalDapClient('localhost', 5678, JsDebugAdapterPolicy, {
+        childSessionManagerFactory: () => childSessionManager
+      });
+      (client as any).socket = {
+        destroyed: false,
+        write: vi.fn().mockReturnValue(true),
+        end: vi.fn(),
+        destroy: vi.fn()
+      } as unknown as net.Socket;
+
+      await (client as any).handleProtocolMessage({
+        seq: 1,
+        type: 'request',
+        command: 'startDebugging',
+        arguments: { configuration: { __pendingTargetId: 'stale-target', type: 'pwa-node' } }
+      } as DebugProtocol.Request);
+      expect((client as any).adoptedTargets.size).toBeGreaterThan(0);
+
+      client.shutdown();
+
+      expect((client as any).adoptedTargets.size).toBe(0);
+    });
+
     it('logs child session creation errors without throwing', async () => {
       const childSessionManager = createChildSessionManagerStub();
       childSessionManager.createChildSession.mockRejectedValue(new Error('no child'));

--- a/tests/unit/shared/adapter-policy-default.test.ts
+++ b/tests/unit/shared/adapter-policy-default.test.ts
@@ -6,7 +6,6 @@ describe('DefaultAdapterPolicy', () => {
     expect(DefaultAdapterPolicy.name).toBe('default');
     expect(DefaultAdapterPolicy.supportsReverseStartDebugging).toBe(false);
     expect(DefaultAdapterPolicy.childSessionStrategy).toBe('none');
-    expect(DefaultAdapterPolicy.shouldDeferParentConfigDone({})).toBe(false);
     expect(() => DefaultAdapterPolicy.buildChildStartArgs('pending', {})).toThrow();
     expect(DefaultAdapterPolicy.isChildReadyEvent({ event: 'initialized' } as any)).toBe(false);
     expect(DefaultAdapterPolicy.getDapAdapterConfiguration().type).toBe('default');

--- a/tests/unit/shared/adapter-policy-dotnet.test.ts
+++ b/tests/unit/shared/adapter-policy-dotnet.test.ts
@@ -23,10 +23,6 @@ describe('DotnetAdapterPolicy', () => {
     expect(() => DotnetAdapterPolicy.buildChildStartArgs('', {})).toThrow(/does not support child sessions/);
   });
 
-  it('shouldDeferParentConfigDone returns false', () => {
-    expect(DotnetAdapterPolicy.shouldDeferParentConfigDone()).toBe(false);
-  });
-
   it('isChildReadyEvent returns true for initialized event', () => {
     expect(DotnetAdapterPolicy.isChildReadyEvent({ event: 'initialized', seq: 1, type: 'event' } as any)).toBe(true);
   });
@@ -286,7 +282,6 @@ describe('DotnetAdapterPolicy', () => {
   it('getDapClientBehavior returns expected defaults', () => {
     const behavior = DotnetAdapterPolicy.getDapClientBehavior();
     expect(behavior.mirrorBreakpointsToChild).toBe(false);
-    expect(behavior.deferParentConfigDone).toBe(false);
     expect(behavior.pauseAfterChildAttach).toBe(false);
     expect(behavior.suppressPostAttachConfigDone).toBe(false);
     expect(behavior.childInitTimeout).toBe(5000);

--- a/tests/unit/shared/adapter-policy-go.test.ts
+++ b/tests/unit/shared/adapter-policy-go.test.ts
@@ -40,10 +40,6 @@ describe('GoAdapterPolicy', () => {
     expect(() => GoAdapterPolicy.buildChildStartArgs('', {})).toThrow(/does not support child sessions/);
   });
 
-  it('shouldDeferParentConfigDone returns false', () => {
-    expect(GoAdapterPolicy.shouldDeferParentConfigDone()).toBe(false);
-  });
-
   it('isChildReadyEvent returns true for initialized event', () => {
     expect(GoAdapterPolicy.isChildReadyEvent({ event: 'initialized', seq: 1, type: 'event' } as any)).toBe(true);
   });
@@ -319,7 +315,6 @@ describe('GoAdapterPolicy', () => {
   it('getDapClientBehavior returns expected defaults', () => {
     const behavior = GoAdapterPolicy.getDapClientBehavior();
     expect(behavior.mirrorBreakpointsToChild).toBe(false);
-    expect(behavior.deferParentConfigDone).toBe(false);
     expect(behavior.pauseAfterChildAttach).toBe(false);
     expect(behavior.suppressPostAttachConfigDone).toBe(false);
     expect(behavior.childInitTimeout).toBe(5000);


### PR DESCRIPTION
Fixes #248
Fixes #249
Fixes #250

First of two PRs for the `cluster:js-child-session` backlog chunk (#247 follows separately).

## What changed

**#250 — remove dead `deferParentConfigDone` machinery (commit 1).** The 1500ms parent-`configurationDone` deferral could never arm on any real path: its only writer runs after `createChildSession` resolves, but the js-debug handshake sends parent `configurationDone` (step 4) before `launch`/`attach` (step 5), so no child can exist when the parent configDone goes out. Even force-armed, nothing ever resolved the deferral early — it always burned the full timer. Deleted along with the equally dead `AdapterPolicy.shouldDeferParentConfigDone()` and the `DapClientBehavior.deferParentConfigDone` flag from all eight policies (−233 lines).

**#248 — death-aware adoption (commit 2).** A child target dying mid-adoption used to burn every remaining step's full timeout (worst case ~400s in the attach retry loop; `ensureChildStopped` alone could add 80s) and left the half-adopted socket orphaned at worker shutdown:

- New settle-once `ChildDeathLatch` (modeled on #246's `JsDebugLaunchBarrier`) subscribes `close`/`error` right after connect; every adoption step is raced against it and aborts the moment the child dies.
- `attachChild` gains a 60s total deadline on top of per-request timeouts, with death checks before/after each retry.
- `waitForEvent` settles immediately on client death instead of waiting out its timer.
- The failure path now rolls back `childSessions`/`activeChild` — previously `hasActiveChildren()` latched true forever, silently rejecting every subsequent adoption — and shuts down the failed child client.
- `MinimalDapClient.shutdown()` now also invokes `ChildSessionManager.shutdown()` (previously unreachable from src), covering mid-adoption sockets never promoted via `childCreated`.

**#249 — retryable adoption (commit 3).** The policy-level `adoptedTargets` dedupe kept the pending-target id when adoption failed, so js-debug's re-sent `startDebugging` was answered `{handled: true}` without creating a child. The dispatch site (which already observes the rejection) now rolls the id back, and `shutdown()` clears the set.

## Testing

- 7 new unit tests: close-mid-attach aborts promptly, death at step boundary, attach total deadline, failure rollback + successful retry, manager shutdown reachability, re-sent `startDebugging` retries, `adoptedTargets` cleared on shutdown. The death tests run in ~35ms where the old behavior hung 15s+ (test-timeout kills).
- Full gate: 2593 unit tests, 18 e2e smoke files, break-on-exceptions e2e 8/8, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)