### PR TITLE
ci: add workflow_dispatch to CI/CodeQL and move CodeQL cron off the dependabot window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:  # on-demand run when main lands commits without a push event
+                      # (auto-merge pushes with GITHUB_TOKEN, which suppresses triggers)
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,12 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 6 * * 1'  # Monday 6:00 UTC
+    # Monday 18:00 UTC — deliberately AFTER dependabot's Monday ~06:00 batch has been
+    # merged. Auto-merged PRs are pushed with GITHUB_TOKEN, which does not trigger the
+    # `push` event, so this scheduled run is what actually analyses the week's
+    # dependency merges on main.
+    - cron: '0 18 * * 1'
+  workflow_dispatch:  # on-demand re-analysis when main lands commits without a push event
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

Auto-merge completes the merge as `github-actions[bot]` using `GITHUB_TOKEN`, and GitHub
suppresses workflow triggers for `GITHUB_TOKEN` pushes. Commits reaching `main` that way get
**no `push`-event CI, CodeQL, or Scorecard run**.

This is not hypothetical — #298 and #299 both landed on main with zero checks attached.
The *content* was still validated (branch protection is `strict: true`, so every PR is tested
against the exact main it lands on, and main's tree came out byte-identical to the tested
head), but CodeQL's default-branch analysis silently goes stale.

## What

- **`workflow_dispatch` on `ci.yml` and `codeql.yml`** — lets a stale main be re-analysed on
  demand. `scorecard.yml` already had it.
- **CodeQL cron: Monday 06:00 UTC → Monday 18:00 UTC.** Dependabot opens its weekly batch at
  ~05:55 Monday, so the old schedule ran *just before* the batch merged and systematically
  analysed a main that predated the week's dependency updates. At 18:00 the weekly scan
  covers them with no manual step — which matters precisely because those merges are the ones
  most likely to arrive via auto-merge.

## Alternative considered

Switching the auto-merge workflow to a PAT would fix the trigger suppression at the root, but
it adds a long-lived write credential to rotate and works against the Scorecard posture built
up in #160-#164. Not worth it for a gap the cron already closes.

## Verification

Both files parsed with a YAML parser to confirm the trigger maps are what's intended:

```
ci.yml     => {'push': ..., 'pull_request': ..., 'workflow_dispatch': None}
codeql.yml => {'push': ..., 'pull_request': ..., 'schedule': [{'cron': '0 18 * * 1'}], 'workflow_dispatch': None}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)