### PR TITLE
fix: stable functionBreakpoints shape in unfiltered list_breakpoints (#306)

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -260,12 +260,15 @@ Lists all breakpoints in a session with their current verified state and adapter
       "adapterId": 3
     }
   ],
-  "count": 1
+  "count": 1,
+  "functionBreakpoints": [],
+  "functionCount": 0
 }
 ```
 
 **Notes:**
 - The array is sorted by file, then line. Conditional breakpoints include their `condition`; Java suspend policies appear as `suspendPolicy`.
+- `functionBreakpoints`/`functionCount` are always present in the unfiltered response (empty arrays when none exist). When filtering by `file` they are omitted — function breakpoints are session-global, not file-scoped.
 - `adapterId` is the debug adapter's own numeric id for the breakpoint, captured from setBreakpoints responses and breakpoint events. It is absent until the adapter has seen the breakpoint.
 - Verification is eventually consistent: some adapters (js-debug, JDI, netcoredbg) bind breakpoints asynchronously and confirm via DAP breakpoint events shortly after launch or class load.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1303,7 +1303,7 @@ export class DebugMcpServer {
                   success: true,
                   breakpoints,
                   count: breakpoints.length,
-                  ...(functionBreakpoints.length > 0
+                  ...(args.file === undefined
                     ? { functionBreakpoints, functionCount: functionBreakpoints.length }
                     : {})
                 }) }] };

--- a/tests/core/unit/server/server-breakpoint-management-tools.test.ts
+++ b/tests/core/unit/server/server-breakpoint-management-tools.test.ts
@@ -89,6 +89,67 @@ describe('Server Breakpoint Management Tools', () => {
       expect(mockSessionManager.listBreakpoints).toHaveBeenCalledWith('test-session', undefined);
     });
 
+    it('always includes empty function-breakpoint fields in the unfiltered response (#306)', async () => {
+      mockSessionManager.listBreakpoints.mockReturnValue([]);
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'list_breakpoints',
+          arguments: { sessionId: 'test-session' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.functionBreakpoints).toEqual([]);
+      expect(content.functionCount).toBe(0);
+    });
+
+    it('includes function breakpoints in the unfiltered response', async () => {
+      mockSessionManager.listBreakpoints.mockReturnValue([]);
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([
+        { id: 'fn-1', functionName: 'main', verified: false }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'list_breakpoints',
+          arguments: { sessionId: 'test-session' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.functionBreakpoints).toHaveLength(1);
+      expect(content.functionBreakpoints[0]).toMatchObject({ functionName: 'main', verified: false });
+      expect(content.functionCount).toBe(1);
+    });
+
+    it('omits function-breakpoint fields when filtering by file', async () => {
+      mockSessionManager.listBreakpoints.mockReturnValue([
+        { id: 'bp-1', file: '/a.py', line: 10, verified: true }
+      ]);
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([
+        { id: 'fn-1', functionName: 'main', verified: true }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'list_breakpoints',
+          arguments: { sessionId: 'test-session', file: '/a.py' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      // Function breakpoints are session-global; a file filter deliberately
+      // excludes them (issue #271 phase 3), so the keys stay absent.
+      expect(content.functionBreakpoints).toBeUndefined();
+      expect(content.functionCount).toBeUndefined();
+      expect(mockSessionManager.listFunctionBreakpoints).not.toHaveBeenCalled();
+    });
+
     it('works for a terminated session', async () => {
       mockSessionManager.getSession.mockReturnValue({
         id: 'test-session',

--- a/tests/e2e/mcp-server-bp-addressing.test.ts
+++ b/tests/e2e/mcp-server-bp-addressing.test.ts
@@ -242,7 +242,10 @@ describe('Breakpoint addressing e2e (#271, mock adapter)', () => {
     });
     expect(removeRes.success).toBe(true);
     const finalList = await callToolSafely(mcpClient!, 'list_breakpoints', { sessionId });
-    expect((finalList as { functionBreakpoints?: unknown[] }).functionBreakpoints).toBeUndefined();
+    // Stable response shape (#306): the unfiltered list always carries the
+    // function-breakpoint fields, empty after the last one is removed.
+    expect((finalList as { functionBreakpoints?: unknown[] }).functionBreakpoints).toEqual([]);
+    expect((finalList as { functionCount?: number }).functionCount).toBe(0);
   }, 45_000);
 
   it('accepts statement with a matching expectedContent (#280)', async () => {


### PR DESCRIPTION
## Summary

Fixes #306. `list_breakpoints` returned the `functionBreakpoints`/`functionCount` keys only while at least one function breakpoint existed; after removing the last one the keys disappeared entirely, so agents verifying cleanup had to special-case *key absent* vs *key present and empty* — and absence was ambiguous ("none remain" vs "server predates fn-bp support").

The spread is now keyed on the `file` filter instead of the array length:
- **Unfiltered** responses always include `functionBreakpoints` (possibly `[]`) and `functionCount` (possibly `0`) — same stable shape as `breakpoints`/`count`.
- **File-filtered** responses keep omitting them (intentional: function breakpoints are session-global, issue #271 phase 3).

## Changes

- `src/server.ts`: one-expression change in the `list_breakpoints` handler.
- `tests/core/unit/server/server-breakpoint-management-tools.test.ts`: three new cases — stable empty shape, populated shape, and the previously untested file-filtered omission branch.
- `tests/e2e/mcp-server-bp-addressing.test.ts`: post-removal assertion flipped from `toBeUndefined()` to `toEqual([])` + `functionCount === 0`.
- `docs/tool-reference.md`: response sample + note.

## Test coverage

Coverage-boost pass per this sprint's goal: the file-filtered branch of the handler had no test at all; now covered. Baseline (main): `src/server.ts` 87.64% lines / 79.08% branches.

## Verification

- `npx vitest run tests/core/unit/server/server-breakpoint-management-tools.test.ts` — 14 passed
- `npx vitest run tests/e2e/mcp-server-bp-addressing.test.ts` — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)