### PR TITLE
fix: dev-proxy backend-down hint only on genuine transport failures (#304)

### DIFF
--- a/tests/unit/dev-proxy/tool-error.test.ts
+++ b/tests/unit/dev-proxy/tool-error.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the dev-proxy tool-error classification helpers (issue #304).
+ *
+ * The helpers live in tools/dev-proxy/tool-error.mjs (separate from
+ * dev-proxy.mjs, which runs main() at module top level and therefore cannot
+ * be imported safely).
+ *
+ * The contract under test: the "backend may be down" hint may only accompany
+ * genuine transport/connection failures. A well-formed JSON-RPC error from a
+ * running backend (e.g. -32602 InvalidParams for a bad breakpoint) proves the
+ * backend is alive — hinting a restart there sends agents on a false detour
+ * that, in parallel runs, can destroy every other agent's sessions.
+ */
+import { describe, it, expect } from 'vitest';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- plain-JS module without type declarations
+import { isBackendUnavailableError, dedupeMcpErrorPrefix, assertBackendAvailable } from '../../../tools/dev-proxy/tool-error.mjs';
+
+describe('dev-proxy isBackendUnavailableError', () => {
+  it.each(['stopped', 'starting', 'restarting'])(
+    'returns true whenever the backend state is %s, regardless of error shape',
+    (state) => {
+      expect(isBackendUnavailableError(new Error('anything'), state)).toBe(true);
+      expect(isBackendUnavailableError({ code: -32602 }, state)).toBe(true);
+    }
+  );
+
+  it('returns true for a direct syscall code under running state', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:3001'), {
+      code: 'ECONNREFUSED',
+    });
+    expect(isBackendUnavailableError(err, 'running')).toBe(true);
+  });
+
+  it('walks the cause chain for undici fetch failures', () => {
+    // undici wraps connection failures: TypeError('fetch failed') with the
+    // syscall error on .cause — the common down-backend shape in http mode.
+    const err = new TypeError('fetch failed');
+    (err as Error & { cause?: unknown }).cause = Object.assign(
+      new Error('connect ECONNRESET'),
+      { code: 'ECONNRESET' }
+    );
+    expect(isBackendUnavailableError(err, 'running')).toBe(true);
+  });
+
+  it('walks nested causes more than one level down', () => {
+    const inner = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    const mid = Object.assign(new Error('request failed'), { cause: inner });
+    const outer = Object.assign(new TypeError('fetch failed'), { cause: mid });
+    expect(isBackendUnavailableError(outer, 'running')).toBe(true);
+  });
+
+  it.each([-32000, -32001])(
+    'returns true for SDK transport error code %d (ConnectionClosed / RequestTimeout)',
+    (code) => {
+      expect(isBackendUnavailableError({ code, message: 'x' }, 'running')).toBe(true);
+    }
+  );
+
+  it.each([-32602, -32603, -32601, -32700])(
+    'returns false for JSON-RPC application error code %d from a running backend',
+    (code) => {
+      expect(isBackendUnavailableError({ code, message: 'MCP error' }, 'running')).toBe(false);
+    }
+  );
+
+  it('returns false for a codeless error under running state', () => {
+    expect(isBackendUnavailableError(new Error('something odd'), 'running')).toBe(false);
+  });
+
+  it('tolerates null/undefined errors', () => {
+    expect(isBackendUnavailableError(null, 'running')).toBe(false);
+    expect(isBackendUnavailableError(undefined, 'running')).toBe(false);
+    expect(isBackendUnavailableError(null, 'stopped')).toBe(true);
+  });
+});
+
+describe('dev-proxy dedupeMcpErrorPrefix', () => {
+  it('collapses a doubled prefix to one', () => {
+    expect(dedupeMcpErrorPrefix('MCP error -32602: MCP error -32602: Breakpoint not set')).toBe(
+      'MCP error -32602: Breakpoint not set'
+    );
+  });
+
+  it('collapses a tripled prefix (nested proxies) to one', () => {
+    expect(
+      dedupeMcpErrorPrefix('MCP error -32603: MCP error -32603: MCP error -32603: boom')
+    ).toBe('MCP error -32603: boom');
+  });
+
+  it('leaves a single prefix unchanged', () => {
+    expect(dedupeMcpErrorPrefix('MCP error -32602: Breakpoint not set')).toBe(
+      'MCP error -32602: Breakpoint not set'
+    );
+  });
+
+  it('leaves an unprefixed message unchanged', () => {
+    expect(dedupeMcpErrorPrefix('Backend is stopped — cannot call tool')).toBe(
+      'Backend is stopped — cannot call tool'
+    );
+  });
+
+  it('does not merge differing codes (not a duplicate)', () => {
+    expect(dedupeMcpErrorPrefix('MCP error -32602: MCP error -32603: mixed')).toBe(
+      'MCP error -32602: MCP error -32603: mixed'
+    );
+  });
+
+  it('passes non-string input through', () => {
+    expect(dedupeMcpErrorPrefix(undefined)).toBeUndefined();
+    expect(dedupeMcpErrorPrefix(42)).toBe(42);
+  });
+});
+
+describe('dev-proxy assertBackendAvailable', () => {
+  it('throws a clean state-naming error when the backend is not running', () => {
+    expect(() => assertBackendAvailable({ state: 'stopped', mcpClient: null })).toThrow(
+      /Backend is stopped/
+    );
+  });
+
+  it('throws when the client is null even if state claims running (race)', () => {
+    expect(() => assertBackendAvailable({ state: 'running', mcpClient: null })).toThrow(
+      /Backend is running/
+    );
+  });
+
+  it('passes for a running backend with a client', () => {
+    expect(() => assertBackendAvailable({ state: 'running', mcpClient: {} })).not.toThrow();
+  });
+});

