### PR TITLE
feat(java): advertise exception filters + implement exceptionInfo in JDI bridge (fixes #259)

### DIFF
--- a/docs/java/README.md
+++ b/docs/java/README.md
@@ -122,7 +122,7 @@ use_mcp_tool(
 
 ### 2. Set Breakpoints
 
-Set breakpoints before starting/attaching. Breakpoints must be on executable lines (assignments, method calls, conditionals) — not on blank lines, comments, or declarations. Conditional breakpoints (with a `condition` expression) and exception breakpoints are also supported by the JDI bridge.
+Set breakpoints before starting/attaching. Breakpoints must be on executable lines (assignments, method calls, conditionals) — not on blank lines, comments, or declarations. Conditional breakpoints (with a `condition` expression) and exception breakpoints are also supported by the JDI bridge. On an exception stop the bridge answers the DAP `exceptionInfo` request, so `lastStop.exceptionInfo` (exception class, break mode, message, stack trace) is populated shortly after the pause.
 
 ```
 use_mcp_tool(

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -196,7 +196,7 @@ Starts debugging a script.
 - `"breakpoint"`: Stopped at a breakpoint
 - `"step"`: Stopped after a step operation
 - `"entry"`: Stopped on entry (if configured)
-- `"exception"`: Stopped at an exception (the launch default for most languages; see `breakOnExceptions`). `lastStop.description`/`lastStop.text` carry the exception class and message where the adapter reports them. Where the adapter supports the DAP `exceptionInfo` request (Python, JavaScript, .NET, mock), `lastStop.exceptionInfo` is additionally populated best-effort with `exceptionId`, `breakMode`, and optional `details` (message, type names, adapter-side stack trace). The enrichment is requested asynchronously right after the pause, so it may appear in `list_debug_sessions`/`get_stack_trace` a moment after the stop itself — re-query if it is absent immediately after pausing.
+- `"exception"`: Stopped at an exception (the launch default for most languages; see `breakOnExceptions`). `lastStop.description`/`lastStop.text` carry the exception class and message where the adapter reports them. Where the adapter supports the DAP `exceptionInfo` request (Python, JavaScript, Java, .NET, mock), `lastStop.exceptionInfo` is additionally populated best-effort with `exceptionId`, `breakMode`, and optional `details` (message, type names, adapter-side stack trace). The enrichment is requested asynchronously right after the pause, so it may appear in `list_debug_sessions`/`get_stack_trace` a moment after the stop itself — re-query if it is absent immediately after pausing.
 
 **Exit code:** when the debuggee terminates, the exit code reported by the adapter is surfaced as `exitCode` in `list_debug_sessions`, so a crash (non-zero) is distinguishable from a clean exit.
 

--- a/examples/java/ThrowsTest.java
+++ b/examples/java/ThrowsTest.java
@@ -1,0 +1,15 @@
+/**
+ * Exception fixture for break-on-exceptions e2e tests.
+ * Raises a caught IllegalStateException first (for the 'caught' filter),
+ * then crashes with an uncaught RuntimeException.
+ */
+public class ThrowsTest {
+    public static void main(String[] args) {
+        try {
+            throw new IllegalStateException("caught on purpose");
+        } catch (IllegalStateException e) {
+            System.out.println("caught: " + e.getMessage());
+        }
+        throw new RuntimeException("uncaught on purpose");
+    }
+}

--- a/packages/adapter-java/java/JdiDapServer.java
+++ b/packages/adapter-java/java/JdiDapServer.java
@@ -60,6 +60,21 @@ public class JdiDapServer {
     private volatile boolean stopOnEntry = true; // whether to stop on entry in launch mode
     private volatile boolean lastStopAllThreads = true; // tracks whether last stop suspended all threads
 
+    // --- Exception stop state (retained for DAP exceptionInfo) ---
+    // Written by the JDI event-loop thread, read by the socket-reader thread.
+    // A single volatile reference to an immutable tuple avoids torn reads.
+    private static final class ExceptionStop {
+        final ObjectReference exception;
+        final long threadId;
+        final boolean caught; // catchLocation != null
+        ExceptionStop(ObjectReference exception, long threadId, boolean caught) {
+            this.exception = exception;
+            this.threadId = threadId;
+            this.caught = caught;
+        }
+    }
+    private volatile ExceptionStop lastException;
+
     // --- Logging ---
     private static boolean debug = false;
 
@@ -236,6 +251,7 @@ public class JdiDapServer {
                 case "terminate": handleTerminate(reqSeq, args); break;
                 case "evaluate": handleEvaluate(reqSeq, args); break;
                 case "setExceptionBreakpoints": handleSetExceptionBreakpoints(reqSeq, args); break;
+                case "exceptionInfo": handleExceptionInfo(reqSeq, args); break;
                 case "source": sendResponse(reqSeq, command, true, mapOf("content", "")); break;
                 case "redefineClasses": handleRedefineClasses(reqSeq, args); break;
                 default:
@@ -262,9 +278,27 @@ public class JdiDapServer {
         caps.put("supportsCompletionsRequest", false);
         caps.put("supportsTerminateRequest", true);
         caps.put("supportsDelayedStackTraceLoading", false);
-        caps.put("supportsExceptionInfoRequest", false);
+        caps.put("supportsExceptionInfoRequest", true);
         caps.put("supportsHitConditionalBreakpoints", false);
         caps.put("supportsLogPoints", false);
+        // Must mirror the metadata in java-debug-adapter.ts getCapabilities():
+        // handleSetExceptionBreakpoints honors exactly these two filter ids.
+        List<Map<String, Object>> exFilters = new ArrayList<>();
+        Map<String, Object> caughtFilter = new HashMap<>();
+        caughtFilter.put("filter", "caught");
+        caughtFilter.put("label", "Caught Exceptions");
+        caughtFilter.put("description", "Break on caught exceptions");
+        caughtFilter.put("default", false);
+        caughtFilter.put("supportsCondition", false);
+        exFilters.add(caughtFilter);
+        Map<String, Object> uncaughtFilter = new HashMap<>();
+        uncaughtFilter.put("filter", "uncaught");
+        uncaughtFilter.put("label", "Uncaught Exceptions");
+        uncaughtFilter.put("description", "Break on uncaught exceptions");
+        uncaughtFilter.put("default", true);
+        uncaughtFilter.put("supportsCondition", false);
+        exFilters.add(uncaughtFilter);
+        caps.put("exceptionBreakpointFilters", exFilters);
         sendResponse(reqSeq, "initialize", true, caps);
         sendEvent("initialized", new HashMap<>());
     }
@@ -1149,6 +1183,93 @@ public class JdiDapServer {
         sendResponse(reqSeq, "setExceptionBreakpoints", true, new HashMap<>());
     }
 
+    private void handleExceptionInfo(int reqSeq, Map<String, Object> args) {
+        ExceptionStop ex = lastException;
+        if (vm == null || ex == null) {
+            sendErrorResponse(reqSeq, "exceptionInfo", "No exception is currently being reported");
+            return;
+        }
+        long threadId = longVal(args, "threadId");
+        if (threadId > 0 && threadId != ex.threadId) {
+            sendErrorResponse(reqSeq, "exceptionInfo", "No exception for thread " + threadId);
+            return;
+        }
+        try {
+            String fqcn = ex.exception.referenceType().name();
+            String message = throwableMessage(ex.exception);
+            String simpleName = fqcn.substring(fqcn.lastIndexOf('.') + 1);
+
+            Map<String, Object> details = new HashMap<>();
+            if (message != null) details.put("message", message);
+            details.put("typeName", simpleName);
+            details.put("fullTypeName", fqcn);
+            String stackTrace = formatExceptionStackTrace(fqcn, message, ex.threadId);
+            if (stackTrace != null) details.put("stackTrace", stackTrace);
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("exceptionId", fqcn);
+            body.put("breakMode", ex.caught ? "always" : "unhandled");
+            body.put("description", message != null ? fqcn + ": " + message : fqcn);
+            body.put("details", details);
+            sendResponse(reqSeq, "exceptionInfo", true, body);
+        } catch (ObjectCollectedException e) {
+            sendErrorResponse(reqSeq, "exceptionInfo", "Exception object was garbage collected");
+        } catch (VMDisconnectedException e) {
+            sendErrorResponse(reqSeq, "exceptionInfo", "VM disconnected");
+        }
+    }
+
+    /**
+     * Read Throwable.detailMessage via JDI field access — no thread invocation,
+     * so the suspended debuggee is never resumed. The field is private on
+     * java.lang.Throwable, so it must be resolved on the Throwable ClassType
+     * (walking up from the subclass), not via fieldByName on the exception's own
+     * type. Trade-off: getMessage() overrides are not reflected.
+     */
+    private String throwableMessage(ObjectReference exception) {
+        try {
+            ReferenceType rt = exception.referenceType();
+            ClassType ct = (rt instanceof ClassType) ? (ClassType) rt : null;
+            while (ct != null && !"java.lang.Throwable".equals(ct.name())) {
+                ct = ct.superclass();
+            }
+            if (ct == null) return null;
+            Field f = ct.fieldByName("detailMessage");
+            if (f == null) return null;
+            Value v = exception.getValue(f);
+            return (v instanceof StringReference) ? ((StringReference) v).value() : null;
+        } catch (RuntimeException e) { // ObjectCollectedException, VMDisconnectedException, ...
+            return null;
+        }
+    }
+
+    /** Format the suspended thread's frames in printStackTrace style; null if unavailable. */
+    private String formatExceptionStackTrace(String fqcn, String message, long threadId) {
+        ThreadReference thread = findThread(threadId);
+        if (thread == null) return null;
+        try {
+            StringBuilder sb = new StringBuilder(message != null ? fqcn + ": " + message : fqcn);
+            List<StackFrame> frames = thread.frames();
+            int limit = Math.min(frames.size(), 50);
+            for (int i = 0; i < limit; i++) {
+                Location loc = frames.get(i).location();
+                String source;
+                try {
+                    source = loc.sourceName() + ":" + loc.lineNumber();
+                } catch (AbsentInformationException e) {
+                    source = "Unknown Source";
+                }
+                sb.append("\n\tat ").append(loc.declaringType().name()).append('.')
+                  .append(loc.method().name()).append('(').append(source).append(')');
+            }
+            return sb.toString();
+        } catch (IncompatibleThreadStateException e) {
+            return null; // thread resumed between stop and request — omit stackTrace
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
     // ========== Hot Reload (redefineClasses) ==========
 
     private void handleRedefineClasses(int reqSeq, Map<String, Object> args) {
@@ -1326,11 +1447,17 @@ public class JdiDapServer {
 
                         } else if (event instanceof ExceptionEvent) {
                             ExceptionEvent ee = (ExceptionEvent) event;
-                            log("Exception: " + ee.exception().referenceType().name() + " at " + ee.location());
+                            ObjectReference exObj = ee.exception();
+                            String fqcn = exObj.referenceType().name();
+                            log("Exception: " + fqcn + " at " + ee.location());
+                            lastException = new ExceptionStop(exObj, ee.thread().uniqueID(), ee.catchLocation() != null);
+                            String message = throwableMessage(exObj);
+                            lastStopAllThreads = true; // exception requests are SUSPEND_ALL
                             Map<String, Object> body = new HashMap<>();
                             body.put("reason", "exception");
                             body.put("threadId", ee.thread().uniqueID());
-                            body.put("text", ee.exception().referenceType().name());
+                            body.put("text", fqcn);
+                            body.put("description", message != null ? fqcn + ": " + message : fqcn);
                             body.put("allThreadsStopped", true);
                             sendEvent("stopped", body);
                             resume = false;
@@ -1503,11 +1630,13 @@ public class JdiDapServer {
             frameIdMap.clear();
             nextFrameId.set(1);
         }
+        lastException = null;
     }
 
     // synchronized so the shutdown-hook thread and the disconnect/terminate
     // handlers can't race when the proxy is shutting down rapidly.
     private synchronized void cleanup() {
+        lastException = null;
         if (vm != null) {
             try {
                 vm.dispose();

--- a/packages/adapter-java/src/java-debug-adapter.ts
+++ b/packages/adapter-java/src/java-debug-adapter.ts
@@ -547,7 +547,7 @@ After installation:
       supportsRestartRequest: false,
       supportsExceptionOptions: false,
       supportsValueFormattingOptions: false,
-      supportsExceptionInfoRequest: false,
+      supportsExceptionInfoRequest: true,
       supportTerminateDebuggee: true,
       supportSuspendDebuggee: false,
       supportsDelayedStackTraceLoading: false,

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -71,7 +71,7 @@ attach_to_process {sessionId, host: "localhost", port: 5678, localRoot: "<local 
 ## Crash diagnosis
 
 - Launch sessions pause at uncaught exceptions **by default** (`breakOnExceptions: "uncaught"`) with the stack and locals live instead of losing the session — pass `"none"` to opt out, or `"all"` to also stop on caught raises (language-dependent). Ruby is the exception: rdbg has no uncaught-only filter, so Ruby crashes still run to termination unless you pass `"all"`. Attach sessions apply no default — pass the mode explicitly.
-- On an exception stop, `lastStop.description`/`lastStop.text` carry the exception class and message; where the adapter supports it (Python, JS, .NET), `lastStop.exceptionInfo` adds `exceptionId`, `breakMode`, and details (it lands a moment after the pause — re-query if absent). After termination, `exitCode` in `list_debug_sessions` distinguishes a crash (non-zero) from a clean exit.
+- On an exception stop, `lastStop.description`/`lastStop.text` carry the exception class and message; where the adapter supports it (Python, JS, Java, .NET), `lastStop.exceptionInfo` adds `exceptionId`, `breakMode`, and details (it lands a moment after the pause — re-query if absent). After termination, `exitCode` in `list_debug_sessions` distinguishes a crash (non-zero) from a clean exit.
 
 ## Current limitations (be honest with yourself)
 

--- a/skills/debugging/references/java.md
+++ b/skills/debugging/references/java.md
@@ -56,7 +56,7 @@ continue_execution    {"sessionId": "<id>"}   // required with suspend=y to let 
 
 - **`redefine_classes` hot-swap (Java only):** edit → recompile with `javac -g` → call `redefine_classes {"sessionId": "<id>", "classesDir": "/proj/build/classes/java/main", "sinceTimestamp": 0}`. Pass the returned `newestTimestamp` as `sinceTimestamp` next time for incremental swaps. Limits: no schema changes (adding/removing methods/fields fails per class, others still succeed), only already-loaded classes (others land in `skippedNotLoaded`), works paused or running.
 - Empty variables almost always mean the class was compiled without `-g`, or the source no longer matches the compiled class — recompile.
-- Breakpoints must sit on executable lines (assignments, calls, conditionals) — not blank lines, comments, imports, or bare declarations. Conditional breakpoints (`condition`) and exception breakpoints are supported.
+- Breakpoints must sit on executable lines (assignments, calls, conditionals) — not blank lines, comments, imports, or bare declarations. Conditional breakpoints (`condition`) and exception breakpoints are supported. Exception stops carry `lastStop.description` ("FQCN: message") and, a moment after the pause, best-effort `lastStop.exceptionInfo` (exceptionId, breakMode, message, adapter-side stack trace).
 - `set_breakpoint` accepts a Java-only `suspendPolicy`: `"all"` (default) suspends every thread; `"thread"` suspends only the hitting thread.
 - Debuggee stdout/stderr is forwarded — `get_output {"sessionId": "<id>", "since": 0}` works for Java; poll with the returned `nextSince`.
 

--- a/src/skill-content.ts
+++ b/src/skill-content.ts
@@ -69,7 +69,7 @@ detach_from_process leaves the target running.
 
 ## Crash diagnosis
 - Launch sessions pause at uncaught exceptions by default with stack + locals live ("none" opts out; "all" also stops on caught raises; Ruby has no uncaught filter so its crashes still terminate). Attach applies no default.
-- lastStop.description/text carry the exception class and message; where supported (Python/JS/.NET), lastStop.exceptionInfo adds exceptionId/breakMode/details a moment after the pause. exitCode in list_debug_sessions distinguishes a crash (non-zero) from a clean exit.
+- lastStop.description/text carry the exception class and message; where supported (Python/JS/Java/.NET), lastStop.exceptionInfo adds exceptionId/breakMode/details a moment after the pause. exitCode in list_debug_sessions distinguishes a crash (non-zero) from a clean exit.
 
 ## Current limitations
 - No breakpoint list/remove tools yet: track what you set.

--- a/tests/adapters/java/unit/java-adapter-policy.test.ts
+++ b/tests/adapters/java/unit/java-adapter-policy.test.ts
@@ -195,6 +195,15 @@ describe('JavaAdapterPolicy', () => {
       expect(behavior.deferConfigDone).toBeUndefined();
       expect(behavior.defaultStopOnEntry).toBeUndefined();
     });
+
+    it('should declare the exception filters the JDI bridge honors (issue #259)', () => {
+      const behavior = JavaAdapterPolicy.getInitializationBehavior();
+      expect(behavior.exceptionFilters).toEqual({
+        uncaught: ['uncaught'],
+        all: ['caught', 'uncaught']
+      });
+      expect(behavior.defaultExceptionBreakMode).toBe('uncaught');
+    });
   });
 
   describe('buildChildStartArgs', () => {

--- a/tests/adapters/java/unit/java-debug-adapter.test.ts
+++ b/tests/adapters/java/unit/java-debug-adapter.test.ts
@@ -269,6 +269,7 @@ describe('JavaDebugAdapter', () => {
       expect(caps.supportsTerminateRequest).toBe(true);
       expect(caps.supportsStepBack).toBe(false);
       expect(caps.supportsLogPoints).toBe(false);
+      expect(caps.supportsExceptionInfoRequest).toBe(true);
     });
 
     it('should include caught and uncaught exception filters', () => {
@@ -277,7 +278,9 @@ describe('JavaDebugAdapter', () => {
       expect(caps.exceptionBreakpointFilters).toBeDefined();
       expect(caps.exceptionBreakpointFilters?.length).toBe(2);
       expect(caps.exceptionBreakpointFilters?.[0].filter).toBe('caught');
+      expect(caps.exceptionBreakpointFilters?.[0].default).toBe(false);
       expect(caps.exceptionBreakpointFilters?.[1].filter).toBe('uncaught');
+      expect(caps.exceptionBreakpointFilters?.[1].default).toBe(true);
     });
   });
 

--- a/tests/e2e/java-example-utils.ts
+++ b/tests/e2e/java-example-utils.ts
@@ -24,7 +24,8 @@ export type JavaExampleName =
   | 'EventRaceTest'
   | 'InnerClassTest'
   | 'ExprTest'
-  | 'InfiniteWait';
+  | 'InfiniteWait'
+  | 'ThrowsTest';
 
 export interface JavaExamplePaths {
   /** Absolute path to the main .java source file. */
@@ -49,6 +50,7 @@ const EXAMPLES: Record<JavaExampleName, JavaExampleSpec> = {
   InnerClassTest: { mainClass: 'InnerClassTest' },
   ExprTest:       { mainClass: 'ExprTest' },
   InfiniteWait:   { mainClass: 'InfiniteWait' },
+  ThrowsTest:     { mainClass: 'ThrowsTest' },
 };
 
 const prepared = new Map<JavaExampleName, JavaExamplePaths>();

--- a/tests/e2e/mcp-server-break-on-exceptions.test.ts
+++ b/tests/e2e/mcp-server-break-on-exceptions.test.ts
@@ -9,6 +9,9 @@
  * - Launch default (issue #244): with the option unset, launch sessions pause
  *   at uncaught exceptions; explicit "none" opts out and restores
  *   run-to-termination with the debuggee exit code surfaced
+ * - Java launch (issue #259): JDI bridge advertises the exception filters and
+ *   answers exceptionInfo — uncaught RuntimeException pauses with enrichment,
+ *   'all' also pauses at the caught raise with breakMode 'always'
  * - Python attach: filters armed during the attach init sequence (attach
  *   itself never applies a default)
  */
@@ -16,11 +19,12 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { spawn, type ChildProcess } from 'child_process';
+import { spawn, execSync, type ChildProcess } from 'child_process';
 import net from 'net';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { parseSdkToolResult, callToolSafely } from './smoke-test-utils.js';
+import { prepareJavaExample } from './java-example-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -453,6 +457,148 @@ describe('Break-on-exception (issue #220)', () => {
       expect(stopped, 'js session should run to completion').toBeDefined();
       expect(stopped!.exitCode).toBe(0);
     }, 60000);
+  });
+
+  describe('Java launch (JDI bridge) @requires-java', () => {
+    function hasJdk(): boolean {
+      try {
+        execSync('java -version', { stdio: 'ignore' });
+        execSync('javac -version', { stdio: 'ignore' });
+        return true;
+      } catch {
+        console.log('[break-on-exceptions] Skipping — JDK not installed');
+        return false;
+      }
+    }
+
+    /** Poll until paused at an exception or terminated; undefined on timeout. */
+    async function pollExceptionPauseOrExit(): Promise<SessionSnapshot | undefined> {
+      return pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        if (!snap) return undefined;
+        if (snap.state === 'stopped') return snap;
+        return snap.state === 'paused' && snap.lastStop?.reason === 'exception' ? snap : undefined;
+      }, 15000);
+    }
+
+    it('pauses at the uncaught RuntimeException with exceptionInfo enrichment (issue #259)', async () => {
+      if (!hasJdk()) return;
+      const { sourcePath, classDir, mainClass } = prepareJavaExample('ThrowsTest');
+
+      sessionId = await createSession('java', 'java-break-on-exceptions');
+
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: sourcePath,
+          dapLaunchArgs: { mainClass, classpath: classDir, cwd: classDir, stopOnEntry: false },
+          breakOnExceptions: 'uncaught'
+        }
+      }));
+      expect(startRes.success).toBe(true);
+
+      const paused = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'paused' && snap.lastStop?.reason === 'exception' ? snap : undefined;
+      }, 15000);
+      expect(paused, 'session should pause at the uncaught exception instead of terminating').toBeDefined();
+      expect(paused!.lastStop!.text).toBe('java.lang.RuntimeException');
+      expect(paused!.lastStop!.description).toMatch(/java\.lang\.RuntimeException: uncaught on purpose/);
+
+      // Enrichment proves both halves of #259: the bridge advertised
+      // supportsExceptionInfoRequest (SessionManager's live gate) AND answered
+      // the exceptionInfo request.
+      const enriched = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.lastStop?.exceptionInfo ? snap : undefined;
+      }, 5000);
+      expect(enriched, 'lastStop should gain exceptionInfo from the JDI bridge').toBeDefined();
+      const info = enriched!.lastStop!.exceptionInfo!;
+      expect(info.exceptionId).toBe('java.lang.RuntimeException');
+      expect(info.breakMode).toBe('unhandled');
+      expect(info.details?.message).toBe('uncaught on purpose');
+      expect(info.details?.fullTypeName).toBe('java.lang.RuntimeException');
+      expect(info.details?.stackTrace).toContain('at ThrowsTest.main');
+
+      // Stack trace: top frame at the throw site in main
+      const stack = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'get_stack_trace',
+        arguments: { sessionId }
+      }));
+      expect(stack.stopReason).toBe('exception');
+      const frames = stack.stackFrames as Array<{ name: string; line: number }>;
+      expect(frames.length).toBeGreaterThan(0);
+      expect(frames[0].name).toContain('main');
+
+      // Continue: the JVM re-throws and terminates. The bridge emits
+      // terminated without an exited event, so no exitCode assertion.
+      await callToolSafely(mcpClient!, 'continue_execution', { sessionId });
+      const stopped = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.state === 'stopped' ? snap : undefined;
+      }, 15000);
+      expect(stopped, 'session should terminate after continuing past the exception').toBeDefined();
+    }, 60000);
+
+    it("pauses at the caught IllegalStateException with breakMode 'always' when breakOnExceptions is 'all'", async () => {
+      if (!hasJdk()) return;
+      const { sourcePath, classDir, mainClass } = prepareJavaExample('ThrowsTest');
+
+      sessionId = await createSession('java', 'java-break-on-caught');
+
+      const startRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'start_debugging',
+        arguments: {
+          sessionId,
+          scriptPath: sourcePath,
+          dapLaunchArgs: { mainClass, classpath: classDir, cwd: classDir, stopOnEntry: false },
+          breakOnExceptions: 'all'
+        }
+      }));
+      expect(startRes.success).toBe(true);
+
+      // The unfiltered caught-exception request can also fire on JDK-internal
+      // exceptions during startup — continue past those (bounded) until the
+      // fixture's IllegalStateException.
+      let target: SessionSnapshot | undefined;
+      for (let i = 0; i < 15; i++) {
+        const snap = await pollExceptionPauseOrExit();
+        if (!snap || snap.state === 'stopped') break;
+        if (snap.lastStop?.text === 'java.lang.IllegalStateException') {
+          target = snap;
+          break;
+        }
+        await callToolSafely(mcpClient!, 'continue_execution', { sessionId: sessionId! });
+      }
+      expect(target, 'session should pause at the caught IllegalStateException').toBeDefined();
+      expect(target!.lastStop!.description).toMatch(/java\.lang\.IllegalStateException: caught on purpose/);
+
+      const enriched = await pollUntil(async () => {
+        const snap = await getSessionSnapshot(mcpClient!, sessionId!);
+        return snap?.lastStop?.exceptionInfo ? snap : undefined;
+      }, 5000);
+      expect(enriched, 'caught stop should gain exceptionInfo').toBeDefined();
+      expect(enriched!.lastStop!.exceptionInfo!.exceptionId).toBe('java.lang.IllegalStateException');
+      expect(enriched!.lastStop!.exceptionInfo!.breakMode).toBe('always');
+
+      // Continue on: expect the uncaught RuntimeException stop on the way out
+      // (internal caught stops may intervene), then termination.
+      let sawUncaught = false;
+      let finalSnap: SessionSnapshot | undefined;
+      for (let i = 0; i < 15; i++) {
+        await callToolSafely(mcpClient!, 'continue_execution', { sessionId: sessionId! });
+        const snap = await pollExceptionPauseOrExit();
+        if (!snap) break;
+        if (snap.state === 'stopped') {
+          finalSnap = snap;
+          break;
+        }
+        if (snap.lastStop?.text === 'java.lang.RuntimeException') sawUncaught = true;
+      }
+      expect(sawUncaught, 'should pause at the uncaught RuntimeException on the way out').toBe(true);
+      expect(finalSnap?.state, 'session should terminate').toBe('stopped');
+    }, 90000);
   });
 
   describe('Python attach', () => {


### PR DESCRIPTION
## Summary

Fixes #259. The JDI bridge honored `setExceptionBreakpoints` with `caught`/`uncaught` but never declared `exceptionBreakpointFilters` in its DAP `initialize` response, so every Java session fired the #243 capability-drift warning and capability-gating clients couldn't discover the support. This PR also takes the issue's "while there" suggestion: the bridge now implements `exceptionInfo`, so Java exception stops get the #243 `lastStop.exceptionInfo` enrichment like Python/JS/.NET.

### Bridge (`JdiDapServer.java`)
- `initialize` now advertises the `caught` (default off) / `uncaught` (default on) filters, mirroring the TS adapter metadata, and `supportsExceptionInfoRequest: true`
- New `exceptionInfo` handler: exception retained on stop (single volatile immutable tuple — event-loop thread writes, socket thread reads), message read via JDI field access on `Throwable.detailMessage` (resolved on the Throwable ClassType via `superclass()` walk — the field is private, so `fieldByName` on the subclass returns null; no thread invocation, so the suspended debuggee is never resumed), printStackTrace-style stack from the suspended thread's frames (capped at 50), `breakMode` = `always`/`unhandled` from `catchLocation()`
- Exception stopped events now carry `description` (`"FQCN: message"`, Throwable.toString() convention); `text` stays the FQCN for backward compatibility; `lastStopAllThreads` now set (the stop is SUSPEND_ALL)
- Retained state cleared on resume (`clearFrameCache`, common prologue of continue/step) and `cleanup()`; late `exceptionInfo` gets a clean error response and the TS stale-guard drops late merges

### TypeScript / docs
- `java-debug-adapter.ts`: `supportsExceptionInfoRequest` metadata flipped to true (the live gate uses the bridge's initialize response)
- Java added to the exceptionInfo-supported lists in `skill-content.ts`, `skills/debugging/SKILL.md`, `docs/tool-reference.md`; notes in `skills/debugging/references/java.md` and `docs/java/README.md`

### Tests
- New `examples/java/ThrowsTest.java` fixture (caught IllegalStateException, then uncaught RuntimeException), registered in `java-example-utils.ts`
- New `Java launch (JDI bridge) @requires-java` section in `mcp-server-break-on-exceptions.test.ts` (JDK soft-skip): uncaught stop asserts `description`, full `exceptionInfo` enrichment (exceptionId/breakMode `unhandled`/message/stackTrace) — only passes if the bridge both advertised the capability and answered the request; caught test asserts `breakMode: 'always'` with a bounded continue-loop absorbing JDK-internal caught exceptions
- Unit: capability flip + filter defaults asserted; filled the `getInitializationBehavior` gap (exceptionFilters + defaultExceptionBreakMode) in `java-adapter-policy.test.ts`

## Verification

- Bridge recompiles cleanly (`--release 21`)
- Unit: 2677/2677 pass; Java adapter suites 151/151
- e2e: `mcp-server-break-on-exceptions` 14/14 (incl. the 2 new Java tests), Java+JS smoke suites 19/19
- Log evidence: pre-fix server logs show `Adapter advertises no exceptionBreakpointFilters, but the 'java' policy declares [uncaught, caught]` on every Java session; today's post-fix e2e logs (Java sessions present) show zero drift warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)