### PR TITLE
ci: bump codeql-action init/autobuild/analyze to v4.37.6 in lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
       day: monday
     commit-message:
       prefix: "ci"
+    groups:
+      # init/autobuild/analyze must move together — CodeQL hard-fails with
+      # "Loaded a configuration file for version 'X', but running version 'Y'"
+      # if the steps in one workflow run different action versions. Separate
+      # per-step PRs are individually unmergeable, so keep them in one PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     # Supply-chain mitigation: only open a PR once a release has been public for a few
     # days, giving the community a window to surface a bad/compromised release first.
     # GitHub Actions supports only `default-days` (no semver-* granularity).

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,14 +30,14 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
       with:
         category: /language:${{ matrix.language }}


### PR DESCRIPTION
Supersedes #287 and #291.

Dependabot treats `github/codeql-action/init`, `/autobuild`, and `/analyze` as three
independent dependencies, so it opened #291 (init) and #287 (analyze) separately and
never opened one for autobuild. Each PR alone leaves `codeql.yml` internally
inconsistent, and the Analyze job hard-fails:

```
Loaded a configuration file for version '4.37.6', but running version '4.37.4'
```

Both #287 and #291 fail CI for exactly that reason today.

## Changes

- Bump all three `codeql-action` pins to `5595ccaf912efad79be6eef63a5619ff05969be3` (v4.37.6),
  verified against the upstream `v4.37.6` tag.
- Group `github/codeql-action*` in `dependabot.yml` so future bumps arrive as a single
  mergeable PR.

The grouping is the point: this is the fourth manual lockstep fix for the same cause
(#201, #216, #234, and now this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)