--- a/tools/dev-proxy/dev-proxy.mjs
+++ b/tools/dev-proxy/dev-proxy.mjs
@@ -38,6 +38,7 @@ import { fileURLToPath } from 'url';
 import path from 'path';
 import { installShutdownHandlers, killChildGracefully } from './shutdown.mjs';
 import { createBackendLogger, sanitizeStderrTail, sharedUtilsLoaded } from './backend-logger.mjs';
+import { isBackendUnavailableError, dedupeMcpErrorPrefix, assertBackendAvailable } from './tool-error.mjs';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -744,20 +745,15 @@ async function main() {
       const result = await backend.callTool(name, args || {});
       return result;
     } catch (err) {
+      // A well-formed JSON-RPC error from a running backend (e.g. -32602
+      // InvalidParams) proves the backend is alive — pass it through without
+      // the restart hint, which would send agents on a false detour (#304).
+      const body = { error: dedupeMcpErrorPrefix(err.message) };
+      if (isBackendUnavailableError(err, backend.state)) {
+        body.hint = `The mcp-debugger backend is not reachable (state: ${backend.state}). Use dev_server_status to check, or dev_restart_debugger to restart it.`;
+      }
       return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(
-              {
-                error: err.message,
-                hint: 'The mcp-debugger backend may be down. Use dev_server_status to check, or dev_restart_debugger to restart it.',
-              },
-              null,
-              2
-            ),
-          },
-        ],
+        content: [{ type: 'text', text: JSON.stringify(body, null, 2) }],
         isError: true,
       };
     }
@@ -778,14 +774,17 @@ async function main() {
   });
 
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    assertBackendAvailable(backend);
     return await backend.mcpClient.readResource(request.params);
   });
 
   server.setRequestHandler(SubscribeRequestSchema, async (request) => {
+    assertBackendAvailable(backend);
     return await backend.mcpClient.subscribeResource(request.params);
   });
 
   server.setRequestHandler(UnsubscribeRequestSchema, async (request) => {
+    assertBackendAvailable(backend);
     return await backend.mcpClient.unsubscribeResource(request.params);
   });
 

