### PR TITLE
test: restore missing js-clean-exit fixture; unignore debug-script fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ src/**/*.js.map
 tests/**/*.js
 tests/**/*.d.ts
 tests/**/*.js.map
+# Exception: hand-written JS debuggee fixtures (not TS output) — without this
+# negation, `git add` silently skips new fixtures (how PR #252 lost one)
+!tests/fixtures/debug-scripts/*.js
 
 # Package source compilation artifacts
 packages/*/src/**/*.js

--- a/tests/fixtures/debug-scripts/js-clean-exit.js
+++ b/tests/fixtures/debug-scripts/js-clean-exit.js
@@ -1,0 +1,8 @@
+// Clean-exit fixture (issue #247): does a little work and exits with code 0.
+// Mirrors js-throws.js's shape (work in a timer callback) so the js-debug
+// child session has time to adopt the process before it finishes.
+function done() {
+  console.log('clean exit fixture done'); // Line 5
+}
+
+setTimeout(done, 100); // Line 8 — node exits 0 once the timer fires


### PR DESCRIPTION
## Summary

`tests/e2e/mcp-server-break-on-exceptions.test.ts` › "reports exit code 0 for a clean run (issue #247)" fails on any fresh checkout with `Script file not found: tests/fixtures/debug-scripts/js-clean-exit.js`.

**Root cause (two layers):**
1. The fixture referenced by the test (added in #252) was never committed — the blanket `tests/**/*.js` gitignore rule (meant for compiled TS artifacts) made `git add` **silently skip it**, so it survived only as an untracked local file until branch cleanup deleted it.
2. The trap was invisible because the committed sibling `js-throws.js` only exists via a force-add — `git check-ignore` doesn't report tracked files, so nothing looked wrong.

CI never caught it because only the container e2e subset runs there.

**Fix:** recreate the fixture (timer-callback shape mirroring `js-throws.js`, natural exit 0) and add a narrow negation `!tests/fixtures/debug-scripts/*.js` so hand-written debuggee fixtures can't be silently dropped again. Compiled artifacts elsewhere under `tests/` stay ignored.

## Test plan
- [x] `npx vitest run tests/e2e/mcp-server-break-on-exceptions.test.ts` — 9/9 pass (previously 1 failing)
- [x] Swept every `debug-scripts/*` reference in `tests/` — no other missing fixtures
- [x] `git check-ignore` confirms the new fixture is no longer ignored; plain `git add` stages it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
