### PR TITLE
fix(rust): fix CodeLLDB version-fallback drift and cover codelldb-resolver with unit tests

### DIFF
--- a/packages/adapter-rust/src/utils/codelldb-resolver.ts
+++ b/packages/adapter-rust/src/utils/codelldb-resolver.ts
@@ -10,6 +10,9 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+/** Keep in sync with the CODELLDB_VERSION default in scripts/vendor-codelldb.js */
+export const DEFAULT_CODELLDB_VERSION = '1.11.8';
+
 /**
  * Resolve the CodeLLDB executable path based on platform
  */
@@ -100,11 +103,11 @@ export async function getCodeLLDBVersion(): Promise<string | null> {
     try {
       const versionData = await fs.readFile(versionFile, 'utf-8');
       const parsed = JSON.parse(versionData);
-      return parsed.version || '1.11.0';
+      return parsed.version || DEFAULT_CODELLDB_VERSION;
     } catch {
       // Continue to next candidate
     }
   }
   
-  return '1.11.0'; // Default version fallback
+  return DEFAULT_CODELLDB_VERSION; // Default version fallback
 }

--- a/packages/adapter-rust/tests/codelldb-resolver.test.ts
+++ b/packages/adapter-rust/tests/codelldb-resolver.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for the CodeLLDB executable resolver.
+ *
+ * fs/promises is fully mocked — these tests must stay hermetic and never
+ * depend on whether the local vendor/ directory has been populated.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import * as path from 'path';
+import { readFileSync } from 'node:fs';
+
+const accessMock: Mock = vi.fn();
+const readFileMock: Mock = vi.fn();
+
+vi.mock('fs/promises', () => ({
+  access: (...args: unknown[]) => accessMock(...args),
+  readFile: (...args: unknown[]) => readFileMock(...args)
+}));
+
+import {
+  resolveCodeLLDBExecutable,
+  getCodeLLDBVersion,
+  DEFAULT_CODELLDB_VERSION
+} from '../src/utils/codelldb-resolver.js';
+
+const realProcess = process;
+
+// The resolver reads process.platform/arch/cwd at call time, so a global stub
+// is enough — no need to re-import the module per platform.
+function stubPlatform(platform: string, arch = 'x64'): void {
+  vi.stubGlobal('process', {
+    ...realProcess,
+    platform,
+    arch,
+    cwd: realProcess.cwd.bind(realProcess),
+    env: realProcess.env
+  });
+}
+
+describe('codelldb-resolver', () => {
+  beforeEach(() => {
+    accessMock.mockReset();
+    readFileMock.mockReset();
+    // Hermetic: never let the host machine's CODELLDB_PATH leak into tests
+    vi.stubEnv('CODELLDB_PATH', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  describe('resolveCodeLLDBExecutable', () => {
+    describe.each([
+      { platform: 'win32', arch: 'x64', dir: 'win32-x64', exe: 'codelldb.exe' },
+      { platform: 'darwin', arch: 'x64', dir: 'darwin-x64', exe: 'codelldb' },
+      { platform: 'darwin', arch: 'arm64', dir: 'darwin-arm64', exe: 'codelldb' },
+      { platform: 'linux', arch: 'x64', dir: 'linux-x64', exe: 'codelldb' },
+      { platform: 'linux', arch: 'arm64', dir: 'linux-arm64', exe: 'codelldb' }
+    ])('on $platform/$arch', ({ platform, arch, dir, exe }) => {
+      it(`returns the first existing candidate under ${dir}`, async () => {
+        stubPlatform(platform, arch);
+        accessMock.mockResolvedValue(undefined);
+
+        const result = await resolveCodeLLDBExecutable();
+
+        expect(accessMock).toHaveBeenCalledTimes(1);
+        const probed = accessMock.mock.calls[0][0] as string;
+        expect(result).toBe(probed);
+        expect(probed.endsWith(path.join(dir, 'adapter', exe))).toBe(true);
+      });
+    });
+
+    it('returns null on unsupported platforms without touching the filesystem', async () => {
+      stubPlatform('freebsd');
+
+      await expect(resolveCodeLLDBExecutable()).resolves.toBeNull();
+      expect(accessMock).not.toHaveBeenCalled();
+    });
+
+    it('falls through to the next candidate when the first does not exist', async () => {
+      stubPlatform('linux', 'x64');
+      accessMock
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await resolveCodeLLDBExecutable();
+
+      expect(accessMock).toHaveBeenCalledTimes(2);
+      expect(result).toBe(accessMock.mock.calls[1][0]);
+    });
+
+    it('probes all four vendored candidates before giving up', async () => {
+      stubPlatform('linux', 'x64');
+      accessMock.mockRejectedValue(new Error('ENOENT'));
+
+      await expect(resolveCodeLLDBExecutable()).resolves.toBeNull();
+
+      expect(accessMock).toHaveBeenCalledTimes(4);
+      const suffix = path.join('vendor', 'codelldb', 'linux-x64', 'adapter', 'codelldb');
+      for (const call of accessMock.mock.calls) {
+        expect(call[0] as string).toMatch(new RegExp(`${suffix.replace(/\\/g, '\\\\')}$`));
+      }
+    });
+
+    it('falls back to CODELLDB_PATH when no vendored candidate exists', async () => {
+      stubPlatform('darwin', 'arm64');
+      vi.stubEnv('CODELLDB_PATH', '/custom/codelldb');
+      accessMock.mockImplementation((p: string) =>
+        p === '/custom/codelldb' ? Promise.resolve() : Promise.reject(new Error('ENOENT'))
+      );
+
+      await expect(resolveCodeLLDBExecutable()).resolves.toBe('/custom/codelldb');
+      expect(accessMock).toHaveBeenCalledTimes(5); // 4 vendored candidates + env path
+    });
+
+    it('returns null when CODELLDB_PATH is set but does not exist', async () => {
+      stubPlatform('darwin', 'x64');
+      vi.stubEnv('CODELLDB_PATH', '/missing/codelldb');
+      accessMock.mockRejectedValue(new Error('ENOENT'));
+
+      await expect(resolveCodeLLDBExecutable()).resolves.toBeNull();
+      expect(accessMock).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe('getCodeLLDBVersion', () => {
+    it('returns null when the executable cannot be resolved', async () => {
+      stubPlatform('win32');
+      accessMock.mockRejectedValue(new Error('ENOENT'));
+
+      await expect(getCodeLLDBVersion()).resolves.toBeNull();
+      expect(readFileMock).not.toHaveBeenCalled();
+    });
+
+    it('reads the version from the vendored version.json', async () => {
+      stubPlatform('linux', 'x64');
+      accessMock.mockResolvedValue(undefined);
+      readFileMock.mockResolvedValue(JSON.stringify({ version: '1.12.3', platform: 'linux-x64' }));
+
+      await expect(getCodeLLDBVersion()).resolves.toBe('1.12.3');
+
+      const versionFile = readFileMock.mock.calls[0][0] as string;
+      expect(versionFile.endsWith(path.join('linux-x64', 'version.json'))).toBe(true);
+    });
+
+    it('skips a malformed version.json and reads the next candidate', async () => {
+      stubPlatform('linux', 'x64');
+      accessMock.mockResolvedValue(undefined);
+      readFileMock
+        .mockResolvedValueOnce('not-json{')
+        .mockResolvedValueOnce(JSON.stringify({ version: '9.9.9' }));
+
+      await expect(getCodeLLDBVersion()).resolves.toBe('9.9.9');
+      expect(readFileMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to DEFAULT_CODELLDB_VERSION when no version.json is readable', async () => {
+      stubPlatform('win32');
+      accessMock.mockResolvedValue(undefined);
+      readFileMock.mockRejectedValue(new Error('ENOENT'));
+
+      await expect(getCodeLLDBVersion()).resolves.toBe(DEFAULT_CODELLDB_VERSION);
+      expect(readFileMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('falls back to DEFAULT_CODELLDB_VERSION when version.json lacks a version field', async () => {
+      stubPlatform('darwin', 'arm64');
+      accessMock.mockResolvedValue(undefined);
+      readFileMock.mockResolvedValue('{}');
+
+      await expect(getCodeLLDBVersion()).resolves.toBe(DEFAULT_CODELLDB_VERSION);
+    });
+  });
+
+  describe('version drift guard', () => {
+    it('keeps DEFAULT_CODELLDB_VERSION in sync with the vendor script default', () => {
+      const source = readFileSync(new URL('../scripts/vendor-codelldb.js', import.meta.url), 'utf-8');
+      const match = source.match(/CODELLDB_VERSION\s*=\s*process\.env\.CODELLDB_VERSION\s*\|\|\s*'([^']+)'/);
+
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe(DEFAULT_CODELLDB_VERSION);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`packages/adapter-rust/src/utils/codelldb-resolver.ts` sat at **4.76% line coverage** (2/42 lines, 0/2 functions, 0/28 branches), dragging overall repo coverage down ~0.5pp. Investigation showed this was a pure test gap, not a hard-to-test file: it is plain `fs/promises.access`/`readFile` + platform mapping — no network, no process spawning. Every existing test that touched it mocked it out entirely.

This PR:

1. **Fixes a real drift bug the new tests caught**: the version fallback was hardcoded to `'1.11.0'` while the vendor script default had moved to `'1.11.8'` (`scripts/vendor-codelldb.js`). Now exported as `DEFAULT_CODELLDB_VERSION` and used at both fallback sites, with a **drift-guard test** that greps the vendor script's default and asserts it matches — so this class of drift fails CI instead of shipping.
2. **Adds 16 hermetic unit tests** (`packages/adapter-rust/tests/codelldb-resolver.test.ts`, `fs/promises` fully mocked — no dependence on a populated `vendor/` dir):
   - platform→vendor-dir mapping for all 5 supported platform/arch combos (`win32-x64`, `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`) + unsupported platform → `null`
   - candidate fall-through and full 4-candidate probe ordering
   - `CODELLDB_PATH` env fallback, both existing and missing — this is the **documented, user-facing path** for macOS/Windows npx users since the published CLI only vendors linux-x64, and was previously 0% covered
   - `version.json` parsing: valid, malformed-JSON skip-to-next-candidate, missing `version` key, all-unreadable → default

## Coverage impact

| | before | after |
|---|---|---|
| `codelldb-resolver.ts` lines | 4.76% (2/42) | **100%** (43/43) |
| `codelldb-resolver.ts` functions | 0/2 | **2/2** |
| `codelldb-resolver.ts` branches | 0/28 | 25/28 |
| overall repo lines | 90.0% | **90.5%** |

The 3 remaining uncovered branches are arms of the duplicated platform mapping inside `getCodeLLDBVersion()` whose logic is already fully exercised via `resolveCodeLLDBExecutable()`; covering them again would be coverage theater, and #265 proposes deleting the duplication anyway.

## Follow-up

Refs #265 — the platform-mapping/candidate-walk logic is triplicated (async resolver, private sync copy in `rust-debug-adapter.ts`, vendor script `PLATFORMS` table) and consolidation is scoped there, since the sync copy's candidate list is depth-adjusted relative to its `__dirname`.

## Test plan

- [x] `npx vitest run codelldb-resolver` — 16/16 pass (watched the drift tests fail RED before the fix)
- [x] `npm run test:unit` — 2693 tests, 161 files, all green
- [x] `npm run test:coverage:summary` — 2851 tests green, totals above
- [x] eslint clean on both files; pre-push hook (lint + clean build + unit + integration) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