--- a/tools/dev-proxy/tool-error.mjs
+++ b/tools/dev-proxy/tool-error.mjs
@@ -1,0 +1,86 @@
+/**
+ * Error classification helpers for the dev-proxy tool-call path (issue #304).
+ *
+ * Kept separate from dev-proxy.mjs (which runs main() at module top level and
+ * therefore cannot be imported safely) so the logic is unit-testable — same
+ * pattern as shutdown.mjs and backend-logger.mjs.
+ */
+
+// Node syscall codes that mean the backend process/socket is gone. With the
+// default Streamable HTTP transport these usually arrive wrapped by undici as
+// TypeError('fetch failed') with the syscall error on err.cause.
+const TRANSPORT_SYSCALL_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ECONNABORTED',
+  'ENOTFOUND',
+]);
+
+// MCP SDK transport-level error codes (not JSON-RPC application errors):
+// -32000 ConnectionClosed, -32001 RequestTimeout.
+const MCP_CONNECTION_CODES = new Set([-32000, -32001]);
+
+/**
+ * True when a failed backend tool call indicates the backend itself is
+ * unreachable (dead process, refused/reset connection, transport timeout) —
+ * the only case where a "restart the backend" hint is honest. A well-formed
+ * JSON-RPC error response (e.g. -32602 InvalidParams) is proof the backend is
+ * alive and must NOT trigger the hint.
+ *
+ * @param {unknown} err - the error thrown by BackendManager.callTool
+ * @param {string} backendState - BackendManager.state at catch time
+ */
+export function isBackendUnavailableError(err, backendState) {
+  if (backendState !== 'running') {
+    return true;
+  }
+  // Walk the cause chain (bounded — cycles/absurd depth are not our problem):
+  // undici and the SDK both wrap the interesting code one level down.
+  let e = err;
+  for (let depth = 0; e && depth < 4; depth++) {
+    const code = /** @type {{code?: unknown}} */ (e).code;
+    if (typeof code === 'string' && TRANSPORT_SYSCALL_CODES.has(code)) {
+      return true;
+    }
+    if (typeof code === 'number' && MCP_CONNECTION_CODES.has(code)) {
+      return true;
+    }
+    e = /** @type {{cause?: unknown}} */ (e).cause;
+  }
+  return false;
+}
+
+/**
+ * Collapse repeated identical "MCP error <code>: " prefixes to one.
+ *
+ * The SDK's McpError constructor bakes the prefix into .message; when the
+ * backend's already-prefixed message crosses the proxy's SDK Client it gets
+ * re-wrapped in a new McpError and prefixed again ("MCP error -32602: MCP
+ * error -32602: ..."). Deduping (rather than stripping) keeps the single
+ * prefix a direct client would see.
+ *
+ * @param {unknown} message
+ */
+export function dedupeMcpErrorPrefix(message) {
+  if (typeof message !== 'string') {
+    return message;
+  }
+  return message.replace(/^(MCP error -?\d+: )\1+/, '$1');
+}
+
+/**
+ * Guard for the resource-passthrough handlers: throw a clean, honest error
+ * when the backend cannot serve resource requests instead of dereferencing a
+ * null mcpClient (latent NPE noted in issue #304).
+ *
+ * @param {{state: string, mcpClient: unknown}} backend
+ */
+export function assertBackendAvailable(backend) {
+  if (backend.state !== 'running' || !backend.mcpClient) {
+    throw new Error(
+      `Backend is ${backend.state} — cannot serve resource requests. Use dev_restart_debugger to start it.`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #304. The dev-proxy attached its "backend may be down — restart it" hint to **every** failed tool call, including ordinary validation errors from a perfectly healthy backend. An agent that trusts the hint detours into `dev_server_status`/`dev_restart_debugger` — and a restart kills every live debug session on that backend, which in a parallel test run destroys other agents' sessions.

## Changes

New `tools/dev-proxy/tool-error.mjs` (pure, unit-testable helpers — same extraction pattern as `shutdown.mjs`/`backend-logger.mjs`):

- **`isBackendUnavailableError(err, backendState)`** — the hint now attaches only when: the backend state isn't `running` (guard throw, mid-restart, process died), or the error carries a transport code: Node syscall codes (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `EPIPE`, `ECONNABORTED`, `ENOTFOUND`) **walked through the `err.cause` chain** (undici wraps refusals as `TypeError: fetch failed` with the code on `.cause` — the common down-backend shape in the default http mode), or SDK transport codes `-32000` ConnectionClosed / `-32001` RequestTimeout. JSON-RPC application errors (`-32602`, `-32603`, …) return false — a well-formed error response is proof the backend is alive.
- **`dedupeMcpErrorPrefix(message)`** — collapses the doubled `MCP error -32602: MCP error -32602:` prefix. The doubling is SDK-inherent (backend `McpError` bakes the prefix into `.message`; the proxy's SDK `Client` re-wraps the wire message in a new `McpError`, re-applying it). Dedupe rather than strip: a single prefix — what a direct client sees — is preserved; differing codes are not merged.
- **`assertBackendAvailable(backend)`** — guards the resource passthrough handlers (`ReadResource`/`Subscribe`/`Unsubscribe`), which previously dereferenced `backend.mcpClient` unguarded and NPE'd when the backend was down (latent bug found while fixing #304).

The hint text now includes the actual backend state: `The mcp-debugger backend is not reachable (state: stopped). …`

## Test coverage

`tests/unit/dev-proxy/tool-error.test.ts` — 23 new tests: state matrix, direct + cause-chain syscall codes, nested causes, SDK transport codes, application codes → no hint, codeless errors, null tolerance; prefix dedupe (single/double/triple/unprefixed/differing codes/non-string); resource guard. The dev-proxy previously had test coverage only for shutdown + logging.

## Verification

- `npx vitest run tests/unit/dev-proxy/` — 52 passed (23 new)
- `node --check` on both `.mjs` files; `npm run lint` clean
- Manual (post-merge, requires a proxy restart since the running proxy process predates this change): call a tool with bad params against a running backend → error without hint, single `MCP error` prefix; stop the backend → hint present with state name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)