### PR TITLE
feat: least-privilege variable access mode + names filter (#237)

### DIFF
--- a/docs/docker-support.md
+++ b/docs/docker-support.md
@@ -91,7 +91,7 @@ Here's the recommended configuration for your MCP settings file:
 - The `:rw` suffix allows read-write access (required for debugging)
 - The Docker entrypoint (`scripts/docker-entry.sh`) runs `dist/bundle.cjs` and passes through command-line arguments (e.g., `stdio`). It does not hardcode `--log-level` or `--log-file`
 - When using the debugger, provide paths relative to the project root (e.g., `examples/test.py` not `/workspace/examples/test.py`)
-- Optional env flags pass through with `-e`, e.g. `-e DEBUG_MCP_BP_ADDRESSING=line` restricts breakpoint addressing features (default: all enabled; see the set_breakpoint section of the tool reference), or `-e DEBUG_MCP_NO_REDACT=1` to disable the default masking of credential-shaped values in variable/evaluate/output results (see the Secret redaction section of the tool reference)
+- Optional env flags pass through with `-e`, e.g. `-e DEBUG_MCP_BP_ADDRESSING=line` restricts breakpoint addressing features (default: all enabled; see the set_breakpoint section of the tool reference), `-e DEBUG_MCP_NO_REDACT=1` to disable the default masking of credential-shaped values in variable/evaluate/output results, or `-e DEBUG_MCP_VARIABLE_ACCESS=explicit` to require explicit variable names on get_variables/get_local_variables (see the Secret redaction and Least-privilege mode sections of the tool reference)
 
 ## Rust support in Docker
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -23,6 +23,7 @@ This document provides a complete reference for all tools available in mcp-debug
    - [pause_execution](#pause_execution)
 4. [State Inspection](#state-inspection)
    - [Secret redaction](#secret-redaction)
+   - [Least-privilege mode](#least-privilege-mode)
    - [get_stack_trace](#get_stack_trace)
    - [get_scopes](#get_scopes)
    - [get_variables](#get_variables)
@@ -523,6 +524,18 @@ Results that had values masked carry a `redaction` field (`{ masked, notice }` o
 
 **Limitations**: redaction is display-level protection against credentials leaking into transcripts, not a security boundary against a hostile agent — an agent can still compute over secrets via `evaluate_expression` side effects. Secrets split across separate output chunks, and generic high-entropy strings with no recognizable shape or name, are not detected. The [`expose_session`](#expose_session) IDE mirror shows **raw, unredacted** values — it serves a human's IDE, not the agent.
 
+### Least-privilege mode
+
+For security-sensitive deployments, `DEBUG_MCP_VARIABLE_ACCESS=explicit` disables bulk scope dumps: `get_variables` and `get_local_variables` **require** a `names` filter, so the agent must ask for specific variables instead of sweeping every value in scope into its context. An unfiltered call is rejected with a clear `InvalidParams` error that teaches the correct call shape; the tool schemas and the initialize instructions advertise the requirement.
+
+The `names` parameter works in the default (`open`) mode too, as an ordinary filter:
+
+- Exact-match and **case-sensitive** against variable names (DAP names are language identifiers).
+- The response's `notFound` array lists requested names absent from the scope, so "filtered out" is distinguishable from "doesn't exist".
+- Unrequested values are dropped in the session layer, before redaction and logging.
+
+`evaluate_expression` is deliberately **not** restricted in explicit mode: least-privilege guards against indiscriminate bulk exposure, not against a determined agent — evaluate is already explicit-by-name, per-request, and audit-logged, which is exactly the access discipline the mode enforces, and removing the core debugging primitive would make the mode unusable. [Secret redaction](#secret-redaction) still applies to evaluate results.
+
 ### get_stack_trace
 
 Gets the current call stack.
@@ -610,6 +623,7 @@ Gets variables within a scope.
 **Parameters:**
 - `sessionId` (string, required): The ID of the debug session.
 - `scope` (number, required): The `variablesReference` number from a scope or variable.
+- `names` (string[], optional): Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's `notFound`. Required in [least-privilege mode](#least-privilege-mode).
 
 **Response:**
 ```json
@@ -650,6 +664,7 @@ Gets local variables by traversing all stack frames and their scopes, then using
 **Parameters:**
 - `sessionId` (string, required): The ID of the debug session.
 - `includeSpecial` (boolean, optional): Include special/internal variables like `this`, `__proto__`, `__builtins__`, etc. Default: false.
+- `names` (string[], optional): Only return variables with these exact names (case-sensitive). Requested names missing from the extracted locals are listed in the response's `notFound`. Required in [least-privilege mode](#least-privilege-mode).
 
 **Response:**
 ```json

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -41,6 +41,7 @@ Rules that prevent 90% of failed sessions:
 - **Respect session state.** Stepping, evaluation, and variable reads require `PAUSED`. After `continue_execution` the session is `RUNNING`; after a step or breakpoint hit it returns to `PAUSED` with a persisted stop reason telling you why it stopped (`breakpoint`, `step`, `entry`, `exception`, ...).
 - **Breakpoints may verify late.** Some adapters (debugpy, JDI) report breakpoints unverified until the module/class loads; that is normal, not an error.
 - **`<redacted:...>` placeholders are masking, not program state.** Credential-shaped values and values of sensitive variable names (`password`, `api_key`, ...) are masked by default in variable/evaluate/output results; a `redaction` field reports what was hidden. The real value is intact in the debuggee — don't "fix" it, and don't retry the read. The user can disable masking by restarting the server with `DEBUG_MCP_NO_REDACT=1`.
+- **If `get_variables` demands `names`, the server is in least-privilege mode** (`DEBUG_MCP_VARIABLE_ACCESS=explicit`): pass the exact variable names you need (`names: ["user", "total"]`; case-sensitive, misses reported in `notFound`) instead of dumping the scope. `evaluate_expression` still works for targeted reads.
 - **Always `close_debug_session`** when done — it tears down the debuggee process tree.
 
 ## Root-cause discipline

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,7 @@ import {
   supportsLoudSnapping
 } from './utils/bp-addressing.js';
 import { isRedactionEnabled } from './utils/redaction-mode.js';
+import { getVariableAccessMode, requiresExplicitNames } from './utils/variable-access.js';
 import { assertLineContent, resolveStatement } from './utils/breakpoint-resolver.js';
 
 const DEFAULT_LANGUAGES = Object.freeze([DebugLanguage.PYTHON, DebugLanguage.MOCK] as const);
@@ -116,6 +117,7 @@ interface ToolArguments {
   linesContext?: number;
   includeInternals?: boolean;
   includeSpecial?: boolean;
+  names?: string[];
   // Attach-related parameters
   port?: number;
   host?: string;
@@ -176,7 +178,7 @@ const TOOL_ARG_EXPECTED_TYPES: Record<string, 'number' | 'boolean' | 'object' | 
   // objects
   dapLaunchArgs: 'object', adapterLaunchConfig: 'object',
   // arrays
-  args: 'array', sourcePaths: 'array',
+  args: 'array', sourcePaths: 'array', names: 'array',
 };
 
 export function coerceToolArguments(args: Record<string, unknown>): Record<string, unknown> {
@@ -765,9 +767,9 @@ export class DebugMcpServer {
     return this.sessionManager.clearBreakpoints(sessionId, effectiveFile);
   }
 
-  public async getVariables(sessionId: string, variablesReference: number): Promise<Variable[]> {
+  public async getVariables(sessionId: string, variablesReference: number, names?: string[]): Promise<Variable[]> {
     this.validateSession(sessionId);
-    return this.sessionManager.getVariables(sessionId, variablesReference);
+    return this.sessionManager.getVariables(sessionId, variablesReference, names);
   }
 
   public async getStackTrace(sessionId: string, includeInternals: boolean = false): Promise<StackFrame[]> {
@@ -801,13 +803,13 @@ export class DebugMcpServer {
     return this.sessionManager.getScopes(sessionId, frameId);
   }
 
-  public async getLocalVariables(sessionId: string, includeSpecial: boolean = false): Promise<{
+  public async getLocalVariables(sessionId: string, includeSpecial: boolean = false, names?: string[]): Promise<{
     variables: Variable[];
     frame: { name: string; file: string; line: number } | null;
     scopeName: string | null;
   }> {
     this.validateSession(sessionId);
-    return this.sessionManager.getLocalVariables(sessionId, includeSpecial);
+    return this.sessionManager.getLocalVariables(sessionId, includeSpecial, names);
   }
 
   public async continueExecution(sessionId: string): Promise<boolean> {
@@ -881,7 +883,8 @@ export class DebugMcpServer {
         // Redaction state rides along (issue #237) so agents aren't surprised
         // by <redacted:...> placeholders.
         instructions: buildServerInstructions(getBpAddressingMode(this.environment), {
-          redactionEnabled: isRedactionEnabled(this.environment)
+          redactionEnabled: isRedactionEnabled(this.environment),
+          variableAccessMode: getVariableAccessMode(this.environment)
         })
       }
     );
@@ -985,6 +988,18 @@ export class DebugMcpServer {
         setBreakpointRequired = ['sessionId'];
       }
 
+      // Least-privilege gating (issue #237): in explicit mode the names
+      // filter is required, and the schema must say so.
+      const varAccessExplicit = requiresExplicitNames(getVariableAccessMode(this.environment));
+      const namesProp = {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response\'s notFound.' +
+          (varAccessExplicit ? ' Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled.' : '')
+      };
+      const getVariablesRequired = varAccessExplicit ? ['sessionId', 'scope', 'names'] : ['sessionId', 'scope'];
+      const getLocalVariablesRequired = varAccessExplicit ? ['sessionId', 'names'] : ['sessionId'];
+
       return {
         tools: [
           { name: 'create_debug_session', description: 'Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode', inputSchema: { type: 'object', properties: { language: { type: 'string', enum: supportedLanguages, description: 'Programming language for debugging' }, name: { type: 'string', description: 'Optional session name' }, executablePath: {type: 'string', description: 'Path to language executable (optional, will auto-detect if not provided)'}, host: { type: 'string', description: 'Host to attach to for remote debugging (optional, triggers attach mode)' }, port: { type: 'number', description: 'Debug port to attach to for remote debugging (optional, triggers attach mode)' }, timeout: { type: 'number', description: 'Connection timeout in milliseconds for attach mode (default: 30000)' }, verifyTimeout: { type: 'number', description: 'Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 5000, max: 600000)' } }, required: ['language'] } },
@@ -1055,8 +1070,8 @@ export class DebugMcpServer {
           { name: 'continue_execution', description: 'Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes "paused" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. "breakpoint" vs "exception"). Use get_output to read the program\'s stdout/stderr', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
           { name: 'pause_execution', description: 'Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code), returns success with pending:true and the session reports "paused" once the stop lands', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, threadId: { type: 'number', description: 'Thread ID to pause. If omitted or 0, pauses all threads.' } }, required: ['sessionId'] } },
           { name: 'list_threads', description: 'List all threads in the debugged process', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'get_variables', description: 'Get variables (scope is variablesReference: number)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, scope: { type: 'number', description: "The variablesReference number from a StackFrame or Variable" } }, required: ['sessionId', 'scope'] } },
-          { name: 'get_local_variables', description: 'Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeSpecial: { type: 'boolean', description: 'Include special/internal variables like this, __proto__, __builtins__, etc. Default: false' } }, required: ['sessionId'] } },
+          { name: 'get_variables', description: 'Get variables (scope is variablesReference: number)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, scope: { type: 'number', description: "The variablesReference number from a StackFrame or Variable" }, names: namesProp }, required: getVariablesRequired } },
+          { name: 'get_local_variables', description: 'Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeSpecial: { type: 'boolean', description: 'Include special/internal variables like this, __proto__, __builtins__, etc. Default: false' }, names: namesProp }, required: getLocalVariablesRequired } },
           { name: 'get_stack_trace', description: 'Get stack trace. The response includes stopReason — why the session is paused (e.g. "breakpoint" vs "exception")', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeInternals: { type: 'boolean', description: 'Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output.' } }, required: ['sessionId'] } },
           { name: 'get_scopes', description: 'Get scopes for a stack frame', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, frameId: { type: 'number', description: "The ID of the stack frame from a stackTrace response" } }, required: ['sessionId', 'frameId'] } },
           { name: 'evaluate_expression', description: 'Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, expression: { type: 'string' }, frameId: { type: 'number', description: 'Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically' }, timeout: { type: 'number', description: 'Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout' } }, required: ['sessionId', 'expression'] } },
@@ -1838,9 +1853,10 @@ export class DebugMcpServer {
               if (!args.sessionId || args.scope === undefined) {
                 throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
               }
-              
+              this.enforceExplicitNames('get_variables', args.names);
+
               try {
-                const variables = await this.getVariables(args.sessionId, args.scope);
+                const variables = await this.getVariables(args.sessionId, args.scope, args.names);
                 
                 // Log variable inspection (truncate large values)
                 const truncatedVars = variables.map(v => ({
@@ -1859,7 +1875,10 @@ export class DebugMcpServer {
                 });
                 
                 const redaction = this.redactionSummary(variables);
-                result = { content: [{ type: 'text', text: JSON.stringify({ success: true, variables, count: variables.length, variablesReference: args.scope, ...(redaction ? { redaction } : {}) }) }] };
+                const notFound = args.names
+                  ? args.names.filter(name => !variables.some(v => v.name === name))
+                  : undefined;
+                result = { content: [{ type: 'text', text: JSON.stringify({ success: true, variables, count: variables.length, variablesReference: args.scope, ...(notFound !== undefined ? { notFound } : {}), ...(redaction ? { redaction } : {}) }) }] };
               } catch (error) {
                 // Handle validation errors specifically
                 if (error instanceof SessionTerminatedError ||
@@ -1932,7 +1951,7 @@ export class DebugMcpServer {
               break;
             }
             case 'get_local_variables': {
-              result = await this.handleGetLocalVariables(args as { sessionId: string; includeSpecial?: boolean });
+              result = await this.handleGetLocalVariables(args as { sessionId: string; includeSpecial?: boolean; names?: string[] });
               break;
             }
             case 'get_output': {
@@ -2154,6 +2173,25 @@ export class DebugMcpServer {
     } catch (error) {
       this.logger.error('Failed to list debug sessions', { error });
       throw new McpError(McpErrorCode.InternalError, `Failed to list debug sessions: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Least-privilege enforcement (issue #237): in explicit mode, bulk scope
+   * dumps are disabled — the tools require a non-empty names filter, and the
+   * error teaches the correct call shape.
+   */
+  private enforceExplicitNames(toolName: string, names: string[] | undefined): void {
+    if (!requiresExplicitNames(getVariableAccessMode(this.environment))) {
+      return;
+    }
+    if (!names || names.length === 0) {
+      throw new McpError(
+        McpErrorCode.InvalidParams,
+        `${toolName} requires "names" in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit): ` +
+        `pass the exact variable names you need, e.g. names:["user","order_total"]. ` +
+        `Unfiltered scope dumps are disabled by this server's configuration.`
+      );
     }
   }
 
@@ -2433,15 +2471,17 @@ export class DebugMcpServer {
     }
   }
 
-  private async handleGetLocalVariables(args: { sessionId: string; includeSpecial?: boolean }): Promise<ServerResult> {
+  private async handleGetLocalVariables(args: { sessionId: string; includeSpecial?: boolean; names?: string[] }): Promise<ServerResult> {
+    this.enforceExplicitNames('get_local_variables', args.names);
     try {
       // Validate session
       this.validateSession(args.sessionId);
-      
+
       // Get local variables using the new convenience method
       const result = await this.getLocalVariables(
         args.sessionId,
-        args.includeSpecial ?? false
+        args.includeSpecial ?? false,
+        args.names
       );
       
       // Log for debugging
@@ -2465,6 +2505,12 @@ export class DebugMcpServer {
       const redaction = this.redactionSummary(result.variables);
       if (redaction) {
         response.redaction = redaction;
+      }
+
+      if (args.names) {
+        response.notFound = args.names.filter(
+          name => !result.variables.some(v => v.name === name)
+        );
       }
 
       // Include frame information if available

--- a/src/session/session-manager-data.ts
+++ b/src/session/session-manager-data.ts
@@ -54,7 +54,12 @@ export abstract class SessionManagerData extends SessionManagerCore {
       .sort((a, b) => a.functionName.localeCompare(b.functionName));
   }
 
-  async getVariables(sessionId: string, variablesReference: number): Promise<Variable[]> {
+  /**
+   * @param names Optional exact-match, case-sensitive filter (issue #237,
+   * least-privilege mode): only variables with these names are returned,
+   * redacted, or logged.
+   */
+  async getVariables(sessionId: string, variablesReference: number, names?: string[]): Promise<Variable[]> {
     const session = this._getSessionById(sessionId);
     this.logger.info(`[SM getVariables ${sessionId}] Entered. variablesReference: ${variablesReference}, Current state: ${session.state}`);
     
@@ -80,6 +85,11 @@ export abstract class SessionManagerData extends SessionManagerCore {
             variablesReference: v.variablesReference,
             expandable: v.variablesReference > 0
         }));
+        // Names filter before redaction/logging: unrequested values never
+        // leave the raw response object.
+        if (names) {
+          vars = vars.filter(v => names.includes(v.name));
+        }
         // Redaction hook (issue #237): this is the single DAP→Variable
         // mapping point, so get_variables, get_local_variables and child
         // expansion are all covered here, upstream of every log line.
@@ -194,7 +204,12 @@ export abstract class SessionManagerData extends SessionManagerCore {
    * scopes, and variables, then delegates to the adapter policy to extract
    * just the local variables.
    */
-  async getLocalVariables(sessionId: string, includeSpecial: boolean = false): Promise<{
+  /**
+   * @param names Optional exact-match, case-sensitive filter (issue #237),
+   * applied to the final extracted locals — the policy's scope traversal
+   * still sees everything it needs to pick the right scopes.
+   */
+  async getLocalVariables(sessionId: string, includeSpecial: boolean = false, names?: string[]): Promise<{
     variables: Variable[];
     frame: { name: string; file: string; line: number } | null;
     scopeName: string | null;
@@ -278,8 +293,12 @@ export abstract class SessionManagerData extends SessionManagerCore {
         }
       }
       
+      if (names) {
+        localVars = localVars.filter(v => names.includes(v.name));
+      }
+
       this.logger.info(`[SM getLocalVariables ${sessionId}] Found ${localVars.length} local variables.`);
-      
+
       return {
         variables: localVars,
         frame: {

--- a/src/skill-content.ts
+++ b/src/skill-content.ts
@@ -20,12 +20,15 @@ import {
 
 export function buildServerInstructions(
   mode: BpAddressingMode = DEFAULT_BP_ADDRESSING,
-  opts: { redactionEnabled?: boolean } = {}
+  opts: { redactionEnabled?: boolean; variableAccessMode?: 'open' | 'explicit' } = {}
 ): string {
   // Default matches the runtime default: redaction is on unless the server
   // was started with DEBUG_MCP_NO_REDACT=1 (issue #237).
   const redactionRule = (opts.redactionEnabled ?? true)
     ? `\n- Credential-shaped values (API keys, tokens, private keys) and values of sensitive variable names (password, api_key, ...) render as <redacted:rule-id> placeholders in variable/evaluate/output results — the program's real state is unchanged, only the display is masked. A "redaction" field reports what was masked; the user can disable this by restarting the server with DEBUG_MCP_NO_REDACT=1.`
+    : '';
+  const variableAccessRule = opts.variableAccessMode === 'explicit'
+    ? `\n- This server runs in least-privilege variable access mode (DEBUG_MCP_VARIABLE_ACCESS=explicit): get_variables and get_local_variables require names:["..."] — request only the variables you need (names are exact and case-sensitive; missing ones are listed in notFound). evaluate_expression remains available for targeted reads.`
     : '';
   const expectedContentRule = supportsExpectedContent(mode)
     ? `\n- set_breakpoint accepts expectedContent — pass the exact text of the target line (whitespace-trimmed); a mismatch fails fast and shows the actual nearby lines, catching off-by-one line numbers before they cause a confusing session. A response reporting "requested line N, bound to line M" means the adapter moved your breakpoint — trust the bound line.`
@@ -48,7 +51,7 @@ Key rules:
 - get_output returns buffered debuggee stdout/stderr with a cursor; pass nextCursor back to read only new output.
 - attach_to_process connects to running/remote targets (debugpy --listen, rdbg --open, JVM JDWP), including pods via port-forward.
 - expose_session {sessionId} returns host/port/token for a read-only IDE mirror of the live session (VS Code launch.json: "debugServer": port + "mirrorToken"); relay these to the human, unexpose_session when done. The IDE observes — execution control stays with you.
-- Launch sessions pause at uncaught exceptions by default (breakOnExceptions "uncaught"; Ruby excepted — rdbg has no uncaught filter). Pass "none" to let crashing scripts run to termination; attach applies no default.${redactionRule}
+- Launch sessions pause at uncaught exceptions by default (breakOnExceptions "uncaught"; Ruby excepted — rdbg has no uncaught filter). Pass "none" to let crashing scripts run to termination; attach applies no default.${redactionRule}${variableAccessRule}
 
 For the full debugging workflow (root-cause discipline, per-language quirks), request the "debugging-workflow" prompt or install the agent skill from skills/debugging/ in the repo.`;
 }

--- a/src/utils/variable-access.ts
+++ b/src/utils/variable-access.ts
@@ -1,0 +1,40 @@
+/**
+ * Least-privilege variable access mode (issue #237).
+ *
+ * DEBUG_MCP_VARIABLE_ACCESS gates how variables may be retrieved:
+ *   - 'open':     bulk scope dumps allowed (the default)
+ *   - 'explicit': get_variables / get_local_variables require a names filter —
+ *                 the agent must ask for specific variables instead of
+ *                 sweeping every value in scope into its context
+ * Mode-style (rather than boolean) mirrors DEBUG_MCP_BP_ADDRESSING and leaves
+ * room for a future stricter tier without a second flag. The mode guards
+ * against indiscriminate bulk exposure, not against a determined agent:
+ * evaluate_expression stays available (already explicit-by-name, per-request,
+ * and audit-logged), and redaction still applies to all results.
+ */
+
+export type VariableAccessMode = 'open' | 'explicit';
+
+export const VARIABLE_ACCESS_ENV_KEY = 'DEBUG_MCP_VARIABLE_ACCESS';
+
+export const DEFAULT_VARIABLE_ACCESS: VariableAccessMode = 'open';
+
+const VALID_MODES: ReadonlySet<string> = new Set(['open', 'explicit']);
+
+/**
+ * Read the access mode from the environment. Unset, empty, or invalid values
+ * fall back to the shipped default ('open').
+ */
+export function getVariableAccessMode(environment: {
+  get(key: string): string | undefined;
+}): VariableAccessMode {
+  const raw = environment.get(VARIABLE_ACCESS_ENV_KEY)?.trim().toLowerCase();
+  if (raw && VALID_MODES.has(raw)) {
+    return raw as VariableAccessMode;
+  }
+  return DEFAULT_VARIABLE_ACCESS;
+}
+
+export function requiresExplicitNames(mode: VariableAccessMode): boolean {
+  return mode === 'explicit';
+}

--- a/tests/core/unit/server/server-inspection-tools.test.ts
+++ b/tests/core/unit/server/server-inspection-tools.test.ts
@@ -90,7 +90,7 @@ describe('Server Inspection Tools Tests', () => {
         }
       });
       
-      expect(mockSessionManager.getVariables).toHaveBeenCalledWith('test-session', 100);
+      expect(mockSessionManager.getVariables).toHaveBeenCalledWith('test-session', 100, undefined);
       
       const content = JSON.parse(result.content[0].text);
       expect(content.success).toBe(true);

--- a/tests/core/unit/server/server-variable-access-gating.test.ts
+++ b/tests/core/unit/server/server-variable-access-gating.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Least-privilege variable access gating tests (issue #237, second half).
+ *
+ * DEBUG_MCP_VARIABLE_ACCESS=explicit requires a `names` filter on
+ * get_variables / get_local_variables — schema (`required`), runtime
+ * enforcement, and instructions must all agree, per the
+ * DEBUG_MCP_BP_ADDRESSING precedent.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { DebugMcpServer } from '../../../../src/server.js';
+import { SessionManager } from '../../../../src/session/session-manager.js';
+import { createProductionDependencies } from '../../../../src/container/dependencies.js';
+import { buildServerInstructions } from '../../../../src/skill-content.js';
+import {
+  createMockDependencies,
+  createMockServer,
+  createMockSessionManager,
+  createMockStdioTransport,
+  getToolHandlers
+} from './server-test-helpers.js';
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js');
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js');
+vi.mock('../../../../src/session/session-manager.js');
+vi.mock('../../../../src/container/dependencies.js');
+
+function createServer(envOverrides: Record<string, string>) {
+  const mockDependencies = createMockDependencies();
+  mockDependencies.environment = {
+    get: vi.fn((key: string) => envOverrides[key]),
+    getAll: vi.fn(() => ({ ...envOverrides })),
+    getCurrentWorkingDirectory: vi.fn(() => process.cwd())
+  };
+  vi.mocked(createProductionDependencies).mockReturnValue(mockDependencies);
+
+  const mockServer = createMockServer();
+  vi.mocked(Server).mockImplementation(function() { return mockServer as any; });
+  const mockStdioTransport = createMockStdioTransport();
+  vi.mocked(StdioServerTransport).mockImplementation(function() { return mockStdioTransport as any; });
+
+  const mockSessionManager = createMockSessionManager(mockDependencies.adapterRegistry);
+  vi.mocked(SessionManager).mockImplementation(function() { return mockSessionManager as any; });
+
+  new DebugMcpServer();
+  mockSessionManager.getSession.mockReturnValue({ id: 'test-session', sessionLifecycle: 'ACTIVE' });
+
+  return { ...getToolHandlers(mockServer), mockSessionManager };
+}
+
+async function getToolSchema(listToolsHandler: any, name: string) {
+  const { tools } = await listToolsHandler({ method: 'tools/list', params: {} });
+  return tools.find((t: { name: string }) => t.name === name);
+}
+
+describe('Variable access gating (issue #237)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema gating', () => {
+    it('open mode (default): names is offered but not required', async () => {
+      const { listToolsHandler } = createServer({});
+      const getVariables = await getToolSchema(listToolsHandler, 'get_variables');
+      expect(getVariables.inputSchema.properties.names).toBeDefined();
+      expect(getVariables.inputSchema.required).toEqual(['sessionId', 'scope']);
+
+      const getLocals = await getToolSchema(listToolsHandler, 'get_local_variables');
+      expect(getLocals.inputSchema.properties.names).toBeDefined();
+      expect(getLocals.inputSchema.required).toEqual(['sessionId']);
+    });
+
+    it('explicit mode: names becomes required on both tools', async () => {
+      const { listToolsHandler } = createServer({ DEBUG_MCP_VARIABLE_ACCESS: 'explicit' });
+      const getVariables = await getToolSchema(listToolsHandler, 'get_variables');
+      expect(getVariables.inputSchema.required).toEqual(['sessionId', 'scope', 'names']);
+
+      const getLocals = await getToolSchema(listToolsHandler, 'get_local_variables');
+      expect(getLocals.inputSchema.required).toEqual(['sessionId', 'names']);
+    });
+  });
+
+  describe('names filtering (open mode)', () => {
+    it('passes names through to the session layer and reports notFound', async () => {
+      const { callToolHandler, mockSessionManager } = createServer({});
+      mockSessionManager.getVariables.mockResolvedValue([
+        { name: 'user', value: "'ada'", type: 'str', expandable: false }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'get_variables',
+          arguments: { sessionId: 'test-session', scope: 100, names: ['user', 'missing'] }
+        }
+      });
+
+      expect(mockSessionManager.getVariables).toHaveBeenCalledWith('test-session', 100, ['user', 'missing']);
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.notFound).toEqual(['missing']);
+    });
+
+    it('coerces a JSON-string names argument into an array (SSE transport quirk)', async () => {
+      const { callToolHandler, mockSessionManager } = createServer({});
+      mockSessionManager.getVariables.mockResolvedValue([]);
+
+      await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'get_variables',
+          arguments: { sessionId: 'test-session', scope: 100, names: '["user"]' }
+        }
+      });
+
+      expect(mockSessionManager.getVariables).toHaveBeenCalledWith('test-session', 100, ['user']);
+    });
+
+    it('omits notFound when no names filter was given', async () => {
+      const { callToolHandler, mockSessionManager } = createServer({});
+      mockSessionManager.getVariables.mockResolvedValue([
+        { name: 'x', value: '1', type: 'int', expandable: false }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_variables', arguments: { sessionId: 'test-session', scope: 100 } }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.notFound).toBeUndefined();
+    });
+  });
+
+  describe('explicit-mode enforcement', () => {
+    it('rejects get_variables without names with a clear InvalidParams error', async () => {
+      const { callToolHandler } = createServer({ DEBUG_MCP_VARIABLE_ACCESS: 'explicit' });
+
+      await expect(callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_variables', arguments: { sessionId: 'test-session', scope: 100 } }
+      })).rejects.toSatisfy((error: unknown) => {
+        expect(error).toBeInstanceOf(McpError);
+        expect((error as McpError).code).toBe(McpErrorCode.InvalidParams);
+        expect((error as McpError).message).toContain('DEBUG_MCP_VARIABLE_ACCESS=explicit');
+        expect((error as McpError).message).toContain('names');
+        return true;
+      });
+    });
+
+    it('rejects an empty names array the same way', async () => {
+      const { callToolHandler } = createServer({ DEBUG_MCP_VARIABLE_ACCESS: 'explicit' });
+
+      await expect(callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_variables', arguments: { sessionId: 'test-session', scope: 100, names: [] } }
+      })).rejects.toBeInstanceOf(McpError);
+    });
+
+    it('rejects get_local_variables without names', async () => {
+      const { callToolHandler } = createServer({ DEBUG_MCP_VARIABLE_ACCESS: 'explicit' });
+
+      await expect(callToolHandler({
+        method: 'tools/call',
+        params: { name: 'get_local_variables', arguments: { sessionId: 'test-session' } }
+      })).rejects.toSatisfy((error: unknown) => {
+        expect(error).toBeInstanceOf(McpError);
+        expect((error as McpError).message).toContain('DEBUG_MCP_VARIABLE_ACCESS=explicit');
+        return true;
+      });
+    });
+
+    it('accepts get_variables with names and threads them through', async () => {
+      const { callToolHandler, mockSessionManager } = createServer({ DEBUG_MCP_VARIABLE_ACCESS: 'explicit' });
+      mockSessionManager.getVariables.mockResolvedValue([
+        { name: 'user', value: "'ada'", type: 'str', expandable: false }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'get_variables',
+          arguments: { sessionId: 'test-session', scope: 100, names: ['user'] }
+        }
+      });
+
+      expect(mockSessionManager.getVariables).toHaveBeenCalledWith('test-session', 100, ['user']);
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.notFound).toEqual([]);
+    });
+
+    it('accepts get_local_variables with names', async () => {
+      const { callToolHandler, mockSessionManager } = createServer({ DEBUG_MCP_VARIABLE_ACCESS: 'explicit' });
+      mockSessionManager.getLocalVariables.mockResolvedValue({
+        variables: [{ name: 'total', value: '99', type: 'int', expandable: false }],
+        frame: { id: 1, name: 'main', file: 'test.py', line: 10 },
+        scopeName: 'Locals'
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'get_local_variables',
+          arguments: { sessionId: 'test-session', names: ['total', 'gone'] }
+        }
+      });
+
+      expect(mockSessionManager.getLocalVariables).toHaveBeenCalledWith('test-session', false, ['total', 'gone']);
+      const content = JSON.parse(result.content[0].text);
+      expect(content.notFound).toEqual(['gone']);
+    });
+  });
+
+  describe('server instructions', () => {
+    it('mentions least-privilege mode when explicit', () => {
+      const instructions = buildServerInstructions(undefined, { variableAccessMode: 'explicit' });
+      expect(instructions).toContain('least-privilege');
+      expect(instructions).toContain('names');
+    });
+
+    it('says nothing about least-privilege in open mode', () => {
+      const instructions = buildServerInstructions(undefined, { variableAccessMode: 'open' });
+      expect(instructions).not.toContain('least-privilege');
+    });
+  });
+});

--- a/tests/core/unit/session/session-manager-names-filter.test.ts
+++ b/tests/core/unit/session/session-manager-names-filter.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Session-layer `names` filter tests (issue #237, least-privilege half).
+ *
+ * getVariables/getLocalVariables accept an optional exact-match,
+ * case-sensitive list of variable names; only matching variables are
+ * returned (and only they are redacted/logged).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SessionManager, SessionManagerConfig } from '../../../../src/session/session-manager.js';
+import { DebugLanguage } from '@debugmcp/shared';
+import { createMockDependencies, createMockEnvironment } from './session-manager-test-utils.js';
+
+function makeManager() {
+  const dependencies = createMockDependencies();
+  dependencies.environment = createMockEnvironment({ DEBUG_MCP_NO_REDACT: '' });
+  const config: SessionManagerConfig = {
+    logDirBase: '/tmp/test-sessions',
+    defaultDapLaunchArgs: { stopOnEntry: true, justMyCode: true }
+  };
+  return { sessionManager: new SessionManager(config, dependencies), dependencies };
+}
+
+async function createPausedSession(
+  sessionManager: SessionManager,
+  dependencies: ReturnType<typeof createMockDependencies>
+) {
+  const session = await sessionManager.createSession({
+    language: DebugLanguage.MOCK,
+    executablePath: 'python'
+  });
+  await sessionManager.startDebugging(session.id, 'test.py');
+  await vi.runAllTimersAsync();
+  dependencies.mockProxyManager.simulateStopped(1, 'entry');
+  return session;
+}
+
+function stubVariables(dependencies: ReturnType<typeof createMockDependencies>) {
+  dependencies.mockProxyManager.setDapRequestHandler(async (command: string, args?: any) => {
+    if (command === 'variables') {
+      return {
+        success: true,
+        body: {
+          variables: [
+            { name: 'user', value: "'ada'", type: 'str', variablesReference: 0 },
+            { name: 'User', value: "'ADA'", type: 'str', variablesReference: 0 },
+            { name: 'total', value: '99', type: 'int', variablesReference: 0 }
+          ]
+        }
+      };
+    }
+    if (command === 'stackTrace') {
+      return {
+        success: true,
+        body: { stackFrames: [{ id: 1, name: 'main', source: { path: 'test.py' }, line: 10, column: 0 }] }
+      };
+    }
+    if (command === 'scopes') {
+      return {
+        success: true,
+        body: { scopes: [{ name: 'Locals', variablesReference: 100, expensive: false }] }
+      };
+    }
+    return { success: true, args };
+  });
+}
+
+describe('SessionManager - names filter (issue #237)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('getVariables returns only the requested names, case-sensitively', async () => {
+    const { sessionManager, dependencies } = makeManager();
+    const session = await createPausedSession(sessionManager, dependencies);
+    stubVariables(dependencies);
+
+    const variables = await sessionManager.getVariables(session.id, 100, ['user', 'missing']);
+
+    expect(variables.map(v => v.name)).toEqual(['user']);
+  });
+
+  it('getVariables without names returns everything (unchanged behavior)', async () => {
+    const { sessionManager, dependencies } = makeManager();
+    const session = await createPausedSession(sessionManager, dependencies);
+    stubVariables(dependencies);
+
+    const variables = await sessionManager.getVariables(session.id, 100);
+
+    expect(variables).toHaveLength(3);
+  });
+
+  it('getLocalVariables filters the extracted locals by names', async () => {
+    const { sessionManager, dependencies } = makeManager();
+    const session = await createPausedSession(sessionManager, dependencies);
+    stubVariables(dependencies);
+
+    const result = await sessionManager.getLocalVariables(session.id, false, ['total']);
+
+    expect(result.variables.map((v: { name: string }) => v.name)).toEqual(['total']);
+  });
+});

--- a/tests/unit/utils/variable-access.test.ts
+++ b/tests/unit/utils/variable-access.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VARIABLE_ACCESS_ENV_KEY,
+  DEFAULT_VARIABLE_ACCESS,
+  getVariableAccessMode,
+  requiresExplicitNames,
+} from '../../../src/utils/variable-access.js';
+
+function envWith(value: string | undefined) {
+  return {
+    get: (key: string) => (key === VARIABLE_ACCESS_ENV_KEY ? value : undefined),
+  };
+}
+
+describe('variable access mode helpers', () => {
+  it('defaults to open when the env variable is unset', () => {
+    expect(getVariableAccessMode(envWith(undefined))).toBe('open');
+    expect(DEFAULT_VARIABLE_ACCESS).toBe('open');
+  });
+
+  it('defaults to open for empty or whitespace-only values', () => {
+    expect(getVariableAccessMode(envWith(''))).toBe('open');
+    expect(getVariableAccessMode(envWith('   '))).toBe('open');
+  });
+
+  it('parses each valid mode, normalizing case and whitespace', () => {
+    expect(getVariableAccessMode(envWith('open'))).toBe('open');
+    expect(getVariableAccessMode(envWith('explicit'))).toBe('explicit');
+    expect(getVariableAccessMode(envWith(' EXPLICIT '))).toBe('explicit');
+  });
+
+  it('falls back to open for invalid values', () => {
+    expect(getVariableAccessMode(envWith('strict'))).toBe('open');
+    expect(getVariableAccessMode(envWith('1'))).toBe('open');
+    expect(getVariableAccessMode(envWith('true'))).toBe('open');
+  });
+
+  it('requires explicit names only in explicit mode', () => {
+    expect(requiresExplicitNames('open')).toBe(false);
+    expect(requiresExplicitNames('explicit')).toBe(true);
+  });
+
+  it('uses the documented env key', () => {
+    expect(VARIABLE_ACCESS_ENV_KEY).toBe('DEBUG_MCP_VARIABLE_ACCESS');
+  });
+});


### PR DESCRIPTION
Second half of #237, stacked on #315 (retarget to main after #315 merges, or merge in order).

## What

`DEBUG_MCP_VARIABLE_ACCESS=explicit` disables bulk scope dumps: `get_variables` and `get_local_variables` require an explicit `names` filter, so the agent must ask for specific variables instead of sweeping every value in scope into its context. Closes #237 together with #315.

- **Mode flag** `src/utils/variable-access.ts` (`open` default | `explicit`), following the `DEBUG_MCP_BP_ADDRESSING` precedent across every surface: tool schemas gate `required`, runtime enforcement rejects unfiltered calls with an `InvalidParams` error that teaches the correct call shape (acceptance criterion d), and the initialize instructions advertise the mode so agents adapt without trial and error.
- **`names: string[]`** works in the default mode too, as an ordinary filter: exact-match and case-sensitive, applied in the session layer *before* redaction and logging (unrequested values never leave the raw response object). The response's `notFound` array distinguishes "filtered" from "doesn't exist".
- **`evaluate_expression` deliberately not restricted** (documented stance): least-privilege guards against indiscriminate bulk exposure, not a determined agent — evaluate is already explicit-by-name, per-request, and audit-logged, which is precisely the access discipline the mode enforces; and it is the core debugging primitive. Redaction (#315) still applies to its results. A future `strict` tier has room in the mode enum if demand appears.

## Tests

Mode-helper unit tests; session-layer filter tests; server gating tests (schema `required` per mode, explicit-without-names rejection incl. empty array, `notFound`, case-sensitivity, SSE string-form coercion, instructions text). Full suite: 3294 unit tests green; `names` + `notFound` + redaction interplay verified live against a Python session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)