### PR TITLE
feat: secret redaction in variable/evaluate/output results, on by default (#237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If your agent runs in a terminal, a pipeline, or a cloud sandbox — or needs to
 - ⚡ **npx ready** – Run directly with `npx @debugmcp/mcp-debugger` - no installation needed
 - 🐳 **Docker and npm packages** – Deploy anywhere
 - 🤖 **Built for AI agents** – Structured JSON responses for easy parsing
+- 🔒 **Secret redaction on by default** – Credential-shaped values (API keys, tokens, private keys) are masked as labeled placeholders in variable, evaluate, and output results before they reach the agent ([details](./docs/tool-reference.md#secret-redaction); opt out with `DEBUG_MCP_NO_REDACT=1`)
 - 🛡️ **Path validation** – Prevents crashes from non-existent files
 - 📝 **AI-aware line context** – Intelligent breakpoint placement with code context
 - ✅ **Comprehensive test suite** – unit, integration, and end-to-end coverage across every adapter ([CI status](https://github.com/debugmcp/mcp-debugger/actions/workflows/ci.yml))

--- a/docs/docker-support.md
+++ b/docs/docker-support.md
@@ -91,7 +91,7 @@ Here's the recommended configuration for your MCP settings file:
 - The `:rw` suffix allows read-write access (required for debugging)
 - The Docker entrypoint (`scripts/docker-entry.sh`) runs `dist/bundle.cjs` and passes through command-line arguments (e.g., `stdio`). It does not hardcode `--log-level` or `--log-file`
 - When using the debugger, provide paths relative to the project root (e.g., `examples/test.py` not `/workspace/examples/test.py`)
-- Optional env flags pass through with `-e`, e.g. `-e DEBUG_MCP_BP_ADDRESSING=line` restricts breakpoint addressing features (default: all enabled; see the set_breakpoint section of the tool reference)
+- Optional env flags pass through with `-e`, e.g. `-e DEBUG_MCP_BP_ADDRESSING=line` restricts breakpoint addressing features (default: all enabled; see the set_breakpoint section of the tool reference), or `-e DEBUG_MCP_NO_REDACT=1` to disable the default masking of credential-shaped values in variable/evaluate/output results (see the Secret redaction section of the tool reference)
 
 ## Rust support in Docker
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -22,6 +22,7 @@ This document provides a complete reference for all tools available in mcp-debug
    - [continue_execution](#continue_execution)
    - [pause_execution](#pause_execution)
 4. [State Inspection](#state-inspection)
+   - [Secret redaction](#secret-redaction)
    - [get_stack_trace](#get_stack_trace)
    - [get_scopes](#get_scopes)
    - [get_variables](#get_variables)
@@ -501,6 +502,27 @@ Pauses a running program. The debugger sends a DAP pause request and returns imm
 
 ## State Inspection
 
+### Secret redaction
+
+Debuggers see everything in scope — including credentials — and when the debugging driver is an AI agent, variable values flow into model context and transcripts. By default, mcp-debugger masks credential-shaped values in every value-bearing surface: `get_variables`, `get_local_variables`, `evaluate_expression` results, and captured output (`get_output` and the `debug://sessions/{id}/output` resource).
+
+Masking is per-token and labeled, so the rest of the value stays legible:
+
+```json
+{ "name": "gh_token", "value": "<redacted:github-pat>", "type": "str", "redacted": true }
+```
+
+Two detection layers apply:
+
+- **Value shapes** — well-known token formats (GitHub/GitLab PATs, OpenAI/Anthropic-style `sk-` keys, Slack, Stripe, AWS access key IDs, Google API keys, npm/PyPI/Hugging Face tokens, SendGrid, JWTs, PEM private-key blocks, `Bearer` credentials, connection-string passwords, URL userinfo passwords). Patterns are adapted from the MIT-licensed [gitleaks](https://github.com/gitleaks/gitleaks) corpus.
+- **Sensitive names** — a variable whose *name* exactly matches a known sensitive name (`password`, `api_key`, `client_secret`, ...) has its whole value masked as `<redacted:sensitive-name>`, unless the value is trivial (`None`, `''`, `0`, ...) so "why is my token empty?" stays debuggable. Matching is exact after normalization, never substring — `tokenCount`, `PATH`, and `patience` are untouched. `evaluate_expression` treats the expression's final dot-segment as the name, so `config.password` is masked like the variable `password`.
+
+Results that had values masked carry a `redaction` field (`{ masked, notice }` on variable/output tools; `{ rules, notice }` on evaluate results) explaining that only the display is masked, not program state. Redacted variables and output entries are flagged `redacted: true`.
+
+**Opting out**: start the server with `DEBUG_MCP_NO_REDACT=1` to disable redaction entirely (e.g. when debugging credential-handling code itself). Adapter stderr sanitization (unconditional, whole-line) is unaffected by this flag.
+
+**Limitations**: redaction is display-level protection against credentials leaking into transcripts, not a security boundary against a hostile agent — an agent can still compute over secrets via `evaluate_expression` side effects. Secrets split across separate output chunks, and generic high-entropy strings with no recognizable shape or name, are not detected. The [`expose_session`](#expose_session) IDE mirror shows **raw, unredacted** values — it serves a human's IDE, not the agent.
+
 ### get_stack_trace
 
 Gets the current call stack.
@@ -969,6 +991,8 @@ Starts a per-session DAP server endpoint on `127.0.0.1` (ephemeral port) inside 
 ```
 
 The endpoint closes on `unexpose_session`, `close_debug_session`, `restart_debugging`, or debuggee exit. `list_debug_sessions` shows `exposure: {host, port}` for exposed sessions (never the token).
+
+Note: the mirror serves a human's IDE and proxies DAP responses directly, so it shows **raw variable values** — [secret redaction](#secret-redaction) does not apply to this surface.
 
 **Connecting VS Code:**
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -215,5 +215,19 @@ export {
   sanitizeStderr,
   sanitizeStderrTail
 } from './utils/env-sanitizer.js';
+// Per-token labeled secret redaction for tool results (issue #237). The
+// stderr sanitizer above derives its value corpus from this rule table.
+export {
+  SECRET_VALUE_RULES,
+  SECRET_VALUE_ALTERNATION,
+  REDACTION_NOTICE,
+  redactSecretsInString,
+  isSensitiveName,
+  isTrivialValue,
+  redactVariableValue,
+  redactSecretsDeep,
+  buildRedactionNotice
+} from './utils/secret-redaction.js';
+export type { SecretRule, RedactionHit, RedactionResult } from './utils/secret-redaction.js';
 export { LineBuffer } from './utils/line-buffer.js';
 export { toSourceBreakpoint, type BreakpointFields, toFunctionBreakpoint, type FunctionBreakpointFields } from './utils/to-source-breakpoint.js';

--- a/packages/shared/src/models/index.ts
+++ b/packages/shared/src/models/index.ts
@@ -368,6 +368,8 @@ export interface SessionOutputEntry {
   timestamp: number;
   /** Present and true when the entry exceeded the per-entry size cap and was cut */
   truncated?: boolean;
+  /** Present and true when secret-shaped values were masked in this entry (issue #237) */
+  redacted?: boolean;
 }
 
 export interface DebugSessionInfo {
@@ -403,6 +405,8 @@ export interface Variable {
   expandable: boolean;
   /** Variable children (for complex objects) */
   children?: Variable[];
+  /** Present and true when the value was masked as a secret (issue #237) */
+  redacted?: boolean;
 }
 
 /**

--- a/packages/shared/src/utils/env-sanitizer.ts
+++ b/packages/shared/src/utils/env-sanitizer.ts
@@ -4,6 +4,7 @@
  * Prevents sensitive values (API keys, tokens, passwords) from leaking
  * into log files, stderr captures, or MCP tool responses.
  */
+import { SECRET_VALUE_ALTERNATION, redactSecretsInString } from './secret-redaction.js';
 
 const SENSITIVE_PATTERNS = [
   /api[_-]?key/i,
@@ -79,6 +80,11 @@ export function sanitizePayloadForLogging(payload: unknown): unknown {
 }
 
 function redactEnvDeep(value: unknown, ancestors: WeakSet<object>): unknown {
+  // Value-shape masking on string leaves (issue #237): DAP response payloads
+  // (variables/evaluate bodies) flow through here on their way to proxy debug
+  // logs and the DAP trace file, and key-name rules cannot see a secret held
+  // in a debuggee variable's *value*.
+  if (typeof value === 'string') return redactSecretsInString(value).value;
   if (!value || typeof value !== 'object') return value;
   if (ancestors.has(value)) return '[circular]';
   ancestors.add(value);
@@ -112,10 +118,11 @@ const STDERR_SENSITIVE_LINE = /(?:api[_-]?key|secret|token|password|passwd|pwd|c
 
 /**
  * Well-known secret value shapes, for secrets whose key name never appears
- * on the line: GitHub tokens (ghp_/gho_/... and github_pat_), sk- API keys,
- * Slack xox tokens, AWS access key ids, JWTs, PEM private key headers.
+ * on the line. Derived from the secret-redaction rule table (issue #237) so
+ * the line-scoped stderr sanitizer and the per-token tool-result redactor
+ * share one corpus and cannot drift apart.
  */
-const STDERR_SENSITIVE_VALUE = /\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{10,}\.eyJ)|-----BEGIN[A-Z ]*PRIVATE KEY-----/;
+const STDERR_SENSITIVE_VALUE = SECRET_VALUE_ALTERNATION;
 
 /**
  * Sanitize stderr lines to redact any that appear to contain sensitive env var assignments.

--- a/packages/shared/src/utils/secret-redaction.ts
+++ b/packages/shared/src/utils/secret-redaction.ts
@@ -1,0 +1,374 @@
+/**
+ * Secret redaction for debugger tool results (issue #237).
+ *
+ * Debuggers see everything in scope — including credentials. When the
+ * debugging driver is an AI agent, variable values flow into model context
+ * and transcripts, so credential-shaped values are masked before they leave
+ * the server. Unlike the whole-line stderr sanitizer (env-sanitizer.ts),
+ * replacement here is per-token and labeled (`<redacted:github-pat>`), so
+ * the surrounding value stays legible and the agent can tell what was
+ * withheld and why.
+ *
+ * Pattern provenance: value shapes adapted from the gitleaks default config
+ * (https://github.com/gitleaks/gitleaks, MIT license) and this project's
+ * pre-existing stderr corpus (issues #146/#153). The name-set + trivial-value
+ * design is adapted from microsoft/DebugMCP's secretRedaction module (MIT).
+ *
+ * Engine rules:
+ * - Every rule carries lowercase literal keyword anchors; its regex only runs
+ *   when an anchor is present in the text (gitleaks' pre-filter technique).
+ * - Patterns use literal prefixes and bounded character-class tails — no
+ *   unbounded wildcards, no backtracking hazards on untrusted input.
+ * - No trailing word boundaries: tails may butt up against arbitrary text and
+ *   a prefix over-match is safer than a miss (matches the stderr corpus
+ *   behavior the property tests pin).
+ * - Known limitation: values split across chunks (e.g. a secret straddling
+ *   two DAP output events) cannot be matched — same class of limitation as
+ *   the line-scoped stderr sanitizer.
+ */
+
+export interface SecretRule {
+  /** Stable rule id; becomes the placeholder label (`<redacted:${id}>`). */
+  id: string;
+  /** Lowercase literal anchors; the regex only runs if one is present. */
+  keywords: string[];
+  /** Bounded, non-backtracking pattern with the 'g' flag. */
+  pattern: RegExp;
+  /**
+   * When set, only this capture group is replaced; groups 1..maskGroup-1 are
+   * kept verbatim as the prefix (rules must shape their groups accordingly).
+   */
+  maskGroup?: number;
+  /** Provenance note (e.g. the gitleaks rule this was adapted from). */
+  note?: string;
+}
+
+export interface RedactionHit {
+  ruleId: string;
+  count: number;
+}
+
+export interface RedactionResult {
+  value: string;
+  hits: RedactionHit[];
+  redacted: boolean;
+}
+
+/**
+ * v1 value-shape corpus. Deliberately excluded: AWS secret access keys by
+ * shape (40 base64 chars — pure false-positive machine; the sensitive-name
+ * set covers them), standalone entropy detection (industry practice is
+ * entropy as per-rule confirmation only), and long-tail providers
+ * (Twilio/Heroku/Databricks/… — add on demand).
+ */
+export const SECRET_VALUE_RULES: readonly SecretRule[] = [
+  {
+    id: 'pem-private-key',
+    keywords: ['-----begin'],
+    // Body class excludes '-' so a greedy body always stops at the END
+    // delimiter; '\\' catches JSON-escaped newlines (GCP service accounts).
+    // Header alone still matches (stderr corpus compatibility).
+    pattern: /-----BEGIN[A-Z ]{0,32}PRIVATE KEY(?: BLOCK)?-----[A-Za-z0-9+/=\\\s]{0,8192}(?:-----END[A-Z ]{0,32}PRIVATE KEY(?: BLOCK)?-----)?/g,
+    note: 'gitleaks: private-key'
+  },
+  {
+    id: 'github-pat',
+    keywords: ['ghp_', 'gho_', 'ghu_', 'ghs_', 'ghr_'],
+    pattern: /\bgh[pousr]_[A-Za-z0-9]{20,255}/g,
+    note: 'gitleaks: github-pat/github-oauth/github-app-token/github-refresh-token'
+  },
+  {
+    id: 'github-fine-grained-pat',
+    keywords: ['github_pat_'],
+    pattern: /\bgithub_pat_[A-Za-z0-9_]{20,255}/g,
+    note: 'gitleaks: github-fine-grained-pat'
+  },
+  {
+    id: 'gitlab-pat',
+    keywords: ['glpat-'],
+    pattern: /\bglpat-[A-Za-z0-9_-]{20,50}/g,
+    note: 'gitleaks: gitlab-pat'
+  },
+  {
+    id: 'npm-token',
+    keywords: ['npm_'],
+    pattern: /\bnpm_[A-Za-z0-9]{36}/g,
+    note: 'gitleaks: npm-access-token'
+  },
+  {
+    id: 'pypi-token',
+    keywords: ['pypi-'],
+    pattern: /\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{20,1000}/g,
+    note: 'gitleaks: pypi-upload-token'
+  },
+  {
+    id: 'huggingface-token',
+    keywords: ['hf_'],
+    pattern: /\bhf_[A-Za-z0-9]{30,40}/g,
+    note: 'gitleaks: huggingface-access-token'
+  },
+  {
+    id: 'openai-style-key',
+    keywords: ['sk-'],
+    pattern: /\bsk-[A-Za-z0-9_-]{20,255}/g,
+    note: 'covers OpenAI (sk-, sk-proj-) and Anthropic (sk-ant-) key shapes'
+  },
+  {
+    id: 'stripe-key',
+    keywords: ['sk_live_', 'sk_test_', 'rk_live_', 'rk_test_', 'pk_live_', 'pk_test_'],
+    pattern: /\b[srp]k_(?:live|test)_[A-Za-z0-9]{10,99}/g,
+    note: 'gitleaks: stripe-access-token'
+  },
+  {
+    id: 'slack-token',
+    keywords: ['xox'],
+    pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,250}/g,
+    note: 'gitleaks: slack-*-token'
+  },
+  {
+    id: 'sendgrid-key',
+    keywords: ['sg.'],
+    pattern: /\bSG\.[A-Za-z0-9_-]{16,64}\.[A-Za-z0-9_-]{16,64}/g,
+    note: 'gitleaks: sendgrid-api-token'
+  },
+  {
+    id: 'google-api-key',
+    keywords: ['aiza'],
+    pattern: /\bAIza[0-9A-Za-z_-]{35}/g,
+    note: 'gitleaks: gcp-api-key'
+  },
+  {
+    id: 'aws-access-key-id',
+    keywords: ['akia', 'asia', 'abia', 'acca'],
+    pattern: /\b(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}/g,
+    note: 'gitleaks: aws-access-token'
+  },
+  {
+    id: 'jwt',
+    keywords: ['eyj'],
+    pattern: /\beyJ[A-Za-z0-9_-]{10,2048}\.eyJ[A-Za-z0-9_-]{10,2048}(?:\.[A-Za-z0-9_-]{10,2048})?/g,
+    note: 'gitleaks: jwt (eyJ = base64url \'{"\')'
+  },
+  {
+    id: 'bearer-token',
+    keywords: ['bearer'],
+    // [ \t] (not \s) so the token must sit on the same line as the scheme.
+    pattern: /\b([Bb]earer[ \t]+)([A-Za-z0-9._~+/=-]{16,512})/g,
+    maskGroup: 2,
+    note: 'RFC 6750 bearer credentials; ordered after jwt so raw JWTs keep the jwt label'
+  },
+  {
+    id: 'connection-string-password',
+    keywords: ['password', 'pwd'],
+    pattern: /\b((?:[Pp]assword|PASSWORD|[Pp]wd|PWD)\s*=\s*)([^;'"\s]{4,256})/g,
+    maskGroup: 2,
+    note: 'ADO/ODBC/JDBC connection strings'
+  },
+  {
+    id: 'url-basic-auth',
+    keywords: ['://'],
+    pattern: /\b([a-z][a-z0-9+.-]{1,12}:\/\/[^/\s:@]{1,64}:)([^@/\s]{3,256})(?=@)/g,
+    maskGroup: 2,
+    note: 'URL userinfo password (scheme://user:password@host)'
+  }
+];
+
+/**
+ * OR of every rule pattern, flagless (safe for repeated .test() calls).
+ * env-sanitizer derives its line-scoped value check from this, so the two
+ * sanitizers share one corpus.
+ */
+export const SECRET_VALUE_ALTERNATION: RegExp = new RegExp(
+  SECRET_VALUE_RULES.map(rule => `(?:${rule.pattern.source})`).join('|')
+);
+
+/**
+ * Variable names whose values are masked outright (when non-trivial).
+ * Normalized exact match — lowercase, non-alphanumerics stripped — NOT
+ * substring: `tokenCount`, `PATH`, `patience` must stay debuggable. This is
+ * deliberately stricter than env-sanitizer's substring key patterns: env-key
+ * logging can afford aggressive matching, live variable inspection cannot.
+ * Adapted from microsoft/DebugMCP (MIT).
+ */
+const SENSITIVE_NAME_SET = new Set([
+  'apikey', 'apisecret', 'apitoken', 'accesskey', 'accesstoken', 'authtoken',
+  'auth', 'authorization', 'authheader', 'bearertoken', 'clientsecret',
+  'appsecret', 'connectionstring', 'connstr', 'credential', 'credentials',
+  'dbpassword', 'encryptionkey', 'githubtoken', 'githubpat', 'gitlabtoken',
+  'idtoken', 'masterkey', 'oauthtoken', 'passphrase', 'passwd', 'password',
+  'pat', 'privatekey', 'pwd', 'refreshtoken', 'secret', 'secretkey',
+  'sessiontoken', 'signingkey', 'slacktoken', 'token', 'awsaccesskeyid',
+  'awssecretaccesskey', 'awssessiontoken'
+]);
+
+const SENSITIVE_NAME_RULE_ID = 'sensitive-name';
+
+/**
+ * Values never worth masking, so `password = None` stays debuggable ("why is
+ * my token empty?" is a real debugging session). Checked after stripping one
+ * layer of matching quotes (debugger reprs arrive quoted).
+ */
+const TRIVIAL_VALUES = new Set([
+  'none', 'null', 'nil', 'undefined', 'true', 'false', '0', '1', '', '...',
+  '<optimized out>', '<unavailable>'
+]);
+
+const WHOLE_PLACEHOLDER = /^<redacted:[a-z0-9-]+>$/;
+
+const ALL_KEYWORDS: readonly string[] = [...new Set(SECRET_VALUE_RULES.flatMap(rule => rule.keywords))];
+
+function placeholderFor(ruleId: string): string {
+  return `<redacted:${ruleId}>`;
+}
+
+/**
+ * Mask every well-known secret shape in `text`, replacing only the matched
+ * token (or its secret capture group) with a labeled placeholder. Returns the
+ * original string untouched (`redacted: false`) when nothing matched.
+ */
+export function redactSecretsInString(text: string): RedactionResult {
+  if (!text) {
+    return { value: text, hits: [], redacted: false };
+  }
+  let lower = text.toLowerCase();
+  if (!ALL_KEYWORDS.some(keyword => lower.includes(keyword))) {
+    return { value: text, hits: [], redacted: false };
+  }
+
+  let current = text;
+  const hits: RedactionHit[] = [];
+  for (const rule of SECRET_VALUE_RULES) {
+    if (!rule.keywords.some(keyword => lower.includes(keyword))) {
+      continue;
+    }
+    let count = 0;
+    const replaced = current.replace(rule.pattern, (...args: unknown[]) => {
+      count++;
+      if (rule.maskGroup === undefined) {
+        return placeholderFor(rule.id);
+      }
+      const kept = (args.slice(1, rule.maskGroup) as Array<string | undefined>)
+        .filter((group): group is string => group !== undefined)
+        .join('');
+      return kept + placeholderFor(rule.id);
+    });
+    if (count > 0) {
+      current = replaced;
+      lower = current.toLowerCase();
+      hits.push({ ruleId: rule.id, count });
+    }
+  }
+  return { value: current, hits, redacted: hits.length > 0 };
+}
+
+/** Exact-match (normalized) check of a variable/property name. */
+export function isSensitiveName(name: string): boolean {
+  const normalized = name.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return SENSITIVE_NAME_SET.has(normalized);
+}
+
+/** True for values not worth masking even under a sensitive name. */
+export function isTrivialValue(value: string): boolean {
+  let inner = value.trim();
+  const quoted = /^(['"])([\s\S]*)\1$/.exec(inner);
+  if (quoted) {
+    inner = quoted[2];
+  }
+  return inner.length <= 4 || TRIVIAL_VALUES.has(inner.toLowerCase());
+}
+
+/**
+ * Redact a single variable's value: value-shape pass always; then, when the
+ * variable *name* is sensitive and the value is non-trivial (and not already
+ * masked in full), the entire value is replaced — names like `password`
+ * signal a secret regardless of its shape.
+ */
+export function redactVariableValue(name: string, value: string): RedactionResult {
+  const shape = redactSecretsInString(value);
+  if (
+    isSensitiveName(name) &&
+    !isTrivialValue(value) &&
+    !WHOLE_PLACEHOLDER.test(shape.value.trim())
+  ) {
+    return {
+      value: placeholderFor(SENSITIVE_NAME_RULE_ID),
+      hits: [{ ruleId: SENSITIVE_NAME_RULE_ID, count: 1 }],
+      redacted: true
+    };
+  }
+  return shape;
+}
+
+/**
+ * Assign an own enumerable property even for exotic key names ('__proto__'
+ * would otherwise hit the prototype setter and vanish) — same guard as
+ * env-sanitizer, duplicated here because env-sanitizer imports this module.
+ */
+function setOwnProperty(target: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true });
+}
+
+/**
+ * Value-shape pass over every string leaf of a payload (for raw DAP bodies
+ * headed to logs). Never mutates the input; cycles become '[circular]'.
+ */
+export function redactSecretsDeep<T>(payload: T): { value: T; hits: RedactionHit[] } {
+  const totals = new Map<string, number>();
+  const value = redactDeep(payload, new WeakSet(), totals) as T;
+  const hits = [...totals.entries()].map(([ruleId, count]) => ({ ruleId, count }));
+  return { value, hits };
+}
+
+function redactDeep(value: unknown, ancestors: WeakSet<object>, totals: Map<string, number>): unknown {
+  if (typeof value === 'string') {
+    const result = redactSecretsInString(value);
+    for (const hit of result.hits) {
+      totals.set(hit.ruleId, (totals.get(hit.ruleId) ?? 0) + hit.count);
+    }
+    return result.value;
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (ancestors.has(value)) {
+    return '[circular]';
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map(item => redactDeep(item, ancestors, totals));
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      setOwnProperty(out, key, redactDeep(entry, ancestors, totals));
+    }
+    return out;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+/**
+ * Generic notice for tool results whose items carry only `redacted` flags
+ * (per-rule hit details are not retained past the masking point).
+ */
+export const REDACTION_NOTICE =
+  'Values shown as <redacted:…> were masked because they matched known secret patterns ' +
+  "or sensitive variable names. The program's real state is unchanged — placeholders are " +
+  'display-only. Redaction is on by default; restart the server with DEBUG_MCP_NO_REDACT=1 ' +
+  'to disable it.';
+
+/**
+ * One-line notice for tool results, telling the agent what was masked, that
+ * the program state is unchanged, and how the user can opt out.
+ */
+export function buildRedactionNotice(hits: RedactionHit[]): string {
+  const total = hits.reduce((sum, hit) => sum + hit.count, 0);
+  const rules = hits.map(hit => hit.ruleId).join(', ');
+  return (
+    `${total} value(s) masked as <redacted:…> because they matched known secret patterns ` +
+    `or sensitive variable names (rules: ${rules}). The program's real state is unchanged — ` +
+    `placeholders are display-only. Redaction is on by default; restart the server with ` +
+    `DEBUG_MCP_NO_REDACT=1 to disable it.`
+  );
+}

--- a/packages/shared/tests/unit/env-sanitizer.property.test.ts
+++ b/packages/shared/tests/unit/env-sanitizer.property.test.ts
@@ -16,47 +16,15 @@ import {
   sanitizeStderrTail
 } from '../../src/utils/env-sanitizer.js';
 
+import {
+  ALNUM,
+  UPPER,
+  stringOf,
+  filler,
+  mixedLines
+} from './helpers/secret-arbitraries.js';
+
 const REDACTED_LINE = '[REDACTED — line contained sensitive data]';
-
-const ALNUM = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-const charFrom = (chars: string) => fc.constantFrom(...chars.split(''));
-const stringOf = (chars: string, minLength: number, maxLength: number) =>
-  fc.string({ unit: charFrom(chars), minLength, maxLength });
-
-/** Well-known secret value shapes (mirrors STDERR_SENSITIVE_VALUE coverage). */
-const secretValue = fc.oneof(
-  fc.tuple(fc.constantFrom('ghp_', 'gho_', 'ghu_', 'ghs_', 'ghr_'), stringOf(ALNUM, 20, 40))
-    .map(([prefix, rest]) => prefix + rest),
-  stringOf(ALNUM + '_', 20, 40).map(rest => `github_pat_${rest}`),
-  stringOf(ALNUM + '_-', 20, 40).map(rest => `sk-${rest}`),
-  fc.tuple(fc.constantFrom('xoxb-', 'xoxa-', 'xoxp-', 'xoxr-', 'xoxs-'), stringOf(ALNUM + '-', 10, 30))
-    .map(([prefix, rest]) => prefix + rest),
-  stringOf('0123456789' + UPPER, 16, 16).map(rest => `AKIA${rest}`),
-  fc.constant('-----BEGIN RSA PRIVATE KEY-----'),
-  fc.constant('-----BEGIN PRIVATE KEY-----')
-);
-
-/** Newline-free filler that cannot span lines. May coincidentally look sensitive — that's fine. */
-const filler = fc.string({ unit: charFrom(ALNUM + ' .,()[]/'), maxLength: 20 });
-
-/**
- * A line embedding a secret. The prefix always ends at a word boundary
- * (space, '=', ':' or nothing), matching how secrets actually appear in
- * stderr: bare, or as `SOME_KEY=<secret>` assignments.
- */
-const lineWithSecret = fc
-  .tuple(
-    fc.oneof(fc.constant(''), filler.map(s => `${s} `), filler.map(s => `${s}=`), filler.map(s => `${s}:`)),
-    secretValue,
-    filler
-  )
-  .map(([prefix, secret, suffix]) => ({ line: prefix + secret + suffix, secret: secret as string | null }));
-
-const benignLine = filler.map(line => ({ line, secret: null as string | null }));
-
-const mixedLines = fc.array(fc.oneof(benignLine, lineWithSecret), { maxLength: 15 });
 
 describe('sanitizeStderr properties', () => {
   it('preserves line count and only ever substitutes the redaction marker', () => {

--- a/packages/shared/tests/unit/env-sanitizer.test.ts
+++ b/packages/shared/tests/unit/env-sanitizer.test.ts
@@ -205,6 +205,22 @@ describe('sanitizePayloadForLogging', () => {
     expect(result.token).toBe(42);
     expect(result.nested.token).toEqual({ kind: 'parser-token' });
   });
+
+  it('masks secret-shaped string values at any depth (issue #237 — DAP variable bodies in proxy logs)', () => {
+    const payload = {
+      type: 'dapResponse',
+      body: {
+        variables: [
+          { name: 'gh_token', value: "'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123'" },
+          { name: 'count', value: '42' }
+        ]
+      }
+    };
+    const result = sanitizePayloadForLogging(payload) as any;
+    expect(result.body.variables[0].value).toBe("'<redacted:github-pat>'");
+    expect(result.body.variables[1].value).toBe('42');
+    expect(JSON.stringify(result)).not.toContain('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123');
+  });
 });
 
 describe('sanitizeStderr', () => {
@@ -255,6 +271,23 @@ describe('sanitizeStderr', () => {
 
   it('handles empty array', () => {
     expect(sanitizeStderr([])).toEqual([]);
+  });
+
+  it('redacts lines containing #237 corpus shapes (value regex derived from secret-redaction)', () => {
+    // Tokens are concatenated so GitHub push protection doesn't flag the
+    // fixtures as live keys.
+    const lines = [
+      'google key AIza' + 'SyA1234567890abcdefghijklmnopqrstuv',
+      'gitlab token glpat-' + 'ABCDEFGHIJKLMNOPQRST',
+      'hf_' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh loaded',
+      'published with npm_' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+      'stripe sk_live_' + '4eC39HqLyjWDarjtT1zdp7dc',
+      'db at postgres://admin:s3cretpw@db.example.com:5432/app'
+    ];
+    const result = sanitizeStderr(lines);
+    for (const line of result) {
+      expect(line).toBe('[REDACTED — line contained sensitive data]');
+    }
   });
 });
 

--- a/packages/shared/tests/unit/helpers/secret-arbitraries.ts
+++ b/packages/shared/tests/unit/helpers/secret-arbitraries.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared fast-check arbitraries for secret-shaped values.
+ *
+ * Single source for the generated token corpus, used by both sanitizer
+ * property suites (env-sanitizer.property.test.ts and
+ * secret-redaction.property.test.ts) so the two cannot drift apart:
+ * the stderr sanitizer derives its value regex from the redaction rule
+ * table, and these arbitraries generate against that same table.
+ */
+import fc from 'fast-check';
+
+export const ALNUM = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+export const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+export const charFrom = (chars: string) => fc.constantFrom(...chars.split(''));
+export const stringOf = (chars: string, minLength: number, maxLength: number) =>
+  fc.string({ unit: charFrom(chars), minLength, maxLength });
+
+/** PEM private-key headers — multi-line blocks whose greedy body match may
+ * absorb adjacent base64-ish text, so they are kept out of the token-shaped
+ * arbitraries used for byte-identity properties. */
+export const pemSecretValue = fc.constantFrom(
+  '-----BEGIN RSA PRIVATE KEY-----',
+  '-----BEGIN PRIVATE KEY-----'
+);
+
+/** Token shapes of the pre-#237 stderr corpus (mirrors the legacy
+ * STDERR_SENSITIVE_VALUE coverage, minus PEM). */
+export const legacyTokenSecretValue = fc.oneof(
+  fc.tuple(fc.constantFrom('ghp_', 'gho_', 'ghu_', 'ghs_', 'ghr_'), stringOf(ALNUM, 20, 40))
+    .map(([prefix, rest]) => prefix + rest),
+  stringOf(ALNUM + '_', 20, 40).map(rest => `github_pat_${rest}`),
+  stringOf(ALNUM + '_-', 20, 40).map(rest => `sk-${rest}`),
+  fc.tuple(fc.constantFrom('xoxb-', 'xoxa-', 'xoxp-', 'xoxr-', 'xoxs-'), stringOf(ALNUM + '-', 10, 30))
+    .map(([prefix, rest]) => prefix + rest),
+  stringOf('0123456789' + UPPER, 16, 16).map(rest => `AKIA${rest}`)
+);
+
+/** Well-known secret value shapes of the original stderr corpus. */
+export const secretValue = fc.oneof(legacyTokenSecretValue, pemSecretValue);
+
+/** Token shapes added by the #237 redaction corpus (secret-redaction.ts). */
+export const extendedTokenSecretValue = fc.oneof(
+  stringOf(ALNUM + '_-', 35, 35).map(rest => `AIza${rest}`),
+  fc.tuple(
+    fc.constantFrom('sk_live_', 'sk_test_', 'rk_live_', 'rk_test_', 'pk_live_', 'pk_test_'),
+    stringOf(ALNUM, 10, 40)
+  ).map(([prefix, rest]) => prefix + rest),
+  stringOf(ALNUM, 36, 36).map(rest => `npm_${rest}`),
+  stringOf(ALNUM + '_-', 20, 50).map(rest => `glpat-${rest}`),
+  stringOf(ALNUM, 30, 40).map(rest => `hf_${rest}`),
+  stringOf(ALNUM + '_-', 20, 40).map(rest => `pypi-AgEIcHlwaS5vcmc${rest}`),
+  fc.tuple(stringOf(ALNUM + '_-', 16, 64), stringOf(ALNUM + '_-', 16, 64))
+    .map(([a, b]) => `SG.${a}.${b}`),
+  fc.tuple(stringOf(ALNUM + '_-', 10, 30), stringOf(ALNUM + '_-', 10, 30), stringOf(ALNUM + '_-', 10, 30))
+    .map(([h, p, s]) => `eyJ${h}.eyJ${p}.${s}`)
+);
+
+/** Every token-shaped secret (safe for byte-identity assertions). */
+export const tokenSecretValue = fc.oneof(legacyTokenSecretValue, extendedTokenSecretValue);
+
+/** The whole corpus, PEM included. */
+export const anySecretValue = fc.oneof(tokenSecretValue, pemSecretValue);
+
+/** Newline-free filler that cannot span lines. May coincidentally look sensitive — that's fine. */
+export const filler = fc.string({ unit: charFrom(ALNUM + ' .,()[]/'), maxLength: 20 });
+
+/**
+ * A line embedding a secret from the whole corpus (legacy + #237 shapes).
+ * The prefix always ends at a word boundary (space, '=', ':' or nothing),
+ * matching how secrets actually appear in stderr: bare, or as
+ * `SOME_KEY=<secret>` assignments.
+ */
+export const lineWithSecret = fc
+  .tuple(
+    fc.oneof(fc.constant(''), filler.map(s => `${s} `), filler.map(s => `${s}=`), filler.map(s => `${s}:`)),
+    anySecretValue,
+    filler
+  )
+  .map(([prefix, secret, suffix]) => ({ line: prefix + secret + suffix, secret: secret as string | null }));
+
+export const benignLine = filler.map(line => ({ line, secret: null as string | null }));
+
+export const mixedLines = fc.array(fc.oneof(benignLine, lineWithSecret), { maxLength: 15 });

--- a/packages/shared/tests/unit/secret-redaction.property.test.ts
+++ b/packages/shared/tests/unit/secret-redaction.property.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Property-based tests (fast-check) for secret-redaction.ts (issue #237).
+ *
+ * Example tests pin known tokens; these properties assert the invariants for
+ * *generated* secrets across the whole corpus: every secret shape triggers
+ * redaction and never survives, masking is context-independent (surrounding
+ * text is untouched), idempotent, and the deep variant preserves structure
+ * without mutating its input.
+ */
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  redactSecretsInString,
+  redactSecretsDeep,
+  redactVariableValue,
+  isTrivialValue
+} from '../../src/utils/secret-redaction.js';
+import { tokenSecretValue, anySecretValue, filler } from './helpers/secret-arbitraries.js';
+
+/**
+ * Lowercase-only filler: cannot coincidentally form the uppercase-anchored
+ * shapes (AKIA…, AIza…, SG., eyJ…) that the mixed-case `filler` could, so it
+ * is safe for exact byte-identity assertions.
+ */
+const safeFiller = fc.string({
+  unit: fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789 .,()'.split('')),
+  maxLength: 20
+});
+
+describe('redactSecretsInString properties', () => {
+  it('every generated secret triggers redaction and never survives, in any embedding', () => {
+    fc.assert(
+      fc.property(anySecretValue, filler, filler, (secret, pre, suf) => {
+        for (const text of [secret, `${pre} ${secret} ${suf}`, `${pre}=${secret}${suf}`]) {
+          const result = redactSecretsInString(text);
+          expect(result.redacted).toBe(true);
+          expect(result.value).not.toContain(secret);
+          expect(result.hits.length).toBeGreaterThan(0);
+        }
+      })
+    );
+  });
+
+  it('masking is context-independent: redacting an embedded token equals embedding the redacted token', () => {
+    fc.assert(
+      fc.property(tokenSecretValue, safeFiller, safeFiller, (secret, pre, suf) => {
+        const alone = redactSecretsInString(secret);
+        const embedded = redactSecretsInString(`${pre} ${secret} ${suf}`);
+        expect(embedded.value).toBe(`${pre} ${alone.value} ${suf}`);
+      })
+    );
+  });
+
+  it('is idempotent for every corpus shape', () => {
+    fc.assert(
+      fc.property(anySecretValue, filler, filler, (secret, pre, suf) => {
+        const once = redactSecretsInString(`${pre} ${secret} ${suf}`);
+        const twice = redactSecretsInString(once.value);
+        expect(twice.value).toBe(once.value);
+      })
+    );
+  });
+});
+
+describe('redactVariableValue properties', () => {
+  const sensitiveName = fc.constantFrom(
+    'password', 'apiKey', 'client_secret', 'TOKEN', 'AWS_SECRET_ACCESS_KEY', 'connectionString'
+  );
+
+  it('non-trivial values of sensitive names never survive', () => {
+    fc.assert(
+      fc.property(sensitiveName, fc.string({ minLength: 5, maxLength: 60 }), (name, value) => {
+        fc.pre(!isTrivialValue(value));
+        const result = redactVariableValue(name, value);
+        expect(result.redacted).toBe(true);
+        expect(result.value).not.toContain(value);
+      })
+    );
+  });
+});
+
+describe('redactSecretsDeep properties', () => {
+  it('preserves structure, redacts every string leaf, and never mutates its input', () => {
+    fc.assert(
+      fc.property(tokenSecretValue, safeFiller, (secret, note) => {
+        const payload = {
+          command: 'variables',
+          a: `${note} ${secret}`,
+          b: [secret, 42, null, { nested: secret }],
+          c: { d: note }
+        };
+        const snapshot = JSON.parse(JSON.stringify(payload));
+
+        const { value, hits } = redactSecretsDeep(payload);
+
+        expect(payload).toEqual(snapshot);
+        expect(JSON.stringify(value)).not.toContain(secret);
+        expect(hits.length).toBeGreaterThan(0);
+        const out = value as typeof payload;
+        expect(out.command).toBe('variables');
+        expect(out.b[1]).toBe(42);
+        expect(out.b[2]).toBe(null);
+        expect(out.c.d).toBe(note);
+      })
+    );
+  });
+});

--- a/packages/shared/tests/unit/secret-redaction.test.ts
+++ b/packages/shared/tests/unit/secret-redaction.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Unit tests for secret-redaction.ts (issue #237).
+ *
+ * The redaction engine masks credential-shaped values in debugger tool
+ * results (get_variables, evaluate_expression, output capture) before they
+ * reach the AI agent. Unlike the whole-line stderr sanitizer, replacement is
+ * per-token and labeled, so the surrounding value stays legible.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  SECRET_VALUE_RULES,
+  SECRET_VALUE_ALTERNATION,
+  redactSecretsInString,
+  isSensitiveName,
+  isTrivialValue,
+  redactVariableValue,
+  redactSecretsDeep,
+  buildRedactionNotice
+} from '../../src/utils/secret-redaction.js';
+
+const mask = (id: string) => `<redacted:${id}>`;
+
+/**
+ * One realistic dummy token per whole-match rule. maskGroup rules (bearer,
+ * connection strings, URL userinfo) and the multi-line PEM rule get
+ * dedicated tests below.
+ *
+ * Every token is built by concatenation so GitHub push protection never sees
+ * a scannable secret-shaped literal in this file's blob (it flags realistic
+ * fixtures — Stripe, Slack, Hugging Face — as real keys).
+ */
+const WHOLE_MATCH_CASES: Array<{ ruleId: string; token: string }> = [
+  { ruleId: 'github-pat', token: 'ghp_' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123' },
+  { ruleId: 'github-pat', token: 'gho_' + '0123456789abcdefghij0123456789' },
+  { ruleId: 'github-fine-grained-pat', token: 'github_pat_' + '11ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' },
+  { ruleId: 'openai-style-key', token: 'sk-' + 'proj-abcdefghijklmnopqrstuvwxyz012345' },
+  { ruleId: 'openai-style-key', token: 'sk-' + 'ant-api03-abcdefghijklmnopqrstuv' },
+  { ruleId: 'stripe-key', token: 'sk_live_' + '4eC39HqLyjWDarjtT1zdp7dc' },
+  { ruleId: 'slack-token', token: 'xoxb-' + '123456789012-abcdefghijklmnop' },
+  { ruleId: 'aws-access-key-id', token: 'AKIA' + 'IOSFODNN7EXAMPLE' },
+  { ruleId: 'aws-access-key-id', token: 'ASIA' + 'IOSFODNN7EXAMPLE' },
+  { ruleId: 'google-api-key', token: 'AIza' + 'SyA1234567890abcdefghijklmnopqrstuv' },
+  { ruleId: 'gitlab-pat', token: 'glpat-' + 'ABCDEFGHIJKLMNOPQRST' },
+  { ruleId: 'npm-token', token: 'npm_' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' },
+  { ruleId: 'pypi-token', token: 'pypi-' + 'AgEIcHlwaS5vcmcCJDAxMjM0NTY3ODkwMTIzNDU2Nzg5' },
+  { ruleId: 'huggingface-token', token: 'hf_' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh' },
+  { ruleId: 'sendgrid-key', token: 'SG.' + 'abcdefghijklmnop.qrstuvwxyz0123456789ABCDEF' },
+  { ruleId: 'jwt', token: 'eyJ' + 'hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5NxXgL0n3I9PlFUP0THsR8U' }
+];
+
+/** Values that must never be touched (over-redaction guards). */
+const BENIGN_STRINGS = [
+  'Starting debugger on port 5678',
+  'sk-only-short',                       // sk- tail below length floor
+  'ghp_short',                           // gh*_ tail below length floor
+  'AKIATOOSHORT',                        // AKIA but not 16 uppercase/digits
+  'tokenCount = 42',
+  'PATH=/usr/bin:/usr/local/bin',
+  'https://example.com/path?query=1',    // URL without userinfo
+  'Bearer of bad news',                  // bearer followed by short words
+  'the task-abcdefghijklmnopqrstuvwxyz item' // 'sk-' inside 'task-' must not anchor
+];
+
+describe('redactSecretsInString', () => {
+  it.each(WHOLE_MATCH_CASES)('masks $ruleId token as a labeled placeholder', ({ ruleId, token }) => {
+    const input = `The value is ${token} right here.`;
+    const result = redactSecretsInString(input);
+    expect(result.value).toBe(`The value is ${mask(ruleId)} right here.`);
+    expect(result.redacted).toBe(true);
+    expect(result.hits).toEqual([{ ruleId, count: 1 }]);
+  });
+
+  it('masks PEM private key blocks including body and END line', () => {
+    const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA7bq0\nqqB4kp1Z\n-----END RSA PRIVATE KEY-----';
+    const result = redactSecretsInString(`cert: ${pem} (loaded)`);
+    expect(result.value).toBe(`cert: ${mask('pem-private-key')} (loaded)`);
+    expect(result.hits).toEqual([{ ruleId: 'pem-private-key', count: 1 }]);
+  });
+
+  it('masks JSON-escaped PEM blocks (GCP service-account style, literal \\n)', () => {
+    const value = '{"private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvQIBADAN\\n-----END PRIVATE KEY-----\\n"}';
+    const result = redactSecretsInString(value);
+    expect(result.value).not.toContain('MIIEvQIBADAN');
+    expect(result.value).toContain(mask('pem-private-key'));
+    expect(result.value).toContain('"private_key"');
+  });
+
+  it('masks a bare PEM header even without a body (stderr corpus compatibility)', () => {
+    const result = redactSecretsInString('-----BEGIN RSA PRIVATE KEY-----');
+    expect(result.value).toBe(mask('pem-private-key'));
+  });
+
+  it('masks only the token after "Bearer", keeping the scheme word', () => {
+    const result = redactSecretsInString('Authorization: Bearer abc123def456ghi789jkl');
+    expect(result.value).toBe(`Authorization: Bearer ${mask('bearer-token')}`);
+    expect(result.hits).toEqual([{ ruleId: 'bearer-token', count: 1 }]);
+  });
+
+  it('masks only the password in connection strings, keeping the key and other pairs', () => {
+    const result = redactSecretsInString('Server=db;User Id=sa;Password=Sup3rS3cret!;Encrypt=true');
+    expect(result.value).toBe(`Server=db;User Id=sa;Password=${mask('connection-string-password')};Encrypt=true`);
+    expect(result.hits).toEqual([{ ruleId: 'connection-string-password', count: 1 }]);
+  });
+
+  it('masks only the password in URL userinfo, keeping scheme, user and host', () => {
+    const result = redactSecretsInString('postgres://admin:s3cretpw@db.example.com:5432/app');
+    expect(result.value).toBe(`postgres://admin:${mask('url-basic-auth')}@db.example.com:5432/app`);
+    expect(result.hits).toEqual([{ ruleId: 'url-basic-auth', count: 1 }]);
+  });
+
+  it.each(BENIGN_STRINGS.map(s => [s]))('leaves benign string untouched: %s', (input) => {
+    const result = redactSecretsInString(input);
+    expect(result.value).toBe(input);
+    expect(result.redacted).toBe(false);
+    expect(result.hits).toEqual([]);
+  });
+
+  it('returns empty input unchanged', () => {
+    const result = redactSecretsInString('');
+    expect(result.value).toBe('');
+    expect(result.redacted).toBe(false);
+  });
+
+  it('aggregates repeated matches of one rule into a single hit with a count', () => {
+    const a = 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123';
+    const b = 'ghp_0123456789abcdefghijklmnopqrstuv0123';
+    const result = redactSecretsInString(`first ${a} second ${b}`);
+    expect(result.value).toBe(`first ${mask('github-pat')} second ${mask('github-pat')}`);
+    expect(result.hits).toEqual([{ ruleId: 'github-pat', count: 2 }]);
+  });
+
+  it('reports one hit entry per distinct rule', () => {
+    const result = redactSecretsInString(
+      "env = {'GITHUB_PAT': 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123', 'AWS_ACCESS_KEY_ID': 'AKIAIOSFODNN7EXAMPLE'}"
+    );
+    expect(result.value).toContain(mask('github-pat'));
+    expect(result.value).toContain(mask('aws-access-key-id'));
+    expect(result.value).toContain("'GITHUB_PAT'"); // dict keys survive
+    expect(result.hits).toHaveLength(2);
+  });
+
+  it('does not re-trigger on its own placeholders (idempotence)', () => {
+    const placeholder = `value ${mask('github-pat')} tail`;
+    const result = redactSecretsInString(placeholder);
+    expect(result.value).toBe(placeholder);
+    expect(result.redacted).toBe(false);
+  });
+
+  it.each(WHOLE_MATCH_CASES)('is idempotent for $ruleId', ({ token }) => {
+    const once = redactSecretsInString(`x = '${token}'`);
+    const twice = redactSecretsInString(once.value);
+    expect(twice.value).toBe(once.value);
+  });
+});
+
+describe('isSensitiveName', () => {
+  it.each([
+    ['password'], ['PASSWORD'], ['API_KEY'], ['apiKey'], ['clientSecret'],
+    ['client_secret'], ['GITHUB_TOKEN'], ['auth_token'], ['connectionString'],
+    ['AWS_SECRET_ACCESS_KEY'], ['pat'], ['token']
+  ])('matches %s', (name) => {
+    expect(isSensitiveName(name)).toBe(true);
+  });
+
+  it.each([
+    ['tokenCount'], ['PATH'], ['PATTERN'], ['KEYBOARD'], ['MONKEY'],
+    ['patience'], ['keyboardEvent'], ['authorTag'], ['secretsManagerClient'], ['i']
+  ])('does not match %s (exact, not substring)', (name) => {
+    expect(isSensitiveName(name)).toBe(false);
+  });
+});
+
+describe('isTrivialValue', () => {
+  it.each([
+    ['None'], ['null'], ['nil'], ['undefined'], ['true'], ['False'], ['0'], ['1'],
+    [''], ['...'], ['<optimized out>'], ['<unavailable>'], ['ab'],
+    ["'None'"], ['"none"'], ["''"]
+  ])('treats %s as trivial', (value) => {
+    expect(isTrivialValue(value)).toBe(true);
+  });
+
+  it.each([['hunter2blue'], ['s3cretpw!'], ["'some real value'"]])(
+    'treats %s as non-trivial',
+    (value) => {
+      expect(isTrivialValue(value)).toBe(false);
+    }
+  );
+});
+
+describe('redactVariableValue', () => {
+  it('masks a GitHub PAT held in a variable, keeping the repr quotes (acceptance #237a)', () => {
+    const result = redactVariableValue('gh_token', "'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123'");
+    expect(result.value).toBe(`'${mask('github-pat')}'`);
+    expect(result.redacted).toBe(true);
+    expect(result.hits).toEqual([{ ruleId: 'github-pat', count: 1 }]);
+  });
+
+  it('masks secrets embedded in JSON-shaped variable values, keeping other fields', () => {
+    const result = redactVariableValue(
+      'config',
+      '{"github_token": "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123", "region": "us-east-1"}'
+    );
+    expect(result.value).toContain(mask('github-pat'));
+    expect(result.value).toContain('"region": "us-east-1"');
+  });
+
+  it('masks the whole value when the variable name is sensitive and the value is non-trivial', () => {
+    const result = redactVariableValue('password', 'hunter2blue');
+    expect(result.value).toBe(mask('sensitive-name'));
+    expect(result.hits).toEqual([{ ruleId: 'sensitive-name', count: 1 }]);
+  });
+
+  it('does not double-mask when a value-shape rule already masked the whole value', () => {
+    const result = redactVariableValue('token', 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123');
+    expect(result.value).toBe(mask('github-pat'));
+    expect(result.hits).toEqual([{ ruleId: 'github-pat', count: 1 }]);
+  });
+
+  it('leaves trivial values of sensitive names untouched (debuggability)', () => {
+    for (const value of ['None', "''", 'undefined', '0', 'null']) {
+      const result = redactVariableValue('password', value);
+      expect(result.value).toBe(value);
+      expect(result.redacted).toBe(false);
+    }
+  });
+
+  it('leaves non-sensitive names with benign values untouched', () => {
+    for (const [name, value] of [
+      ['tokenCount', '42'],
+      ['PATH', '/usr/bin:/usr/local/bin'],
+      ['patience', 'high'],
+      ['keyboardEvent', "{type: 'keydown'}"]
+    ] as const) {
+      const result = redactVariableValue(name, value);
+      expect(result.value).toBe(value);
+      expect(result.redacted).toBe(false);
+    }
+  });
+});
+
+describe('redactSecretsDeep', () => {
+  it('masks string leaves at any depth, preserves structure, and never mutates input', () => {
+    const input = {
+      command: 'variables',
+      body: {
+        variables: [
+          { name: 'gh', value: "'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123'" },
+          { name: 'n', value: 42 }
+        ]
+      },
+      tags: ['AKIAIOSFODNN7EXAMPLE', 'clean']
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    const { value, hits } = redactSecretsDeep(input);
+
+    expect(input).toEqual(snapshot); // input untouched
+    const out = value as typeof input;
+    expect(out.body.variables[0].value).toBe(`'${mask('github-pat')}'`);
+    expect(out.body.variables[1].value).toBe(42);
+    expect(out.tags[0]).toBe(mask('aws-access-key-id'));
+    expect(out.tags[1]).toBe('clean');
+    expect(out.command).toBe('variables');
+    expect(hits).toEqual(
+      expect.arrayContaining([
+        { ruleId: 'github-pat', count: 1 },
+        { ruleId: 'aws-access-key-id', count: 1 }
+      ])
+    );
+  });
+
+  it('survives circular structures without throwing', () => {
+    const payload: Record<string, unknown> = { note: 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123' };
+    payload.self = payload;
+    const { value } = redactSecretsDeep(payload);
+    expect((value as Record<string, unknown>).note).toBe(mask('github-pat'));
+  });
+});
+
+describe('buildRedactionNotice', () => {
+  it('names the rules, totals the count, and points at the opt-out flag', () => {
+    const notice = buildRedactionNotice([
+      { ruleId: 'github-pat', count: 2 },
+      { ruleId: 'sensitive-name', count: 1 }
+    ]);
+    expect(notice).toContain('3');
+    expect(notice).toContain('github-pat');
+    expect(notice).toContain('sensitive-name');
+    expect(notice).toContain('DEBUG_MCP_NO_REDACT=1');
+  });
+});
+
+describe('SECRET_VALUE_RULES / SECRET_VALUE_ALTERNATION', () => {
+  it('every rule carries at least one lowercase keyword anchor', () => {
+    expect(SECRET_VALUE_RULES.length).toBeGreaterThanOrEqual(15);
+    for (const rule of SECRET_VALUE_RULES) {
+      expect(rule.keywords.length, rule.id).toBeGreaterThan(0);
+      for (const keyword of rule.keywords) {
+        expect(keyword, rule.id).toBe(keyword.toLowerCase());
+      }
+    }
+  });
+
+  it('rule ids are unique and never themselves retrigger a rule', () => {
+    const ids = SECRET_VALUE_RULES.map(r => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(redactSecretsInString(mask(id)).redacted, id).toBe(false);
+    }
+  });
+
+  it('the derived alternation matches every corpus token and is safe to reuse (no lastIndex state)', () => {
+    for (const { token } of WHOLE_MATCH_CASES) {
+      const line = `some prefix ${token} some suffix`;
+      expect(SECRET_VALUE_ALTERNATION.test(line), token).toBe(true);
+      expect(SECRET_VALUE_ALTERNATION.test(line), `${token} (second call)`).toBe(true);
+    }
+    expect(SECRET_VALUE_ALTERNATION.test('PATH=/usr/bin')).toBe(false);
+  });
+});

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -40,6 +40,7 @@ Rules that prevent 90% of failed sessions:
 - **Expand variable containers.** If a variable entry carries a `variablesReference`, call `get_variables` again with that reference to see children (Python's "special variables", object fields, array elements).
 - **Respect session state.** Stepping, evaluation, and variable reads require `PAUSED`. After `continue_execution` the session is `RUNNING`; after a step or breakpoint hit it returns to `PAUSED` with a persisted stop reason telling you why it stopped (`breakpoint`, `step`, `entry`, `exception`, ...).
 - **Breakpoints may verify late.** Some adapters (debugpy, JDI) report breakpoints unverified until the module/class loads; that is normal, not an error.
+- **`<redacted:...>` placeholders are masking, not program state.** Credential-shaped values and values of sensitive variable names (`password`, `api_key`, ...) are masked by default in variable/evaluate/output results; a `redaction` field reports what was hidden. The real value is intact in the debuggee — don't "fix" it, and don't retry the read. The user can disable masking by restarting the server with `DEBUG_MCP_NO_REDACT=1`.
 - **Always `close_debug_session`** when done — it tears down the debuggee process tree.
 
 ## Root-cause discipline

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,8 @@ import {
     FunctionBreakpoint,
     SessionLifecycleState,
     IEnvironment,
-    ExceptionBreakMode
+    ExceptionBreakMode,
+    REDACTION_NOTICE
 } from '@debugmcp/shared';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import path from 'path';
@@ -51,6 +52,7 @@ import {
   supportsStatementAnchors,
   supportsLoudSnapping
 } from './utils/bp-addressing.js';
+import { isRedactionEnabled } from './utils/redaction-mode.js';
 import { assertLineContent, resolveStatement } from './utils/breakpoint-resolver.js';
 
 const DEFAULT_LANGUAGES = Object.freeze([DebugLanguage.PYTHON, DebugLanguage.MOCK] as const);
@@ -876,7 +878,11 @@ export class DebugMcpServer {
         capabilities: { tools: {}, resources: { subscribe: true, listChanged: true }, prompts: {} },
         // Mode-gated (issue #271): the handshake must not teach restricted
         // addressing features. Env is process-stable, so constructor-time is fine.
-        instructions: buildServerInstructions(getBpAddressingMode(this.environment))
+        // Redaction state rides along (issue #237) so agents aren't surprised
+        // by <redacted:...> placeholders.
+        instructions: buildServerInstructions(getBpAddressingMode(this.environment), {
+          redactionEnabled: isRedactionEnabled(this.environment)
+        })
       }
     );
 
@@ -1852,7 +1858,8 @@ export class DebugMcpServer {
                   timestamp: Date.now()
                 });
                 
-                result = { content: [{ type: 'text', text: JSON.stringify({ success: true, variables, count: variables.length, variablesReference: args.scope }) }] };
+                const redaction = this.redactionSummary(variables);
+                result = { content: [{ type: 'text', text: JSON.stringify({ success: true, variables, count: variables.length, variablesReference: args.scope, ...(redaction ? { redaction } : {}) }) }] };
               } catch (error) {
                 // Handle validation errors specifically
                 if (error instanceof SessionTerminatedError ||
@@ -2150,6 +2157,16 @@ export class DebugMcpServer {
     }
   }
 
+  /**
+   * Top-level `redaction` notice object for tool results (issue #237):
+   * present when any returned item carries the session layer's `redacted`
+   * flag, so the agent learns why values changed and how to opt out.
+   */
+  private redactionSummary(items: Array<{ redacted?: boolean }>): { masked: number; notice: string } | undefined {
+    const masked = items.filter(item => item.redacted).length;
+    return masked > 0 ? { masked, notice: REDACTION_NOTICE } : undefined;
+  }
+
   private async handleGetOutput(args: { sessionId: string; since?: number; limit?: number }): Promise<ServerResult> {
     // Deliberately no validateSession(): that rejects TERMINATED sessions, but
     // reading output after the program finished is the primary use case.
@@ -2163,13 +2180,15 @@ export class DebugMcpServer {
     const read = session.outputBuffer
       ? session.outputBuffer.read(since, limit)
       : { entries: [], nextSince: since, hasMore: false, dropped: 0 }; // session created but never launched
+    const redaction = this.redactionSummary(read.entries);
     return { content: [{ type: 'text', text: JSON.stringify({
       success: true,
       sessionId: args.sessionId,
       entries: read.entries,
       nextSince: read.nextSince,
       hasMore: read.hasMore,
-      dropped: read.dropped
+      dropped: read.dropped,
+      ...(redaction ? { redaction } : {})
     }) }] };
   }
 
@@ -2442,7 +2461,12 @@ export class DebugMcpServer {
         variables: result.variables,
         count: result.variables.length
       };
-      
+
+      const redaction = this.redactionSummary(result.variables);
+      if (redaction) {
+        response.redaction = redaction;
+      }
+
       // Include frame information if available
       if (result.frame) {
         response.frame = result.frame;

--- a/src/session/output-buffer.ts
+++ b/src/session/output-buffer.ts
@@ -29,14 +29,20 @@ export class OutputRingBuffer {
 
   constructor(private readonly cap: number = OUTPUT_BUFFER_CAP) {}
 
-  push(category: string, output: string, timestamp: number = Date.now()): SessionOutputEntry {
+  push(
+    category: string,
+    output: string,
+    timestamp: number = Date.now(),
+    flags?: { redacted?: boolean }
+  ): SessionOutputEntry {
     const truncated = output.length > MAX_OUTPUT_ENTRY_CHARS;
     const entry: SessionOutputEntry = {
       seq: this.nextSeq++,
       category,
       output: truncated ? output.slice(0, MAX_OUTPUT_ENTRY_CHARS) : output,
       timestamp,
-      ...(truncated ? { truncated: true } : {})
+      ...(truncated ? { truncated: true } : {}),
+      ...(flags?.redacted ? { redacted: true } : {})
     };
     this.entries.push(entry);
     if (this.entries.length > this.cap) {

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -5,8 +5,9 @@
 import { EventEmitter } from 'events';
 import {
   SessionState, SessionLifecycleState, DebugLanguage, DebugSessionInfo, mapLegacyState,
-  AdapterPolicy, SessionOutputEntry
+  AdapterPolicy, SessionOutputEntry, redactSecretsInString
 } from '@debugmcp/shared';
+import { isRedactionEnabled } from '../utils/redaction-mode.js';
 import { SessionStore, ManagedSession } from './session-store.js';
 import { OutputRingBuffer } from './output-buffer.js';
 import { DebugProtocol } from '@vscode/debugprotocol'; 
@@ -113,6 +114,15 @@ export abstract class SessionManagerCore extends EventEmitter {
     
     this.fileSystem.ensureDirSync(this.logDirBase);
     this.logger.info(`[SessionManager] Initialized. Session logs will be stored in: ${this.logDirBase}`);
+  }
+
+  /**
+   * Secret redaction of tool-facing values (issue #237): on unless the
+   * environment opts out via DEBUG_MCP_NO_REDACT. Read per call — cheap, and
+   * keeps construction order irrelevant.
+   */
+  protected redactionEnabled(): boolean {
+    return isRedactionEnabled(this.environment);
   }
 
   async createSession(params: { language: DebugLanguage; name?: string; executablePath?: string; }): Promise<DebugSessionInfo> {
@@ -877,7 +887,24 @@ export abstract class SessionManagerCore extends EventEmitter {
       if (category === 'telemetry') {
         return;
       }
-      const entry: SessionOutputEntry | undefined = session.outputBuffer?.push(category, body.output);
+      // Redact-at-write (issue #237): one hook covers both buffer readers —
+      // the get_output tool and the debug:// output resource. The original
+      // text is deliberately not retained.
+      let text = body.output;
+      let redacted = false;
+      if (this.redactionEnabled()) {
+        const result = redactSecretsInString(text);
+        if (result.redacted) {
+          text = result.value;
+          redacted = true;
+        }
+      }
+      const entry: SessionOutputEntry | undefined = session.outputBuffer?.push(
+        category,
+        text,
+        undefined,
+        redacted ? { redacted: true } : undefined
+      );
       if (entry) {
         this.emit('output-captured', sessionId, entry);
       }

--- a/src/session/session-manager-data.ts
+++ b/src/session/session-manager-data.ts
@@ -10,7 +10,8 @@ import {
   getPolicyForLanguage,
   DebugLanguage,
   Breakpoint,
-  FunctionBreakpoint
+  FunctionBreakpoint,
+  redactVariableValue
 } from '@debugmcp/shared';
 import { SessionManagerCore } from './session-manager-core.js';
 import { DebugProtocol } from '@vscode/debugprotocol';
@@ -69,15 +70,26 @@ export abstract class SessionManagerData extends SessionManagerCore {
     try {
       this.logger.info(`[SM getVariables ${sessionId}] Sending DAP 'variables' for variablesReference ${variablesReference}.`);
       const response = await session.proxyManager.sendDapRequest<DebugProtocol.VariablesResponse>('variables', { variablesReference });
-      this.logger.info(`[SM getVariables ${sessionId}] DAP 'variables' response received. Body:`, response?.body);
+      // Count only — the raw body carries unredacted values (issue #237); the
+      // parsed (post-redaction) values are logged below.
+      this.logger.info(`[SM getVariables ${sessionId}] DAP 'variables' response received. ${response?.body?.variables?.length ?? 0} variable(s).`);
 
       if (response && response.body && response.body.variables) {
-        const vars = response.body.variables.map((v: DebugProtocol.Variable) => ({ 
-            name: v.name, value: v.value, type: v.type || "<unknown_type>", 
+        let vars = response.body.variables.map((v: DebugProtocol.Variable) => ({
+            name: v.name, value: v.value, type: v.type || "<unknown_type>",
             variablesReference: v.variablesReference,
-            expandable: v.variablesReference > 0 
+            expandable: v.variablesReference > 0
         }));
-        this.logger.info(`[SM getVariables ${sessionId}] Parsed variables:`, vars.map(v => ({name: v.name, value: v.value, type: v.type}))); 
+        // Redaction hook (issue #237): this is the single DAP→Variable
+        // mapping point, so get_variables, get_local_variables and child
+        // expansion are all covered here, upstream of every log line.
+        if (this.redactionEnabled()) {
+          vars = vars.map(v => {
+            const result = redactVariableValue(v.name, v.value);
+            return result.redacted ? { ...v, value: result.value, redacted: true } : v;
+          });
+        }
+        this.logger.info(`[SM getVariables ${sessionId}] Parsed variables:`, vars.map(v => ({name: v.name, value: v.value, type: v.type})));
         return vars;
       }
       this.logger.warn(`[SM getVariables ${sessionId}] No variables in response body for reference ${variablesReference}. Response:`, response);

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -11,6 +11,10 @@ import {
   sanitizePayloadForLogging,
   toSourceBreakpoint,
   toFunctionBreakpoint,
+  isSensitiveName,
+  redactVariableValue,
+  redactSecretsDeep,
+  buildRedactionNotice,
   type AdapterPolicy,
   type ExceptionBreakMode
 } from '@debugmcp/shared';
@@ -49,6 +53,8 @@ export interface EvaluateResult {
   indexedVariables?: number;
   presentationHint?: DebugProtocol.VariablePresentationHint;
   error?: string;
+  /** Present when secret-shaped content was masked in `result` (issue #237) */
+  redaction?: { rules: string[]; notice: string };
 }
 
 export interface RedefineClassesResult {
@@ -2065,6 +2071,21 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     return value.length > maxLength ? value.substring(0, maxLength) + '... (truncated)' : value;
   }
 
+  /**
+   * The "variable name" an evaluate expression stands for, for name-based
+   * redaction (issue #237): the whole expression when it is itself a
+   * sensitive name, otherwise its final dot-segment — so `config.password`
+   * is treated like the variable `password`.
+   */
+  protected static expressionNameForRedaction(expression: string): string {
+    const trimmed = expression.trim();
+    if (isSensitiveName(trimmed)) {
+      return trimmed;
+    }
+    const lastDot = trimmed.lastIndexOf('.');
+    return lastDot >= 0 ? trimmed.slice(lastDot + 1) : trimmed;
+  }
+
   /** Upper bound for caller-supplied per-request DAP timeouts (10 minutes). */
   private static readonly MAX_DAP_TIMEOUT_MS = 600000;
 
@@ -2229,8 +2250,12 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         : await session.proxyManager.sendDapRequest<DebugProtocol.EvaluateResponse>(
             'evaluate', evaluateArgs);
 
-      // Log raw response in debug mode
-      this.logger.debug(`[SM evaluateExpression ${sessionId}] DAP evaluate raw response:`, response);
+      // Log raw response in debug mode — scrubbed, the raw body carries
+      // unredacted values (issue #237)
+      this.logger.debug(
+        `[SM evaluateExpression ${sessionId}] DAP evaluate raw response:`,
+        this.redactionEnabled() ? redactSecretsDeep(response).value : response
+      );
 
       // Process response
       if (response && response.body) {
@@ -2246,6 +2271,24 @@ export abstract class SessionManagerOperations extends SessionManagerData {
           indexedVariables: body.indexedVariables,
           presentationHint: body.presentationHint,
         };
+
+        // Redaction hook (issue #237), placed above the logs below so they
+        // only ever see masked values. The expression's final dot-segment
+        // counts as the "variable name" so `config.password` is treated like
+        // the variable `password` would be.
+        if (this.redactionEnabled() && result.result) {
+          const redacted = redactVariableValue(
+            SessionManagerOperations.expressionNameForRedaction(expression),
+            result.result
+          );
+          if (redacted.redacted) {
+            result.result = redacted.value;
+            result.redaction = {
+              rules: redacted.hits.map(hit => hit.ruleId),
+              notice: buildRedactionNotice(redacted.hits)
+            };
+          }
+        }
 
         // Log the evaluation result with structured logging
         this.logger.info('debug:evaluate', {

--- a/src/skill-content.ts
+++ b/src/skill-content.ts
@@ -19,8 +19,14 @@ import {
 } from './utils/bp-addressing.js';
 
 export function buildServerInstructions(
-  mode: BpAddressingMode = DEFAULT_BP_ADDRESSING
+  mode: BpAddressingMode = DEFAULT_BP_ADDRESSING,
+  opts: { redactionEnabled?: boolean } = {}
 ): string {
+  // Default matches the runtime default: redaction is on unless the server
+  // was started with DEBUG_MCP_NO_REDACT=1 (issue #237).
+  const redactionRule = (opts.redactionEnabled ?? true)
+    ? `\n- Credential-shaped values (API keys, tokens, private keys) and values of sensitive variable names (password, api_key, ...) render as <redacted:rule-id> placeholders in variable/evaluate/output results — the program's real state is unchanged, only the display is masked. A "redaction" field reports what was masked; the user can disable this by restarting the server with DEBUG_MCP_NO_REDACT=1.`
+    : '';
   const expectedContentRule = supportsExpectedContent(mode)
     ? `\n- set_breakpoint accepts expectedContent — pass the exact text of the target line (whitespace-trimmed); a mismatch fails fast and shows the actual nearby lines, catching off-by-one line numbers before they cause a confusing session. A response reporting "requested line N, bound to line M" means the adapter moved your breakpoint — trust the bound line.`
     : '';
@@ -42,7 +48,7 @@ Key rules:
 - get_output returns buffered debuggee stdout/stderr with a cursor; pass nextCursor back to read only new output.
 - attach_to_process connects to running/remote targets (debugpy --listen, rdbg --open, JVM JDWP), including pods via port-forward.
 - expose_session {sessionId} returns host/port/token for a read-only IDE mirror of the live session (VS Code launch.json: "debugServer": port + "mirrorToken"); relay these to the human, unexpose_session when done. The IDE observes — execution control stays with you.
-- Launch sessions pause at uncaught exceptions by default (breakOnExceptions "uncaught"; Ruby excepted — rdbg has no uncaught filter). Pass "none" to let crashing scripts run to termination; attach applies no default.
+- Launch sessions pause at uncaught exceptions by default (breakOnExceptions "uncaught"; Ruby excepted — rdbg has no uncaught filter). Pass "none" to let crashing scripts run to termination; attach applies no default.${redactionRule}
 
 For the full debugging workflow (root-cause discipline, per-language quirks), request the "debugging-workflow" prompt or install the agent skill from skills/debugging/ in the repo.`;
 }

--- a/src/utils/redaction-mode.ts
+++ b/src/utils/redaction-mode.ts
@@ -1,0 +1,25 @@
+/**
+ * Secret-redaction opt-out flag (issue #237).
+ *
+ * Redaction of credential-shaped values in tool results is ON by default —
+ * the server is a security boundary between the debuggee and the AI agent.
+ * DEBUG_MCP_NO_REDACT=1 (or 'true') disables it for local debugging of
+ * secrets themselves ("why is my token empty?" sessions). Read once at
+ * server construction; changing it requires a server restart, same as
+ * DEBUG_MCP_BP_ADDRESSING.
+ */
+
+export const REDACTION_ENV_KEY = 'DEBUG_MCP_NO_REDACT';
+
+const DISABLE_VALUES: ReadonlySet<string> = new Set(['1', 'true']);
+
+/**
+ * True unless the environment explicitly opts out. Unset, empty, or
+ * unrecognized values keep redaction enabled.
+ */
+export function isRedactionEnabled(environment: {
+  get(key: string): string | undefined;
+}): boolean {
+  const raw = environment.get(REDACTION_ENV_KEY)?.trim().toLowerCase();
+  return !(raw !== undefined && DISABLE_VALUES.has(raw));
+}

--- a/tests/core/unit/server/server-redaction.test.ts
+++ b/tests/core/unit/server/server-redaction.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Server-layer redaction notice tests (issue #237).
+ *
+ * Masking itself happens in the session layer (see
+ * session-manager-redaction.test.ts); the server's job is to surface a
+ * top-level `redaction` notice object whenever a returned item carries the
+ * `redacted` flag, and to mention redaction in the initialize instructions.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { DebugMcpServer } from '../../../../src/server.js';
+import { SessionManager } from '../../../../src/session/session-manager.js';
+import { createProductionDependencies } from '../../../../src/container/dependencies.js';
+import { buildServerInstructions } from '../../../../src/skill-content.js';
+import {
+  createMockDependencies,
+  createMockServer,
+  createMockSessionManager,
+  createMockStdioTransport,
+  getToolHandlers
+} from './server-test-helpers.js';
+import { OutputRingBuffer } from '../../../../src/session/output-buffer.js';
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js');
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js');
+vi.mock('../../../../src/session/session-manager.js');
+vi.mock('../../../../src/container/dependencies.js');
+
+describe('Server redaction notices (issue #237)', () => {
+  let mockServer: any;
+  let mockSessionManager: any;
+  let mockDependencies: any;
+  let callToolHandler: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    mockDependencies = createMockDependencies();
+    vi.mocked(createProductionDependencies).mockReturnValue(mockDependencies);
+
+    mockServer = createMockServer();
+    vi.mocked(Server).mockImplementation(function() { return mockServer as any; });
+
+    const mockStdioTransport = createMockStdioTransport();
+    vi.mocked(StdioServerTransport).mockImplementation(function() { return mockStdioTransport as any; });
+
+    mockSessionManager = createMockSessionManager(mockDependencies.adapterRegistry);
+    vi.mocked(SessionManager).mockImplementation(function() { return mockSessionManager as any; });
+
+    new DebugMcpServer();
+    callToolHandler = getToolHandlers(mockServer).callToolHandler;
+
+    mockSessionManager.getSession.mockReturnValue({
+      id: 'test-session',
+      sessionLifecycle: 'ACTIVE'
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('get_variables', () => {
+    it('adds a redaction notice when any returned variable was masked', async () => {
+      mockSessionManager.getVariables.mockResolvedValue([
+        { name: 'gh_token', value: '<redacted:github-pat>', type: 'str', expandable: false, redacted: true },
+        { name: 'count', value: '42', type: 'int', expandable: false }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_variables', arguments: { sessionId: 'test-session', scope: 100 } }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.redaction).toBeDefined();
+      expect(content.redaction.masked).toBe(1);
+      expect(content.redaction.notice).toContain('DEBUG_MCP_NO_REDACT=1');
+    });
+
+    it('omits the redaction object when nothing was masked', async () => {
+      mockSessionManager.getVariables.mockResolvedValue([
+        { name: 'count', value: '42', type: 'int', expandable: false }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_variables', arguments: { sessionId: 'test-session', scope: 100 } }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.redaction).toBeUndefined();
+    });
+  });
+
+  describe('get_local_variables', () => {
+    it('adds a redaction notice when any returned variable was masked', async () => {
+      mockSessionManager.getLocalVariables.mockResolvedValue({
+        variables: [
+          { name: 'password', value: '<redacted:sensitive-name>', type: 'str', expandable: false, redacted: true },
+          { name: 'x', value: '1', type: 'int', expandable: false }
+        ],
+        frame: { id: 1, name: 'main', file: 'test.py', line: 10 },
+        scopeName: 'Locals'
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_local_variables', arguments: { sessionId: 'test-session' } }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.redaction).toBeDefined();
+      expect(content.redaction.masked).toBe(1);
+      expect(content.redaction.notice).toContain('DEBUG_MCP_NO_REDACT=1');
+    });
+  });
+
+  describe('get_output', () => {
+    it('adds a redaction notice when any returned entry was masked', async () => {
+      const buffer = new OutputRingBuffer();
+      buffer.push('stdout', 'token: <redacted:github-pat>\n', undefined, { redacted: true });
+      buffer.push('stdout', 'ready\n');
+      mockSessionManager.getSession.mockReturnValue({
+        id: 'test-session',
+        sessionLifecycle: 'ACTIVE',
+        outputBuffer: buffer
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_output', arguments: { sessionId: 'test-session' } }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.entries).toHaveLength(2);
+      expect(content.entries[0].redacted).toBe(true);
+      expect(content.redaction.masked).toBe(1);
+      expect(content.redaction.notice).toContain('DEBUG_MCP_NO_REDACT=1');
+    });
+
+    it('omits the redaction object for clean output', async () => {
+      const buffer = new OutputRingBuffer();
+      buffer.push('stdout', 'hello\n');
+      mockSessionManager.getSession.mockReturnValue({
+        id: 'test-session',
+        sessionLifecycle: 'ACTIVE',
+        outputBuffer: buffer
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_output', arguments: { sessionId: 'test-session' } }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.redaction).toBeUndefined();
+    });
+  });
+
+  describe('server instructions', () => {
+    it('mentions redaction when enabled (the default)', () => {
+      const instructions = buildServerInstructions();
+      expect(instructions).toContain('<redacted:');
+      expect(instructions).toContain('DEBUG_MCP_NO_REDACT');
+    });
+
+    it('drops the redaction rule when the server opted out', () => {
+      const instructions = buildServerInstructions(undefined, { redactionEnabled: false });
+      expect(instructions).not.toContain('<redacted:');
+    });
+  });
+});

--- a/tests/core/unit/server/server-test-helpers.ts
+++ b/tests/core/unit/server/server-test-helpers.ts
@@ -102,6 +102,7 @@ export function createMockSessionManager(mockAdapterRegistry: any) {
     stepOut: vi.fn(),
     continue: vi.fn(),
     getVariables: vi.fn(),
+    getLocalVariables: vi.fn(),
     getStackTrace: vi.fn(),
     getScopes: vi.fn(),
     evaluateExpression: vi.fn(),

--- a/tests/core/unit/session/session-manager-redaction.test.ts
+++ b/tests/core/unit/session/session-manager-redaction.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Session-layer secret redaction tests (issue #237).
+ *
+ * Redaction hooks live in the session layer — the single point upstream of
+ * both tool results and log lines — so getVariables, evaluateExpression and
+ * output capture are covered here, with DEBUG_MCP_NO_REDACT=1 restoring raw
+ * values.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SessionManager, SessionManagerConfig } from '../../../../src/session/session-manager.js';
+import { DebugLanguage, SessionOutputEntry } from '@debugmcp/shared';
+import { createMockDependencies, createMockEnvironment } from './session-manager-test-utils.js';
+
+const GH_PAT = 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123';
+
+function makeManager(noRedact: '' | '1') {
+  const dependencies = createMockDependencies();
+  // '' forces the default-on path even if the developer's real environment
+  // sets DEBUG_MCP_NO_REDACT (the mock env falls back to process.env).
+  dependencies.environment = createMockEnvironment({ DEBUG_MCP_NO_REDACT: noRedact });
+  const config: SessionManagerConfig = {
+    logDirBase: '/tmp/test-sessions',
+    defaultDapLaunchArgs: { stopOnEntry: true, justMyCode: true }
+  };
+  return { sessionManager: new SessionManager(config, dependencies), dependencies };
+}
+
+async function createPausedSession(
+  sessionManager: SessionManager,
+  dependencies: ReturnType<typeof createMockDependencies>
+) {
+  const session = await sessionManager.createSession({
+    language: DebugLanguage.MOCK,
+    executablePath: 'python'
+  });
+  await sessionManager.startDebugging(session.id, 'test.py');
+  await vi.runAllTimersAsync();
+  dependencies.mockProxyManager.simulateStopped(1, 'entry');
+  return session;
+}
+
+function stubSecretVariables(dependencies: ReturnType<typeof createMockDependencies>) {
+  dependencies.mockProxyManager.setDapRequestHandler(async (command: string) => {
+    if (command === 'variables') {
+      return {
+        success: true,
+        body: {
+          variables: [
+            { name: 'gh_token', value: GH_PAT, type: 'str', variablesReference: 0 },
+            { name: 'password', value: 'hunter2blue', type: 'str', variablesReference: 0 },
+            { name: 'count', value: '42', type: 'int', variablesReference: 0 }
+          ]
+        }
+      };
+    }
+    if (command === 'evaluate') {
+      return { success: true, body: { result: `'${GH_PAT}'`, type: 'str', variablesReference: 0 } };
+    }
+    return { success: true };
+  });
+}
+
+describe('SessionManager - secret redaction (issue #237)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('getVariables', () => {
+    it('masks credential-shaped and sensitive-name values by default', async () => {
+      const { sessionManager, dependencies } = makeManager('');
+      const session = await createPausedSession(sessionManager, dependencies);
+      stubSecretVariables(dependencies);
+
+      const variables = await sessionManager.getVariables(session.id, 100);
+
+      expect(variables).toHaveLength(3);
+      expect(variables[0]).toMatchObject({
+        name: 'gh_token',
+        value: '<redacted:github-pat>',
+        redacted: true
+      });
+      expect(variables[1]).toMatchObject({
+        name: 'password',
+        value: '<redacted:sensitive-name>',
+        redacted: true
+      });
+      expect(variables[2]).toMatchObject({ name: 'count', value: '42' });
+      expect(variables[2].redacted).toBeUndefined();
+    });
+
+    it('returns raw values when DEBUG_MCP_NO_REDACT=1', async () => {
+      const { sessionManager, dependencies } = makeManager('1');
+      const session = await createPausedSession(sessionManager, dependencies);
+      stubSecretVariables(dependencies);
+
+      const variables = await sessionManager.getVariables(session.id, 100);
+
+      expect(variables[0]).toMatchObject({ name: 'gh_token', value: GH_PAT });
+      expect(variables[0].redacted).toBeUndefined();
+      expect(variables[1]).toMatchObject({ name: 'password', value: 'hunter2blue' });
+    });
+  });
+
+  describe('evaluateExpression', () => {
+    it('masks secret-shaped results and attaches redaction metadata', async () => {
+      const { sessionManager, dependencies } = makeManager('');
+      const session = await createPausedSession(sessionManager, dependencies);
+      stubSecretVariables(dependencies);
+
+      const result = await sessionManager.evaluateExpression(session.id, 'gh_token', 1);
+
+      expect(result.success).toBe(true);
+      expect(result.result).toBe("'<redacted:github-pat>'");
+      expect(result.redaction).toBeDefined();
+      expect(result.redaction?.rules).toContain('github-pat');
+      expect(result.redaction?.notice).toContain('DEBUG_MCP_NO_REDACT=1');
+    });
+
+    it('masks results when the expression itself names a secret (config.password)', async () => {
+      const { sessionManager, dependencies } = makeManager('');
+      const session = await createPausedSession(sessionManager, dependencies);
+      dependencies.mockProxyManager.setDapRequestHandler(async (command: string) => {
+        if (command === 'evaluate') {
+          return { success: true, body: { result: "'hunter2blue'", type: 'str', variablesReference: 0 } };
+        }
+        return { success: true };
+      });
+
+      const result = await sessionManager.evaluateExpression(session.id, 'config.password', 1);
+
+      expect(result.result).toBe('<redacted:sensitive-name>');
+      expect(result.redaction?.rules).toContain('sensitive-name');
+    });
+
+    it('returns raw results when DEBUG_MCP_NO_REDACT=1', async () => {
+      const { sessionManager, dependencies } = makeManager('1');
+      const session = await createPausedSession(sessionManager, dependencies);
+      stubSecretVariables(dependencies);
+
+      const result = await sessionManager.evaluateExpression(session.id, 'gh_token', 1);
+
+      expect(result.result).toBe(`'${GH_PAT}'`);
+      expect(result.redaction).toBeUndefined();
+    });
+  });
+
+  describe('output capture', () => {
+    it('masks secrets in output events at write time and flags the entry', async () => {
+      const { sessionManager, dependencies } = makeManager('');
+      const session = await createPausedSession(sessionManager, dependencies);
+
+      const captured: SessionOutputEntry[] = [];
+      sessionManager.on('output-captured', (_sessionId: string, entry: SessionOutputEntry) => {
+        captured.push(entry);
+      });
+
+      dependencies.mockProxyManager.emit('output', {
+        category: 'stdout',
+        output: `token: ${GH_PAT}\nready\n`
+      });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].output).toBe('token: <redacted:github-pat>\nready\n');
+      expect(captured[0].redacted).toBe(true);
+      expect(session).toBeDefined();
+    });
+
+    it('leaves benign output untouched and unflagged', async () => {
+      const { sessionManager, dependencies } = makeManager('');
+      await createPausedSession(sessionManager, dependencies);
+
+      const captured: SessionOutputEntry[] = [];
+      sessionManager.on('output-captured', (_sessionId: string, entry: SessionOutputEntry) => {
+        captured.push(entry);
+      });
+
+      dependencies.mockProxyManager.emit('output', { category: 'stdout', output: 'hello world\n' });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].output).toBe('hello world\n');
+      expect(captured[0].redacted).toBeUndefined();
+    });
+
+    it('passes secrets through raw when DEBUG_MCP_NO_REDACT=1', async () => {
+      const { sessionManager, dependencies } = makeManager('1');
+      await createPausedSession(sessionManager, dependencies);
+
+      const captured: SessionOutputEntry[] = [];
+      sessionManager.on('output-captured', (_sessionId: string, entry: SessionOutputEntry) => {
+        captured.push(entry);
+      });
+
+      dependencies.mockProxyManager.emit('output', { category: 'stdout', output: `token: ${GH_PAT}\n` });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].output).toBe(`token: ${GH_PAT}\n`);
+      expect(captured[0].redacted).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/utils/redaction-mode.test.ts
+++ b/tests/unit/utils/redaction-mode.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  REDACTION_ENV_KEY,
+  isRedactionEnabled,
+} from '../../../src/utils/redaction-mode.js';
+
+function envWith(value: string | undefined) {
+  return {
+    get: (key: string) => (key === REDACTION_ENV_KEY ? value : undefined),
+  };
+}
+
+describe('redaction mode helper', () => {
+  it('is enabled by default when the env variable is unset', () => {
+    expect(isRedactionEnabled(envWith(undefined))).toBe(true);
+  });
+
+  it('stays enabled for empty or whitespace-only values', () => {
+    expect(isRedactionEnabled(envWith(''))).toBe(true);
+    expect(isRedactionEnabled(envWith('   '))).toBe(true);
+  });
+
+  it('is disabled by DEBUG_MCP_NO_REDACT=1 or true (any case, padded)', () => {
+    expect(isRedactionEnabled(envWith('1'))).toBe(false);
+    expect(isRedactionEnabled(envWith('true'))).toBe(false);
+    expect(isRedactionEnabled(envWith(' TRUE '))).toBe(false);
+    expect(isRedactionEnabled(envWith('True'))).toBe(false);
+  });
+
+  it('stays enabled for other values (0, false, random text)', () => {
+    expect(isRedactionEnabled(envWith('0'))).toBe(true);
+    expect(isRedactionEnabled(envWith('false'))).toBe(true);
+    expect(isRedactionEnabled(envWith('yes please'))).toBe(true);
+  });
+
+  it('uses the documented env key', () => {
+    expect(REDACTION_ENV_KEY).toBe('DEBUG_MCP_NO_REDACT');
+  });
+});


### PR DESCRIPTION
First half of #237: default-on, per-token labeled masking of credential-shaped values in every value-bearing tool surface. The least-privilege variable access mode (second half) ships as a follow-up PR.

## Why

Debuggers see everything in scope — including credentials — and when the debugging driver is an AI agent, variable values flow into model context and transcripts. We already sanitize adapter stderr (#153/#155); this extends the same protection to variable inspection, evaluation results, and captured output.

## Build-vs-buy

We evaluated the OSS landscape before rolling our own (per the discussion in #237, including the `flare-redact` suggestion — thank you for the pointer):

- Every peer that solved this exact problem writes a small in-house masker: npm CLI (`@npmcli/redact`), Azure DevOps (SecretMasker), and microsoft/DebugMCP (a ~180-line dependency-free module — the prior art cited in the issue).
- The pattern corpus is not reinvented: value shapes are adapted from the MIT-licensed gitleaks corpus (with attribution), and the sensitive-name/trivial-value design is adapted from microsoft/DebugMCP (MIT).
- Taking a runtime dependency in this particular code path concentrates supply-chain risk where it hurts most, so the engine is ~250 lines in `@debugmcp/shared` with zero new dependencies.

## What

- **New shared engine** `packages/shared/src/utils/secret-redaction.ts`: 17 value-shape rules (GitHub/GitLab PATs, `sk-` keys, Slack, Stripe, AWS key IDs, Google API keys, npm/PyPI/HF tokens, SendGrid, JWTs, PEM blocks, Bearer credentials, connection-string passwords, URL userinfo) with gitleaks-style keyword pre-filter anchors and bounded, backtracking-safe patterns; plus an exact-match sensitive-name set (`password`, `api_key`, ... — never substring, so `tokenCount`/`PATH` stay debuggable) with trivial-value passthrough (`password = None` stays visible).
- **Per-token labeled placeholders**: `ghp_…` → `<redacted:github-pat>`; surrounding text survives, so structured values stay legible.
- **One corpus, no drift**: env-sanitizer's stderr value regex is now derived from the same rule table, and `sanitizePayloadForLogging` masks secret-shaped string leaves — closing a raw-DAP-body leak into proxy debug logs and the DAP trace file.
- **Session-layer hooks** (single point upstream of both tool results and logs): the DAP→Variable mapping (covers `get_variables`, `get_local_variables`, child expansion), `evaluateExpression` (the expression's final dot-segment counts as the variable name, so `config.password` masks like `password` — the "trivial bypass" from the issue), and output capture at write time (covers `get_output` and the `debug://` resource).
- **Agent-facing notices**: results that masked something carry a `redaction` field explaining the placeholder and the opt-out; redacted variables/entries are flagged; the initialize instructions mention the behavior so agents don't retry reads.
- **Opt-out**: `DEBUG_MCP_NO_REDACT=1` restores raw values (acceptance criterion c).
- **Out of scope, documented**: the `expose_session` IDE mirror shows raw values (human-facing surface).

## Acceptance criteria from #237

- [x] A variable holding a GitHub PAT renders masked in all inspection tools by default — verified live against a Python session (variables, locals, evaluate, output, resource)
- [x] Redaction tests cover the stderr-sanitizer token corpus — the fast-check `secretValue` arbitrary was extracted into a shared helper and extended; the stderr corpus is a subset
- [x] Opt-out flag restores raw values
- [ ] Least-privilege flag — follow-up PR

## Tests

104 example tests + property tests (no generated secret survives, context-independence, idempotence, deep non-mutation) on the engine; session-layer tests for all three hooks incl. opt-out; server-layer notice tests. Full suite: 3273 unit + 23 integration, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)