### PR TITLE
fix(ruby): apply launchConfig.env to the debuggee spawn env (#318)

### DIFF
--- a/docs/ruby/README.md
+++ b/docs/ruby/README.md
@@ -83,6 +83,14 @@ set `$stdout.sync = false` itself. Attach mode connects to a process the server 
 start, so no prelude is injected there — set `$stdout.sync = true` in your program if you
 need mid-run output while attached.
 
+### Environment variables
+
+Launch mode applies `dapLaunchArgs.env` to the debuggee's process environment at spawn
+time (because `rdbg -c` starts the script immediately, the later DAP launch request
+cannot carry it). An explicit value there wins over the server's inherited environment.
+Attach mode cannot set env — the target process is already running; set variables before
+starting it.
+
 ### Bundler projects
 
 Pass `useBundler` through the launch configuration to run the target via `bundle exec`:

--- a/packages/adapter-ruby/src/ruby-debug-adapter.ts
+++ b/packages/adapter-ruby/src/ruby-debug-adapter.ts
@@ -260,9 +260,14 @@ export class RubyDebugAdapter extends EventEmitter implements IDebugAdapter {
     return {
       command: invocation.command,
       args: invocation.args,
+      // rdbg -c starts the debuggee at spawn time, so the spawn env is the
+      // only channel for launchConfig.env — the later DAP launch request is
+      // an ack (issue #318). User env last: an explicit value wins over both
+      // inherited process.env and adapter defaults.
       env: {
         ...process.env,
-        RUBY_DEBUG_DAP_SHOW_PROTOCOL: process.env.DEBUG ? '1' : '0'
+        RUBY_DEBUG_DAP_SHOW_PROTOCOL: process.env.DEBUG ? '1' : '0',
+        ...(launchConfig.env ?? {})
       }
     };
   }

--- a/packages/adapter-ruby/tests/unit/ruby-debug-adapter.test.ts
+++ b/packages/adapter-ruby/tests/unit/ruby-debug-adapter.test.ts
@@ -32,6 +32,7 @@ const createDependencies = () => ({
 describe('RubyDebugAdapter', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('caches resolveExecutablePath results', async () => {
@@ -131,6 +132,61 @@ describe('RubyDebugAdapter', () => {
       '-r/tmp/logs/mcp_stdout_sync.rb',
       '/workspace/app.rb'
     ]);
+  });
+
+  it('merges launchConfig.env into the spawn env (issue #318)', () => {
+    vi.mocked(ensureRubySyncHelper).mockReturnValue('/tmp/logs/mcp_stdout_sync.rb');
+    vi.stubEnv('MCP_TEST_INHERITED', 'old');
+    const adapter = new RubyDebugAdapter(createDependencies());
+    (adapter as unknown as { rdbgPathCache: Map<string, { path: string; timestamp: number }> })
+      .rdbgPathCache.set('default', { path: '/usr/bin/rdbg', timestamp: Date.now() });
+
+    const command = adapter.buildAdapterCommand({
+      sessionId: 'ruby-session',
+      executablePath: '/usr/bin/ruby',
+      adapterHost: '127.0.0.1',
+      adapterPort: 8123,
+      logDir: '/tmp/logs',
+      scriptPath: '/workspace/app.rb',
+      scriptArgs: [],
+      launchConfig: {
+        env: {
+          RAILS_ENV: 'test',
+          MCP_TEST_INHERITED: 'new',
+          RUBY_DEBUG_DAP_SHOW_PROTOCOL: '1'
+        }
+      }
+    });
+
+    // User-supplied values reach the debuggee (rdbg -c starts it at spawn
+    // time, so the spawn env is the only channel).
+    expect(command.env?.RAILS_ENV).toBe('test');
+    // An explicit user value wins over the inherited process.env value...
+    expect(command.env?.MCP_TEST_INHERITED).toBe('new');
+    // ...and over adapter defaults.
+    expect(command.env?.RUBY_DEBUG_DAP_SHOW_PROTOCOL).toBe('1');
+  });
+
+  it('keeps the default spawn env when no launchConfig.env is given', () => {
+    vi.mocked(ensureRubySyncHelper).mockReturnValue('/tmp/logs/mcp_stdout_sync.rb');
+    vi.stubEnv('MCP_TEST_INHERITED', 'inherited');
+    const adapter = new RubyDebugAdapter(createDependencies());
+    (adapter as unknown as { rdbgPathCache: Map<string, { path: string; timestamp: number }> })
+      .rdbgPathCache.set('default', { path: '/usr/bin/rdbg', timestamp: Date.now() });
+
+    const command = adapter.buildAdapterCommand({
+      sessionId: 'ruby-session',
+      executablePath: '/usr/bin/ruby',
+      adapterHost: '127.0.0.1',
+      adapterPort: 8123,
+      logDir: '/tmp/logs',
+      scriptPath: '/workspace/app.rb',
+      scriptArgs: [],
+      launchConfig: {}
+    });
+
+    expect(command.env?.MCP_TEST_INHERITED).toBe('inherited');
+    expect(command.env?.RUBY_DEBUG_DAP_SHOW_PROTOCOL).toBe('0');
   });
 
   it('launches without the prelude when the sync helper cannot be materialized', () => {

--- a/tests/e2e/mcp-server-smoke-ruby.test.ts
+++ b/tests/e2e/mcp-server-smoke-ruby.test.ts
@@ -268,4 +268,46 @@ describe('MCP Server Ruby Debugging Smoke Test @requires-ruby', () => {
     })) as { sessions?: Array<{ id: string; state: string }> };
     expect(listResponse.sessions?.find(s => s.id === sessionId)?.state).toBe('paused');
   }, 90000);
+
+  it('applies dapLaunchArgs.env to the debuggee (issue #318)', async () => {
+    if (!(await rubyToolchainAvailable())) {
+      console.log('[Ruby Smoke Test] Ruby/rdbg not available, skipping launch env test');
+      return;
+    }
+
+    const testRubyFile = path.resolve(ROOT, 'examples', 'ruby', 'fizzbuzz.rb');
+
+    const createResponse = parseSdkToolResult(await mcpClient!.callTool({
+      name: 'create_debug_session',
+      arguments: { language: 'ruby', name: 'ruby-launch-env-test' }
+    }));
+    expect(createResponse.sessionId).toBeDefined();
+    sessionId = createResponse.sessionId as string;
+
+    const bpResponse = await callToolSafely(mcpClient!, 'set_breakpoint', {
+      sessionId,
+      file: testRubyFile,
+      line: 15
+    });
+    expect(bpResponse.success).toBe(true);
+
+    // rdbg -c starts the debuggee at spawn time, so env can only reach it
+    // through the spawn environment — the DAP launch request is an ack.
+    const startResponse = parseSdkToolResult(await mcpClient!.callTool({
+      name: 'start_debugging',
+      arguments: {
+        sessionId,
+        scriptPath: testRubyFile,
+        dapLaunchArgs: { env: { MCP_TEST_ENV_318: 'hello-318' } }
+      }
+    })) as { state?: string };
+    expect(startResponse.state).toBe('paused');
+
+    const evalResult = await callToolSafely(mcpClient!, 'evaluate_expression', {
+      sessionId,
+      expression: "ENV['MCP_TEST_ENV_318']"
+    });
+    // rdbg inspects results, so a String comes back quoted.
+    expect(String(evalResult.result)).toContain('hello-318');
+  }, 90000);
 });


### PR DESCRIPTION
Fixes #318.

## Problem

`env` passed via `dapLaunchArgs` was silently dropped on the ruby launch path. It survives `transformLaunchConfig` into the DAP `launch` request, but with `rdbg --open -c -- ruby <script>` the debuggee is already running when that request arrives — the launch response is effectively an ack. Ruby is the only adapter with this gap: python/js/go/rust/dotnet/java all apply user env when the debug adapter launches the debuggee at DAP-launch time (verified per adapter).

Everything upstream and downstream was already correct — `dapLaunchArgs.env` lands at `AdapterConfig.launchConfig.env` with no shadowed-key warning (`env` is deliberately listed as a legitimate DAP launch key in `server.ts`), and the spawn plumbing passes `AdapterCommand.env` verbatim. The single break was `buildAdapterCommand` never reading it.

## Fix

Merge `launchConfig.env` into the spawn env, user values last:

```ts
env: {
  ...process.env,
  RUBY_DEBUG_DAP_SHOW_PROTOCOL: process.env.DEBUG ? '1' : '0',
  ...(launchConfig.env ?? {})
}
```

An explicit user value wins over both inherited `process.env` and adapter defaults (a user setting `RUBY_DEBUG_DAP_SHOW_PROTOCOL` explicitly presumably intends it). Env inherits through `bundle exec` automatically; no interaction with the #317 `-r` prelude (argv vs env). Attach mode untouched — the target process is already running (documented).

## Tests

- **Hard e2e** (`mcp-server-smoke-ruby.test.ts`): launch fizzbuzz with `dapLaunchArgs: { env: { MCP_TEST_ENV_318: 'hello-318' } }`, evaluate `ENV['MCP_TEST_ENV_318']` at a breakpoint. Red against the pre-fix build (`"nil"`), green after.
- **Unit**: merge order pinned — user env reaches `command.env`, overrides an inherited `process.env` key, and overrides the adapter default; no-env case pins today's behavior. Added `vi.unstubAllEnvs()` to the suite's `afterEach` since env stubbing is now in play.
- Full ruby suite green (unit, integration, all 5 smoke e2e tests including #317's); docs updated (`docs/ruby/README.md` new "Environment variables" section).

Sibling gap filed as #320: `launchConfig.cwd` is dead on the ruby launch path the same way (`AdapterCommand` has no cwd channel; spawn layer already supports it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)