### PR TITLE
docs: osoji cleanup wave 1 — align docs/skills with shipped C++ adapter, codelldb-common split, and current tool surface

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ mcp-debugger is a Model Context Protocol (MCP) server that bridges MCP clients (
 
 ## Monorepo Structure
 
-The project uses pnpm workspaces with 10 packages:
+The project uses pnpm workspaces with 13 packages (the root workspace plus 12 under `packages/`):
 
 ```
 packages/
@@ -16,11 +16,13 @@ packages/
   adapter-go/         Go debugging via Delve
   adapter-java/       Java debugging via JDI bridge
   adapter-dotnet/     .NET/C# debugging via netcoredbg
+  adapter-cpp/        C/C++ debugging via CodeLLDB
+  codelldb-common/    Shared CodeLLDB infrastructure (vendoring, transport) for the Rust and C/C++ adapters
   adapter-mock/       Mock adapter for testing
   mcp-debugger/       Self-contained CLI bundle (npx distribution)
 ```
 
-Build order: `shared` -> adapters -> `mcp-debugger` CLI bundle.
+Build order: `shared` -> `codelldb-common` -> adapters -> `mcp-debugger` CLI bundle.
 
 ## Data Flow
 
@@ -50,7 +52,7 @@ Each debug session runs in a **separate process** for isolation. The ProxyManage
 
 ## Key Components
 
-- **MCP Server** (`src/server.ts`): Registers 21 MCP tools, handles STDIO and SSE transports, dynamically discovers available language adapters
+- **MCP Server** (`src/server.ts`): Registers 28 MCP tools, handles STDIO and SSE transports, dynamically discovers available language adapters
 - **SessionManager** (`src/session/`): 4-class inheritance hierarchy managing session lifecycle (`CREATED` -> `INITIALIZING` -> `READY` -> `RUNNING` <-> `PAUSED` -> `STOPPED`)
 - **Adapter Registry** (`src/adapters/`): Dynamic loading of adapters on-demand via ES module imports
 - **Adapter Policies** (`src/proxy/`): Language-specific DAP behavior via the policy pattern (e.g., `PythonAdapterPolicy`, `JsDebugAdapterPolicy`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,6 +287,8 @@ mcp-debugger/
 │   ├── adapter-go/        # Go adapter (Delve)
 │   ├── adapter-java/      # Java adapter (JDI bridge)
 │   ├── adapter-dotnet/    # .NET/C# adapter (netcoredbg)
+│   ├── adapter-cpp/       # C/C++ adapter (CodeLLDB)
+│   ├── codelldb-common/   # Shared CodeLLDB infrastructure (Rust + C/C++ adapters)
 │   ├── adapter-mock/      # Mock adapter for testing
 │   └── mcp-debugger/      # Self-contained CLI bundle (npx distribution)
 ├── src/                    # Core server source code
@@ -313,7 +315,7 @@ mcp-debugger/
 - **DAP Proxy**: Handles communication with debug adapters via DAP protocol
 - **Adapter Registry**: Dynamically loads and manages language-specific adapters
 - **Adapter Policies**: Language-specific behavior via policy pattern
-- **MCP Tools**: Implements the 21 MCP protocol tools
+- **MCP Tools**: Implements the 28 MCP protocol tools
 
 ## 🏃 Running the Demo
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="assets/logo.png" alt="MCP Debugger Logo - A stylized circuit board with debug breakpoints" width="400" height="400">
 </div>
 
-**A headless, agentic debugger over MCP — let your AI agents debug running programs in seven languages.**
+**A headless, agentic debugger over MCP — let your AI agents debug running programs in eight languages.**
 
 [![CI](https://github.com/debugmcp/mcp-debugger/actions/workflows/ci.yml/badge.svg)](https://github.com/debugmcp/mcp-debugger/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/debugmcp/mcp-debugger/branch/main/graph/badge.svg)](https://codecov.io/gh/debugmcp/mcp-debugger)
@@ -16,7 +16,7 @@
 
 ## 🎯 Overview
 
-mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through debugging as structured tool calls. It lets AI agents set breakpoints, inspect variables, evaluate expressions, and step through running programs across seven languages — driving real language debuggers through the Debug Adapter Protocol (DAP).
+mcp-debugger is a Model Context Protocol (MCP) server that exposes step-through debugging as structured tool calls. It lets AI agents set breakpoints, inspect variables, evaluate expressions, and step through running programs across eight languages — driving real language debuggers through the Debug Adapter Protocol (DAP).
 
 **No IDE required.** mcp-debugger runs anywhere Node.js runs: CI runners, Docker containers, Kubernetes pods, SSH boxes, and the sandboxes that cloud coding agents live in. It's the debugger for where IDEs can't go.
 

--- a/docs/architecture/api-reference.md
+++ b/docs/architecture/api-reference.md
@@ -524,6 +524,7 @@ enum DebugLanguage {
   GO = 'go',
   JAVA = 'java',
   DOTNET = 'dotnet',
+  CPP = 'cpp',
   MOCK = 'mock',
 }
 
@@ -547,6 +548,7 @@ interface AdapterCommand {
   command: string;
   args: string[];
   env?: Record<string, string>;
+  cwd?: string;  // Working directory for the adapter process (issue #320)
 }
 ```
 
@@ -595,8 +597,8 @@ const sessionInfo = await sessionManager.createSession({
 });
 
 // 2. Set breakpoints (one call per breakpoint)
-await sessionManager.setBreakpoint(sessionInfo.sessionId, 'app.py', 10);
-await sessionManager.setBreakpoint(sessionInfo.sessionId, 'app.py', 20);
+await sessionManager.setBreakpoint(sessionInfo.sessionId, { file: 'app.py', line: 10 });
+await sessionManager.setBreakpoint(sessionInfo.sessionId, { file: 'app.py', line: 20 });
 
 // 3. Start debugging
 await sessionManager.startDebugging({

--- a/docs/error-handling-guide.md
+++ b/docs/error-handling-guide.md
@@ -36,6 +36,7 @@ export class SessionNotFoundError extends McpError {
 | `LanguageRuntimeNotFoundError` | Language runtime not found (generic) | `InvalidParams` |
 | `DebugSessionCreationError` | Failed to create session | `InternalError` |
 | `UnsupportedLanguageError` | Language not supported or adapter not found | `InvalidParams` |
+| `UnsupportedFeatureError` | Feature not supported by the session's adapter (e.g. logpoints) | `InvalidParams` |
 
 ## Implementation Patterns
 
@@ -192,9 +193,15 @@ describe('ProxyManager - Integration', () => {
 Some operations return empty data instead of throwing errors for better UX:
 
 ```typescript
-// getVariables, getStackTrace, getScopes:
+// getVariables, getScopes:
 // - Unknown session ID → throws SessionNotFoundError
 // - Valid session but not paused, no active proxy, or DAP request fails → returns []
+//
+// getStackTrace, getLocalVariables:
+// - Unknown session ID → throws SessionNotFoundError
+// - Valid session but not paused or no active proxy → returns empty data
+// - DAP request fails → THROWS (a failed DAP response must not be flattened
+//   into an empty-but-successful result; see issue #124)
 
 async getVariables(sessionId: string, ref: number): Promise<Variable[]> {
   const session = this._getSessionById(sessionId); // throws SessionNotFoundError if not found

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Debug MCP Server
 
-This guide will walk you through testing the Debug MCP Server locally with a simple Python example. The server also supports Ruby, JavaScript, Rust, Go, Java, and .NET/C# debugging -- see the language-specific guides for details.
+This guide will walk you through testing the Debug MCP Server locally with a simple Python example. The server also supports Ruby, JavaScript, Rust, Go, Java, .NET/C#, and C/C++ debugging -- see the language-specific guides for details.
 
 ## Prerequisites
 

--- a/docs/go/README.md
+++ b/docs/go/README.md
@@ -256,7 +256,7 @@ Note: The MCP tools do not expose goroutine-specific commands (listing goroutine
 
 ### Exception Breakpoints
 
-The Go adapter supports exception breakpoints with two built-in filters: `panic` (break on panic, enabled by default) and `fatal` (break on fatal errors, enabled by default). These are declared in the adapter's capabilities and sent to Delve during session configuration. Custom exception breakpoint configuration can also be provided via `dapLaunchArgs`.
+The Go adapter supports exception breakpoints with two built-in filters: `unrecovered-panic` (break on unrecovered panics, enabled by default) and `runtime-fatal-throw` (break on fatal runtime errors, enabled by default). These are declared in the adapter's capabilities and sent to Delve during session configuration. Custom exception breakpoint configuration can also be provided via `dapLaunchArgs`.
 
 ## Debugging Tips
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,20 +1,22 @@
 # mcp-debugger Migration Guide
 
 > **📌 UPDATED DOCUMENTATION**
-> This migration guide covers changes through v0.19.0, including dynamic adapter loading and major UX improvements.
+> This migration guide covers changes through v0.23.x, including dynamic adapter loading and major UX improvements.
 
 ## What's New in v0.15.0
 
 ### ✅ Dynamic Adapter Loading (No Breaking Changes)
 This release introduces dynamic discovery and loading of language adapters at runtime. The core no longer statically imports adapters; instead, it uses a loader/registry to import packages by convention.
 
-- Adapters live in separate packages:
+- Adapters live in separate packages (9 adapters):
   - `@debugmcp/adapter-python`
+  - `@debugmcp/adapter-ruby`
   - `@debugmcp/adapter-javascript`
   - `@debugmcp/adapter-rust`
   - `@debugmcp/adapter-go`
   - `@debugmcp/adapter-java`
   - `@debugmcp/adapter-dotnet`
+  - `@debugmcp/adapter-cpp`
   - `@debugmcp/adapter-mock`
 - Adapters are bundled at build time into the `@debugmcp/mcp-debugger` CLI package (not optional npm dependencies that consumers install separately)
 - The core discovers and loads adapters on demand:
@@ -22,13 +24,13 @@ This release introduces dynamic discovery and loading of language adapters at ru
   - Factory class export: `<CapitalizedLanguage>AdapterFactory` (named export; the loader looks up this class name via convention)
 
 ### 🔧 User Guidance
-- Install the package (adapter packages are bundled as optional dependencies):
+- Install the package (all adapters are bundled into the CLI at build time; the published package has zero runtime dependencies):
   ```bash
   npm install @debugmcp/mcp-debugger
   ```
 - Verify availability:
   - Call the `list_supported_languages` tool (from your MCP client) to see which adapters are discoverable
-  - All adapter packages are included as optional dependencies of `@debugmcp/mcp-debugger` and are installed automatically when available
+  - All adapter packages are bundled into `@debugmcp/mcp-debugger` at build time -- nothing extra is installed at runtime
 
 ### 🐳 Container Notes
 - Stdout in stdio mode must be NDJSON-only; the runtime preloads a silencer that mirrors logs to `/app/logs` without altering protocol
@@ -238,11 +240,13 @@ If you want to add support for a new language:
    ```typescript
    enum DebugLanguage {
      PYTHON = 'python',
+     RUBY = 'ruby',
      JAVASCRIPT = 'javascript',
      RUST = 'rust',
      GO = 'go',
      JAVA = 'java',
      DOTNET = 'dotnet',
+     CPP = 'cpp',
      MOCK = 'mock',
      MYLANG = 'mylang'  // Add your language
    }
@@ -392,7 +396,7 @@ await mcp.startDebugging({
 ```typescript
 // Verify adapter is being used
 const languages = await mcp.getSupportedLanguages();
-console.log('Supported:', languages);  // Should include 'python', 'javascript', 'rust', 'go', 'java', 'dotnet', 'mock'
+console.log('Supported:', languages);  // Should include 'python', 'ruby', 'javascript', 'rust', 'go', 'java', 'dotnet', 'cpp', 'mock'
 ```
 
 ### 3. Event Handling Test

--- a/docs/rust-debugging.md
+++ b/docs/rust-debugging.md
@@ -13,7 +13,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ### 2. CodeLLDB (Automatic)
 The Rust adapter automatically downloads CodeLLDB when you build it:
 ```bash
-cd packages/adapter-rust
+cd packages/codelldb-common
 npm run build:adapter  # Downloads and extracts CodeLLDB
 ```
 
@@ -24,7 +24,7 @@ The Rust adapter bundles the CodeLLDB binaries into `packages/codelldb-common/ve
 - `pnpm install` (postinstall hook)
 - `pnpm vendor` or `pnpm vendor:adapters`
 - `pnpm --filter @debugmcp/codelldb-common run build:adapter`
-- `node packages/adapter-rust/scripts/vendor-codelldb.js`
+- `node packages/codelldb-common/scripts/vendor-codelldb.js`
 
 > **Default behavior:** Locally, the vendoring script downloads **all supported platforms** (win32-x64, linux-x64, linux-arm64, darwin-x64, darwin-arm64) so Docker builds can reuse the same artifacts. Set `CODELLDB_VENDOR_ALL=false` to vendor only the current host platform. In CI environments, the script vendors only the current platform unless `CODELLDB_VENDOR_ALL=true` is explicitly set.
 
@@ -324,7 +324,7 @@ opt-level = 0  # No optimization for better debugging
 If CodeLLDB is not found:
 ```bash
 # Re-run the vendor script
-cd packages/adapter-rust
+cd packages/codelldb-common
 npm run build:adapter
 
 # Check if it was downloaded (fixed layout under vendor/codelldb/ with per-platform subdirectories)

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -7,7 +7,7 @@ This directory contains example Rust projects for testing and demonstrating the 
 1. **Rust toolchain**: Install Rust from [rustup.rs](https://rustup.rs/)
 2. **CodeLLDB**: The Rust adapter will automatically download CodeLLDB when you run:
    ```bash
-   cd packages/adapter-rust
+   cd packages/codelldb-common
    npm run build:adapter
    ```
 

--- a/mcp_debugger_launcher/mcp_debugger_launcher/cli.py
+++ b/mcp_debugger_launcher/mcp_debugger_launcher/cli.py
@@ -39,7 +39,7 @@ def print_runtime_status(runtimes: dict, verbose: bool = False):
     if runtimes["docker"]["available"]:
         print(f"✅ Docker: {runtimes['docker']['version']}")
         if verbose:
-            if "daemon not running" in runtimes["docker"]["version"]:
+            if "daemon not running" in (runtimes["docker"]["version"] or ""):
                 print("   └─ Docker daemon is not running")
             elif runtimes["docker"]["image_exists"]:
                 print("   └─ debugmcp/mcp-debugger:latest: Found locally")

--- a/packages/adapter-javascript/docs/LESSONS_LEARNED.md
+++ b/packages/adapter-javascript/docs/LESSONS_LEARNED.md
@@ -15,7 +15,7 @@ The JavaScript adapter was experiencing consistent `ECONNREFUSED` errors when at
 - **Result**: Connection attempts failed because IPv4 and IPv6 addresses are not interchangeable
 
 ### The Solution
-The fix involves two distinct layers. For child-session creation (e.g., the `JavascriptDebugAdapter.buildAdapterCommand` host default), `'localhost'` is used so that Node.js can resolve to both IPv4 and IPv6 automatically. For DAP attach requests within child sessions, `JsDebugAdapterPolicy` uses `'127.0.0.1'` explicitly to match the address family expected by the child debug target. The session manager (`session-manager-operations.ts`) also uses `'127.0.0.1'` as the `adapterHost` for all adapters.
+The fix involves two distinct layers. For child-session creation, the `JavascriptDebugAdapter.buildAdapterCommand` host default is `'127.0.0.1'` (overridable via the `adapterHost` config), so the spawn address family is pinned explicitly to IPv4. For DAP attach requests within child sessions, `JsDebugAdapterPolicy` uses `'127.0.0.1'` explicitly to match the address family expected by the child debug target. The session manager (`session-manager-operations.ts`) also uses `'127.0.0.1'` as the `adapterHost` for all adapters.
 
 **Key Files:**
 - `src/session/session-manager-operations.ts` - General adapter host configuration
@@ -33,7 +33,7 @@ Created `tests/manual/test-jsdebug-transport.js` to verify:
 - ✅ TCP mode works with IPv6
 
 ### Key Takeaway
-**Use `'localhost'` for adapter spawn commands** (e.g., `buildAdapterCommand` host default) so Node.js can resolve to both IPv4 and IPv6. However, the session manager (`session-manager-operations.ts`) uses `'127.0.0.1'` as the `adapterHost` for all adapters, and `JsDebugAdapterPolicy` uses `'127.0.0.1'` for DAP attach requests within child sessions. The choice depends on the layer and what the target expects.
+**The `buildAdapterCommand` host default is `'127.0.0.1'`** (overridable via the `adapterHost` config). Likewise, the session manager (`session-manager-operations.ts`) uses `'127.0.0.1'` as the `adapterHost` for all adapters, and `JsDebugAdapterPolicy` uses `'127.0.0.1'` for DAP attach requests within child sessions. The choice depends on the layer and what the target expects.
 
 ---
 
@@ -142,7 +142,7 @@ If experiencing connection failures:
 
 1. **Check the host configuration:**
    ```typescript
-   // For adapter spawn commands (buildAdapterCommand), prefer 'localhost'
+   // buildAdapterCommand defaults the spawn host to '127.0.0.1' ('adapterHost' config overrides)
    // For session-manager adapterHost and child-session attach, '127.0.0.1' is used
    adapterHost: '127.0.0.1'  // Used in session-manager-operations.ts
    ```

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -27,7 +27,7 @@ npm run build -w @debugmcp/adapter-mock
 
 ## Exports
 
-import { MockAdapterFactory, MockDebugAdapter, MockErrorScenario, createMockAdapterFactory } from '@debugmcp/adapter-mock';
+import { MockAdapterFactory, MockDebugAdapter, MockErrorScenario } from '@debugmcp/adapter-mock';
 import type { MockAdapterConfig } from '@debugmcp/adapter-mock';
 
 ## Notes

--- a/packages/mcp-debugger/README.md
+++ b/packages/mcp-debugger/README.md
@@ -1,6 +1,6 @@
 # @debugmcp/mcp-debugger
 
-Step-through debugging MCP server for LLMs across seven languages
+Step-through debugging MCP server for LLMs across eight languages
 
 ## Installation
 
@@ -47,6 +47,7 @@ All language adapters are bundled into the CLI package. No separate installation
 - **Go** (`@debugmcp/adapter-go`) - Go debugging via Delve
 - **Java** (`@debugmcp/adapter-java`) - Java debugging via JDI bridge
 - **.NET** (`@debugmcp/adapter-dotnet`) - .NET debugging via netcoredbg
+- **C/C++** (`@debugmcp/adapter-cpp`) - C/C++ debugging via CodeLLDB
 - **Mock** (`@debugmcp/adapter-mock`) - Mock adapter for testing
 
 **System Requirements:** Node.js 22+ is required to run mcp-debugger. You also need the language runtimes and debug tools installed on your system (e.g., Python + debugpy, Ruby + the `debug` gem / `rdbg`, Go + Delve, JDK 21+, netcoredbg with a compatible .NET runtime).

--- a/packages/shared/src/utils/line-buffer.ts
+++ b/packages/shared/src/utils/line-buffer.ts
@@ -25,7 +25,8 @@ export class LineBuffer {
     this.pending = parts.pop() ?? '';
     const lines = parts.map(line => (line.endsWith('\r') ? line.slice(0, -1) : line));
     if (this.pending.length > this.maxPendingLength) {
-      lines.push(this.pending);
+      const overflow = this.pending;
+      lines.push(overflow.endsWith('\r') ? overflow.slice(0, -1) : overflow);
       this.pending = '';
     }
     return lines;
@@ -38,6 +39,6 @@ export class LineBuffer {
     }
     const line = this.pending;
     this.pending = '';
-    return [line];
+    return [line.endsWith('\r') ? line.slice(0, -1) : line];
   }
 }

--- a/packages/shared/tests/unit/line-buffer.property.test.ts
+++ b/packages/shared/tests/unit/line-buffer.property.test.ts
@@ -16,7 +16,9 @@ function referenceSplit(input: string): { lines: string[]; flushed: string[] } {
   const parts = input.split('\n');
   const pending = parts.pop() ?? '';
   const lines = parts.map(line => (line.endsWith('\r') ? line.slice(0, -1) : line));
-  return { lines, flushed: pending === '' ? [] : [pending] };
+  // flush() strips a trailing \r the same way append() does for complete lines.
+  const flushedLine = pending.endsWith('\r') ? pending.slice(0, -1) : pending;
+  return { lines, flushed: pending === '' ? [] : [flushedLine] };
 }
 
 /** Cut a string into contiguous chunks at arbitrary positions (mod length). */
@@ -73,9 +75,12 @@ describe('LineBuffer properties', () => {
   });
 
   it('newline-free streams lose no data and never hold more than maxPendingLength', () => {
+    // CR-free content: a trailing \r on a force-emitted or flushed piece is
+    // stripped by design (consistent with append()'s CRLF handling), so exact
+    // byte conservation holds only for streams without carriage returns.
     fc.assert(
       fc.property(
-        fc.array(fc.string({ maxLength: 30 }).map(s => s.replace(/\n/g, ' ')), { maxLength: 30 }),
+        fc.array(fc.string({ maxLength: 30 }).map(s => s.replace(/[\n\r]/g, ' ')), { maxLength: 30 }),
         fc.integer({ min: 1, max: 16 }),
         (chunks, maxPendingLength) => {
           const buffer = new LineBuffer(maxPendingLength);

--- a/packages/shared/tests/unit/line-buffer.test.ts
+++ b/packages/shared/tests/unit/line-buffer.test.ts
@@ -35,6 +35,18 @@ describe('LineBuffer', () => {
     expect(new LineBuffer().flush()).toEqual([]);
   });
 
+  it('flush strips a trailing carriage return like append does', () => {
+    const buf = new LineBuffer();
+    buf.append('ends with cr\r');
+    expect(buf.flush()).toEqual(['ends with cr']);
+  });
+
+  it('force-emitted oversized pending strips a trailing carriage return', () => {
+    const buf = new LineBuffer(8);
+    expect(buf.append('x'.repeat(12) + '\r')).toEqual(['x'.repeat(12)]);
+    expect(buf.flush()).toEqual([]);
+  });
+
   it('force-emits an oversized pending line to bound memory', () => {
     const buf = new LineBuffer(16);
     expect(buf.append('x'.repeat(20))).toEqual(['x'.repeat(20)]);

--- a/scripts/install-claude-mcp.sh
+++ b/scripts/install-claude-mcp.sh
@@ -44,7 +44,7 @@ if $CLAUDE_CLI mcp list | grep -q "mcp-debugger.*✓ Connected"; then
     echo "  - JavaScript/TypeScript (requires: Node.js 22+)"
     echo "  - Rust (requires: Rust toolchain)"
     echo "  - Go (requires: Go 1.18+ and Delve)"
-    echo "  - Java (requires: JDK 11+)"
+    echo "  - Java (requires: JDK 21+ recommended)"
     echo "  - .NET/C# (requires: .NET 6+ SDK and netcoredbg)"
     echo "  - Mock (for testing)"
     echo ""

--- a/skills/debugging/README.md
+++ b/skills/debugging/README.md
@@ -32,4 +32,4 @@ mkdir -p ~/.copilot/skills && cp -r skills/debugging ~/.copilot/skills/mcp-debug
 
 ## Keeping it honest
 
-The skill states current limitations (per-language output-capture gaps, no breakpoint listing yet) with issue links. If you hit a behavior the skill doesn't describe, please [open an issue](https://github.com/debugmcp/mcp-debugger/issues) — the skill is maintained against real agent transcripts.
+The skill states current limitations (e.g. per-language output-capture gaps) with issue links. If you hit a behavior the skill doesn't describe, please [open an issue](https://github.com/debugmcp/mcp-debugger/issues) — the skill is maintained against real agent transcripts.

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-debugger
-description: Use when investigating a bug, failing test, or unexpected runtime behavior and the mcp-debugger MCP server is available — drives real step-through debuggers (breakpoints, stack traces, variable inspection, expression evaluation) for Python, JavaScript/TypeScript, Ruby, Rust, Go, Java, and .NET/C#, locally or attached to remote processes.
+description: Use when investigating a bug, failing test, or unexpected runtime behavior and the mcp-debugger MCP server is available — drives real step-through debuggers (breakpoints, stack traces, variable inspection, expression evaluation) for Python, JavaScript/TypeScript, Ruby, Rust, Go, Java, .NET/C#, and C/C++, locally or attached to remote processes.
 ---
 
 # Debugging with mcp-debugger

--- a/skills/debugging/references/go.md
+++ b/skills/debugging/references/go.md
@@ -49,7 +49,7 @@ Not supported. The Go adapter implements launch mode only — `attach_to_process
 - **Debuggee output is captured:** the adapter launches with Delve's `outputMode: 'remote'`, so the program's stdout/stderr arrives as `get_output` entries (categories `stdout`/`stderr`).
 - **`stopOnEntry` is forced to `false`** by the Go adapter policy (unless you explicitly set it) to dodge Delve's "unknown goroutine 1" quirk. If you force `stopOnEntry: true` and see that error, it is harmless — execution continues. Set a breakpoint on the first line of `main` if you need an entry stop.
 - Goroutine-aware, with limits: stack traces show the current goroutine's frames; Go runtime and testing frames (paths with `/runtime/` or `/testing/`) are filtered out by default — pass `includeInternals: true` to `get_stack_trace` to see them. There are no MCP tools to list or switch goroutines.
-- Exception breakpoints `panic` and `fatal` are enabled by default — panics stop the debugger without any setup (`get_stack_trace` reports `stopReason`).
+- Exception breakpoints `unrecovered-panic` and `runtime-fatal-throw` are enabled by default — panics stop the debugger without any setup (`get_stack_trace` reports `stopReason`).
 - Delve's variable rendering auto-dereferences pointers, shows slices with len/cap, and maps as key-value pairs.
 - Use absolute paths for `file` and `scriptPath`; breakpoints must be on executable statements.
 - Logpoints work: `set_breakpoint` with `logMessage: "x={x}"` logs interpolated values to `get_output` without pausing (Delve).

--- a/src/server.ts
+++ b/src/server.ts
@@ -2355,12 +2355,13 @@ export class DebugMcpServer {
         throw new McpError(McpErrorCode.InvalidParams, 'Expression too long (max 10KB)');
       }
 
-      // Call SessionManager's evaluateExpression method (uses 'watch' context by default for variable access)
+      // Call SessionManager's evaluateExpression method (no context is passed here;
+      // the adapter policy chooses the DAP evaluate context)
       const result = await this.sessionManager.evaluateExpression(
         args.sessionId,
         args.expression,
         args.frameId,
-        // Let SessionManager use its default context ('watch') for proper variable access
+        // Context is chosen by the adapter policy inside SessionManager
         args.timeout
       );
       

--- a/tests/fixtures/debug-scripts/with-variables.py
+++ b/tests/fixtures/debug-scripts/with-variables.py
@@ -3,18 +3,18 @@
 
 def test_variables():
     # Different data types
-    number = 42  # Line 5
-    text = "Hello, debugger!"  # Line 6
-    items = [1, 2, 3, 4, 5]  # Line 7
-    data = {"name": "test", "value": 100}  # Line 8
-    
+    number = 42  # Line 6
+    text = "Hello, debugger!"  # Line 7
+    items = [1, 2, 3, 4, 5]  # Line 8
+    data = {"name": "test", "value": 100}  # Line 9
+
     # Nested function to test scopes
     def inner():
-        local_var = "inner scope"  # Line 12
-        return local_var  # Line 13
-    
-    result = inner()  # Line 15: Breakpoint here
-    return result  # Line 16
+        local_var = "inner scope"  # Line 13
+        return local_var  # Line 14
+
+    result = inner()  # Line 16: Breakpoint here
+    return result  # Line 17
 
 if __name__ == "__main__":
     test_variables()


### PR DESCRIPTION
First fix wave from the 2026-08-16 osoji audit (285 findings; 16E/107W/162I; triage verified every error against source). This PR takes the 13 real errors + ~28 highest-value warnings — stale build paths (adapter-rust → codelldb-common), wrong Go exception-filter IDs, bundled-not-optional adapter packaging, throw-vs-empty DAP failure semantics split, eight-language/28-tool/13-package counts everywhere, JDK 21+ in the install script, evaluate-context comments, a None guard in the launcher CLI, and CRLF stripping in line-buffer flush/overflow paths.

**Reviewer attention:** `packages/shared/src/utils/line-buffer.ts` is the one behavioral change — `flush()` and the overflow path now strip trailing `\r` like `append()` already did. The fast-check property tests pinned the old semantics; their reference model was updated and two example tests pin the new behavior (13/13 package tests green).

Deliberately NOT done (osoji false positives caught in triage): `requirements/pip.txt` + `docs/release-checklist.md` deletion verdicts (both are living process files), a JdiDapServer.java 'suspend-forever' claim (init value was misread), a release-dry-run subshell claim (here-strings don't subshell).

`pnpm test:unit`: 194 files, 3413 tests, 0 failures.

Closes #323's main body of drift; wave 2 (~75 deeper architecture-doc warnings + info tier) queued for the next cleanup cycle before v0.24.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)