### PR TITLE
fix: shorten mirror stopped-replay fallback to 200ms; fix stale fn-bp doc claim (#307)

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -140,7 +140,7 @@ Sets a breakpoint in a source file.
 - `file` (string, required): Path to the source file (absolute or relative to project root).
 - `line` (number, required): Line number where to set breakpoint (1-indexed).
 - `statement` (string, optional): **Content addressing** — instead of `line`, pass the exact text of the target line (leading/trailing whitespace ignored), like an Edit-tool match. Cannot land on the wrong line; if the text appears on multiple lines the error lists every match; anchors re-resolve across `restart_debugging` after file edits. Provide `statement` OR `line`, not both. See [Statement anchors](#statement-anchors).
-- `function` (string, optional): **Symbol addressing** — break on entry to a function/method by name (DAP function breakpoint). Session-global: no `file` or `line` at all, and names survive edits better than both. Composes with `condition` only. Supported by Python, Go, Rust, .NET, and Java; JavaScript rejects it with a clear error (see [Function breakpoints](#function-breakpoints)).
+- `function` (string, optional): **Symbol addressing** — break on entry to a function/method by name (DAP function breakpoint). Session-global: no `file` or `line` at all, and names survive edits better than both. Composes with `condition` only. Supported by Python, Go, Rust, .NET, Java, and JavaScript (JavaScript names are dotted runtime paths delivered over the CDP bridge — see [Function breakpoints](#function-breakpoints)); Ruby is accepted with a warning and validated at launch.
 - `nearLine` (number, optional): With `statement` only — when the statement text appears on multiple lines, bind to the match closest to this line (ties go to the lower line).
 - `expectedContent` (string, optional): With `line` only — assert the exact text of the target line (leading/trailing whitespace ignored) before setting. On a mismatch the breakpoint is **not** set and the error shows the actual content of that line and its neighbors — a fast, self-explanatory failure instead of a breakpoint that silently lands on the wrong line. See [Content assertions and loud snapping](#content-assertions-and-loud-snapping).
 - `condition` (string, optional): Conditional expression — only break (or log) when it evaluates truthy.
@@ -993,12 +993,12 @@ The endpoint closes on `unexpose_session`, `close_debug_session`, `restart_debug
 Other DAP clients (nvim-dap, etc.): connect a TCP DAP client to the host/port and include `mirrorToken` in the `attach` request arguments.
 
 **What the mirror serves:**
-- Answered locally: `initialize` (from the adapter's real capabilities, with control affordances masked off), `attach`/`launch` (token check), `configurationDone`, `disconnect` (that client only), `cancel`.
+- Answered locally: `initialize` (from the adapter's real capabilities, with control affordances masked off), `attach`/`launch` (token check), `configurationDone` (also the trigger for the late-join stopped replay below), `disconnect` (that client only), `cancel`.
 - Forwarded to the live adapter: `threads`, `stackTrace`, `scopes`, `variables`, `source`, `evaluate`, `exceptionInfo`, `loadedSources`, `modules`.
 - Soft-succeeded so IDE attach flows survive: `setBreakpoints`/`setFunctionBreakpoints` (reported unverified — breakpoints stay agent-owned), `setExceptionBreakpoints`.
 - Rejected with a quiet error: `continue`, `next`, `stepIn`, `stepOut`, `pause`, `setVariable`, `restart`, `terminate`, and every other control or mutation request.
 
-On attach while the session is paused, the mirror replays the last stop as a `stopped` event, so the IDE lands directly on the paused frame.
+On attach while the session is paused, the mirror replays the last stop as a `stopped` event, so the IDE lands directly on the paused frame. The replay is delivered when the client sends `configurationDone` (standard DAP handshake order); clients that skip `configurationDone` receive it after a short (~200ms) fallback. Live events, by contrast, are broadcast to every attached client immediately.
 
 **Security:** the endpoint binds loopback only and every client must present the per-expose token. Treat the token as a **debuggee-execution capability**, not a view-only credential — `evaluate` is forwarded, and DAP evaluate can run arbitrary code in the debuggee. The token appears only in the `expose_session` result and is redacted from logs. "Read-only" means execution control and breakpoint changes are rejected, not that the debuggee is immutable.
 

--- a/src/proxy/dap-mirror-server.ts
+++ b/src/proxy/dap-mirror-server.ts
@@ -85,6 +85,17 @@ export interface IDapMirrorServerFactory {
   create(host: DapMirrorHost, options: DapMirrorServerOptions): IDapMirrorServer;
 }
 
+/**
+ * Late-join stopped replay has two triggers: the client's configurationDone
+ * (standard DAP handshake order — fires the replay immediately, real IDEs
+ * always take this path) and this fallback for minimal scripted clients that
+ * skip configurationDone. Short enough that a script attaching and reading
+ * events sees the replay promptly (issue #307); an immediate-at-join replay
+ * is deliberately avoided so protocol-following IDEs never receive a stopped
+ * event before their configuration phase completes.
+ */
+export const CONFIGURATION_DONE_FALLBACK_MS = 200;
+
 // ===== Request dispatch tables (default-deny) =====
 
 /** Read-only requests forwarded to the real adapter connection. */
@@ -315,7 +326,7 @@ export class MirrorClientConnection {
         this.phase = 'ready';
         this.synthesizeStoppedIfPaused();
       }
-    }, 1000);
+    }, CONFIGURATION_DONE_FALLBACK_MS);
   }
 
   private buildCapabilityMask(): DebugProtocol.Capabilities {

--- a/tests/proxy/dap-mirror-server.test.ts
+++ b/tests/proxy/dap-mirror-server.test.ts
@@ -9,6 +9,7 @@ import { EventEmitter } from 'events';
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import {
   DapMirrorServer,
+  CONFIGURATION_DONE_FALLBACK_MS,
   type DapMirrorHost,
   type MirrorNetServer,
   type MirrorSocket
@@ -302,7 +303,7 @@ describe('DapMirrorServer', () => {
       expect(stopIdx).toBeGreaterThan(cfgIdx);
     });
 
-    it('falls back to a 1s timer for clients that never send configurationDone', async () => {
+    it('falls back to a short timer for clients that never send configurationDone', async () => {
       vi.useFakeTimers();
       const h = await createHarness({ lastStop });
       const socket = h.connect();
@@ -310,8 +311,24 @@ describe('DapMirrorServer', () => {
       send(socket, request('attach', { mirrorToken: h.endpoint.token }));
       await vi.advanceTimersByTimeAsync(0);
 
+      // Never at t=0: protocol-following IDEs must not see a stopped event
+      // before their configuration phase.
       expect(events(socket).map((e) => e.event)).not.toContain('stopped');
-      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(CONFIGURATION_DONE_FALLBACK_MS);
+      expect(events(socket).filter((e) => e.event === 'stopped')).toHaveLength(1);
+    });
+
+    it('delivers a live stopped broadcast to a client still in the configuration phase', async () => {
+      // The synthesized late-join replay waits for configurationDone, but a
+      // real stop happening mid-handshake is broadcast immediately — the
+      // mirror's ordering tolerance the short fallback relies on.
+      const h = await createHarness();
+      const socket = h.connect();
+      await join(h, socket);
+
+      h.server.broadcastEvent('stopped', { reason: 'breakpoint', threadId: 3 });
+      await flush();
+
       expect(events(socket).filter((e) => e.event === 'stopped')).toHaveLength(1);
     });
 


### PR DESCRIPTION
## Summary

Fixes #307 — both halves, with behavior fixed rather than papered over in docs.

**1. Stale doc claim.** The `set_breakpoint` parameter list in `docs/tool-reference.md` still said "JavaScript rejects it with a clear error" — contradicting the Function-breakpoints section 80 lines below and the live tool schema (both correct since #296). The parameter entry now matches: JS supported via the CDP bridge, dotted runtime paths, Ruby accepted-with-warning.

**2. Mirror stopped-replay discoverability.** The late-join synthesized `stopped` replay fires when the client sends `configurationDone` — standard DAP order — with a fallback timer for clients that skip it. At 1000ms, a minimal scripted DAP client (exactly what an agent writes to smoke-test the mirror) that skips `configurationDone` and reads events for under a second concludes the replay is broken. The fallback is now **200ms**, as an exported `CONFIGURATION_DONE_FALLBACK_MS` constant so tests can't drift from the implementation value.

Why 200ms and not replay-at-attach: protocol-following IDEs must never see a `stopped` event before their configuration phase completes (the existing no-stop-at-t0 test contract), and they already get zero-latency replay via the `configurationDone` path, which clears the timer. The fallback only affects protocol-skipping clients — for them 200ms is a comfortable multiple of the machine-paced handshake gap. Docs now state the trigger and the fallback in the `expose_session` section.

## Test coverage

- Fallback test now imports the constant (timing can't silently diverge) and keeps the no-stop-at-t0 assertion.
- New explicit test: a **live** `stopped` broadcast reaches a client still mid-handshake (attached, no `configurationDone` yet) — the pre-existing ordering tolerance the shortened fallback relies on, previously only implicitly covered.

## Verification

- `npx vitest run tests/proxy/dap-mirror-server.test.ts` — 47 passed
- `npx vitest run tests/integration/dap-mirror/` — 2 passed (real-socket path; sends `configurationDone`, unaffected by the timer change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)