### PR TITLE
fix: attach teardown must kill the whole adapter chain (#337)

### DIFF
--- a/src/proxy/dap-proxy-adapter-manager.ts
+++ b/src/proxy/dap-proxy-adapter-manager.ts
@@ -45,7 +45,14 @@ export class GenericAdapterManager {
     private logger: ILogger,
     private fileSystem: IFileSystem,
     /** Platform override for tests (issue #183); defaults to the real platform. */
-    private platform: NodeJS.Platform = globalThis.process.platform
+    private platform: NodeJS.Platform = globalThis.process.platform,
+    /**
+     * Signal seam for tests (issue #183 pattern). A negative pid targets the
+     * POSIX process group — sound only because spawn() below uses
+     * detached:true, which puts the adapter in its own group.
+     */
+    private signalPid: (pid: number, signal: NodeJS.Signals) => void =
+      (pid, signal) => globalThis.process.kill(pid, signal)
   ) {}
 
   /**
@@ -221,12 +228,23 @@ export class GenericAdapterManager {
   /**
    * Gracefully shutdown an adapter process.
    *
-   * killProcessTree (launch mode only): on Windows the debuggee may be a
-   * grandchild of the adapter (e.g. rdbg -c spawns the target as a child),
-   * and a bare kill of the adapter is TerminateProcess — near-instant —
-   * which orphans the grandchild. taskkill /T can only discover children
+   * killProcessTree: the debuggee may be a grandchild of the adapter in
+   * launch mode (e.g. rdbg -c spawns the target as a child), and helper
+   * processes are children of the adapter in both modes (codelldb spawns
+   * lldb-server, which holds the ptrace claim in attach mode — issue #337).
+   * An attach TARGET is never a descendant of the adapter, so tree/group
+   * kill cannot take a pre-existing debuggee down (the issue #156
+   * invariant, preserved structurally).
+   *
+   * win32: a bare kill of the adapter is TerminateProcess — near-instant —
+   * which orphans grandchildren, and taskkill /T can only discover children
    * while the parent is alive, so the tree-kill must be the FIRST strike,
-   * not a fallback (issue #156). Callers must never set it for attach mode.
+   * not a fallback (issue #156).
+   *
+   * POSIX: the adapter is spawned detached:true (its own process group), so
+   * signalling -pid reaches exactly the adapter and its descendants — and a
+   * pgid cannot be recycled while any member is alive, so the group is safe
+   * to signal even after the leader exited (unlike a bare PID).
    */
   async shutdown(process: ChildProcess | null, options: { killProcessTree?: boolean } = {}): Promise<void> {
     if (!process || !process.pid) {
@@ -234,15 +252,28 @@ export class GenericAdapterManager {
       return;
     }
 
+    const pid = process.pid;
+    const posixGroupKill = options.killProcessTree === true && this.platform !== 'win32';
+
     // An adapter that honored the DAP disconnect exits on its own during the
     // worker's grace wait — by now its PID may already belong to an unrelated
     // process, so signalling it (let alone taskkill /T /F) is a PID-reuse hazard.
     if (process.exitCode !== null || process.signalCode !== null) {
-      this.logger.info(`[AdapterManager] Adapter process PID: ${process.pid} already exited (code=${process.exitCode}, signal=${process.signalCode}). Nothing to terminate.`);
+      if (posixGroupKill) {
+        // The leader exiting does not mean its helpers did: codelldb honors
+        // the disconnect and exits while lldb-server — its child, the actual
+        // ptrace holder — survives (issue #337). Sweep the group.
+        this.logger.info(`[AdapterManager] Adapter PID ${pid} already exited — sweeping its process group for surviving helpers.`);
+        try { this.signalPid(-pid, 'SIGTERM'); } catch { /* ESRCH: group already empty */ }
+        await new Promise(resolve => setTimeout(resolve, 300));
+        try { this.signalPid(-pid, 'SIGKILL'); } catch { /* ESRCH: group already empty */ }
+      } else {
+        this.logger.info(`[AdapterManager] Adapter process PID: ${pid} already exited (code=${process.exitCode}, signal=${process.signalCode}). Nothing to terminate.`);
+      }
       return;
     }
 
-    this.logger.info(`[AdapterManager] Attempting to terminate adapter process PID: ${process.pid}`);
+    this.logger.info(`[AdapterManager] Attempting to terminate adapter process PID: ${pid}`);
 
     const treeKillFirst = options.killProcessTree === true && this.platform === 'win32';
 
@@ -254,17 +285,26 @@ export class GenericAdapterManager {
         process.once('exit', onExit);
 
         if (treeKillFirst) {
-          this.logger.info(`[AdapterManager] Killing adapter process tree via taskkill /T /F for PID: ${process.pid}`);
+          this.logger.info(`[AdapterManager] Killing adapter process tree via taskkill /T /F for PID: ${pid}`);
           try {
-            this.processSpawner.spawn('taskkill', ['/PID', String(process.pid), '/T', '/F'], {
+            this.processSpawner.spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
               stdio: 'ignore',
               windowsHide: true
             });
           } catch (tkErr) {
             this.logger.error('[AdapterManager] taskkill tree-kill failed to spawn:', tkErr as Error);
           }
+        } else if (posixGroupKill) {
+          this.logger.info(`[AdapterManager] Sending SIGTERM to adapter process group -${pid}`);
+          try {
+            this.signalPid(-pid, 'SIGTERM');
+          } catch (groupErr) {
+            const message = groupErr instanceof Error ? groupErr.message : String(groupErr);
+            this.logger.warn(`[AdapterManager] Group SIGTERM for -${pid} failed (${message}); falling back to direct SIGTERM.`);
+            process.kill('SIGTERM');
+          }
         } else {
-          this.logger.info(`[AdapterManager] Sending SIGTERM to adapter process PID: ${process.pid}`);
+          this.logger.info(`[AdapterManager] Sending SIGTERM to adapter process PID: ${pid}`);
           process.kill('SIGTERM');
         }
 
@@ -272,21 +312,29 @@ export class GenericAdapterManager {
         await new Promise(resolve => setTimeout(resolve, 300));
 
         if (!exited) {
-          this.logger.warn(`[AdapterManager] Adapter process PID: ${process.pid} did not exit after ${treeKillFirst ? 'taskkill' : 'SIGTERM'}. Sending SIGKILL.`);
-          try {
-            process.kill('SIGKILL');
-          } catch {
-            // ignore SIGKILL errors
+          this.logger.warn(`[AdapterManager] Adapter process PID: ${pid} did not exit after ${treeKillFirst ? 'taskkill' : 'SIGTERM'}. Sending SIGKILL.`);
+          if (posixGroupKill) {
+            try { this.signalPid(-pid, 'SIGKILL'); } catch { /* ESRCH: group already empty */ }
+          } else {
+            try {
+              process.kill('SIGKILL');
+            } catch {
+              // ignore SIGKILL errors
+            }
           }
         } else {
-          this.logger.info(`[AdapterManager] Adapter process PID: ${process.pid} exited after ${treeKillFirst ? 'taskkill' : 'SIGTERM'}.`);
+          this.logger.info(`[AdapterManager] Adapter process PID: ${pid} exited after ${treeKillFirst ? 'taskkill' : 'SIGTERM'}.`);
+          if (posixGroupKill) {
+            // Leader exited on SIGTERM — helpers may remain; sweep the group.
+            try { this.signalPid(-pid, 'SIGKILL'); } catch { /* ESRCH: group already empty */ }
+          }
         }
       } else {
-        this.logger.info(`[AdapterManager] Adapter process PID: ${process.pid} was already marked as killed.`);
+        this.logger.info(`[AdapterManager] Adapter process PID: ${pid} was already marked as killed.`);
       }
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      this.logger.error(`[AdapterManager] Error during adapter process termination (PID: ${process.pid}): ${message}`, e);
+      this.logger.error(`[AdapterManager] Error during adapter process termination (PID: ${pid}): ${message}`, e);
     }
   }
 }

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -1253,13 +1253,17 @@ export class DapProxyWorker {
       await new Promise(resolve => setTimeout(resolve, 500));
     }
 
-    // Terminate adapter process. Launch mode owns the debuggee, which may be
-    // a grandchild of the adapter (e.g. rdbg -c), so request a process-tree
-    // kill; attach mode must never tree-kill (the guard is explicit so a
-    // future attach flow that proxies through a spawned process cannot take
-    // a pre-existing debuggee down with it — see #156).
+    // Terminate the adapter process and its descendants. Launch mode owns the
+    // debuggee, which may be a grandchild of the adapter (e.g. rdbg -c). In
+    // attach mode the debuggee is NOT a descendant of the adapter — so a
+    // tree/group kill cannot take it down (the #156 invariant, preserved
+    // structurally) — but the adapter's own helpers ARE descendants, and
+    // sparing them leaked lldb-server with its ptrace claim on the target
+    // after every attach teardown (issue #337). The DAP disconnect with
+    // terminateDebuggee=false plus the grace wait above already ran, so the
+    // adapter had its chance to detach cleanly.
     if (this.processManager && this.adapterProcess) {
-      await this.processManager.shutdown(this.adapterProcess, { killProcessTree: !this.isAttachMode });
+      await this.processManager.shutdown(this.adapterProcess, { killProcessTree: true });
     }
     this.adapterProcess = null;
 

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -2669,6 +2669,11 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       };
     } catch (error) {
       this.logger.error(`[SessionManager] Failed to attach to process for session ${sessionId}:`, error);
+      // Never leave a live proxy chain behind a failed attach — e.g.
+      // ProxyManager.start()'s init timeout rejects after the worker was
+      // spawned (issue #337). Idempotent with the verify-failure teardown
+      // above, which already nulled session.proxyManager.
+      await this.stopProxyPreservingSession(session);
       this._updateSessionState(session, SessionState.ERROR);
 
       const message = error instanceof Error ? error.message : String(error);

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -2052,7 +2052,12 @@ describe('DapProxyWorker', () => {
       }
     });
 
-    it('shutdown must not request a tree-kill in attach mode', async () => {
+    it('shutdown tree-kills the adapter chain in attach mode too (issue #337)', async () => {
+      // The attach target is never a descendant of the adapter, so a tree/group
+      // kill of the adapter's own chain cannot take the debuggee down — that is
+      // the #156 invariant, preserved structurally. What the old
+      // never-tree-kill-on-attach guard actually did was leak lldb-server
+      // (codelldb's child, the ptrace holder) on every attach teardown.
       vi.useFakeTimers();
       try {
         const processStub = { shutdown: vi.fn().mockResolvedValue(undefined) };
@@ -2069,7 +2074,10 @@ describe('DapProxyWorker', () => {
         await vi.advanceTimersByTimeAsync(500);
         await terminatePromise;
 
-        expect(processStub.shutdown).toHaveBeenCalledWith(adapterProc, { killProcessTree: false });
+        // The DAP disconnect with terminateDebuggee=false has already run by
+        // this point (asserted by the auto-detach test below) — the tree-kill
+        // only reaps the adapter's own helper processes.
+        expect(processStub.shutdown).toHaveBeenCalledWith(adapterProc, { killProcessTree: true });
       } finally {
         vi.useRealTimers();
       }

--- a/tests/unit/proxy/dap-proxy-adapter-manager.test.ts
+++ b/tests/unit/proxy/dap-proxy-adapter-manager.test.ts
@@ -463,11 +463,113 @@ describe('GenericAdapterManager', () => {
       expect(spawner.spawn).not.toHaveBeenCalled();
     });
 
-    it('keeps the SIGTERM-first path on non-win32 even with killProcessTree', async () => {
+  });
+
+  describe('shutdown group-kill on POSIX (issue #337)', () => {
+    // The adapter is spawned detached:true, so on POSIX its process group
+    // contains exactly the adapter and its helpers (codelldb + lldb-server).
+    // The attach target is never in that group, so signalling -pid can never
+    // take a pre-existing debuggee down (the #156 invariant, preserved).
+    let signalPid: ReturnType<typeof vi.fn>;
+
+    const makeManager = (platform: NodeJS.Platform) => {
+      signalPid = vi.fn();
+      return new GenericAdapterManager(spawner, logger, fileSystem, platform, signalPid as any);
+    };
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('signals the process group with SIGTERM then SIGKILL when the adapter does not exit', async () => {
       manager = makeManager('linux');
       vi.useFakeTimers();
 
       const proc = createMockProcess(999);
+      // Adapter never exits
+
+      const shutdownPromise = manager.shutdown(proc, { killProcessTree: true });
+      await vi.advanceTimersByTimeAsync(300);
+      await shutdownPromise;
+
+      expect(signalPid).toHaveBeenCalledWith(-999, 'SIGTERM');
+      expect(signalPid).toHaveBeenCalledWith(-999, 'SIGKILL');
+      expect(proc.kill).not.toHaveBeenCalledWith('SIGTERM');
+      expect(spawner.spawn).not.toHaveBeenCalled();
+    });
+
+    it('sweeps the group with SIGKILL even when the leader exits after SIGTERM', async () => {
+      manager = makeManager('linux');
+      vi.useFakeTimers();
+
+      const proc = createMockProcess(999);
+      signalPid.mockImplementation((pid: number, sig: string) => {
+        if (sig === 'SIGTERM') {
+          process.nextTick(() => proc.emit('exit', 0, null));
+        }
+      });
+
+      const shutdownPromise = manager.shutdown(proc, { killProcessTree: true });
+      await vi.advanceTimersByTimeAsync(300);
+      await shutdownPromise;
+
+      // Leader exiting does not mean the group is empty — lldb-server may
+      // survive codelldb. The group sweep is the point of the fix.
+      expect(signalPid).toHaveBeenCalledWith(-999, 'SIGKILL');
+    });
+
+    it('sweeps the group when the leader already exited (the k8s lldb-server leak)', async () => {
+      manager = makeManager('linux');
+      vi.useFakeTimers();
+
+      const proc = createMockProcess(999);
+      // codelldb honored the DAP disconnect and exited during the grace wait;
+      // lldb-server (its child, the ptrace holder) is still alive. A pgid
+      // cannot be recycled while any member lives, so -pid is safe to signal.
+      proc.exitCode = 0;
+
+      const shutdownPromise = manager.shutdown(proc, { killProcessTree: true });
+      await vi.advanceTimersByTimeAsync(300);
+      await shutdownPromise;
+
+      expect(signalPid).toHaveBeenCalledWith(-999, 'SIGTERM');
+      expect(signalPid).toHaveBeenCalledWith(-999, 'SIGKILL');
+      expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it('keeps the early return for an already-exited adapter without killProcessTree', async () => {
+      manager = makeManager('linux');
+
+      const proc = createMockProcess(999);
+      proc.exitCode = 0;
+
+      await manager.shutdown(proc);
+
+      expect(signalPid).not.toHaveBeenCalled();
+      expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it('keeps the early return for an already-exited adapter on win32 (PID reuse hazard)', async () => {
+      manager = makeManager('win32');
+
+      const proc = createMockProcess(999);
+      proc.exitCode = 1;
+
+      await manager.shutdown(proc, { killProcessTree: true });
+
+      expect(signalPid).not.toHaveBeenCalled();
+      expect(spawner.spawn).not.toHaveBeenCalled();
+      expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a direct SIGTERM when the group signal fails', async () => {
+      manager = makeManager('linux');
+      vi.useFakeTimers();
+
+      const proc = createMockProcess(999);
+      signalPid.mockImplementation((pid: number, sig: string) => {
+        if (sig === 'SIGTERM') throw Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+      });
       proc.kill.mockImplementation(() => {
         process.nextTick(() => proc.emit('exit', 0, null));
       });
@@ -477,7 +579,21 @@ describe('GenericAdapterManager', () => {
       await shutdownPromise;
 
       expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
-      expect(spawner.spawn).not.toHaveBeenCalled();
+    });
+
+    it('swallows ESRCH from the SIGKILL sweep (group already empty)', async () => {
+      manager = makeManager('linux');
+      vi.useFakeTimers();
+
+      const proc = createMockProcess(999);
+      proc.exitCode = 0;
+      signalPid.mockImplementation((pid: number, sig: string) => {
+        if (sig === 'SIGKILL') throw Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+      });
+
+      const shutdownPromise = manager.shutdown(proc, { killProcessTree: true });
+      await vi.advanceTimersByTimeAsync(300);
+      await expect(shutdownPromise).resolves.toBeUndefined();
     });
   });
 });

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -1569,6 +1569,29 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(mockSession.proxyManager).toBeUndefined();
     });
 
+    it('tears down the proxy when attach fails after the proxy was spawned (issue #337)', async () => {
+      // ProxyManager.start()'s init-timeout reject (and any other throw out of
+      // startProxyManager after the proxy process exists) used to land in a
+      // catch that only marked the session ERROR — leaving a live proxy chain
+      // ptrace-attached to the target with no tool able to reach it.
+      vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+        throw new Error('Timeout waiting for proxy initialization');
+      });
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 5005,
+        host: 'localhost',
+        stopOnEntry: true
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.state).toBe(SessionState.ERROR);
+      expect(result.error).toContain('Timeout waiting for proxy initialization');
+      expect(mockProxyManager.stop).toHaveBeenCalled();
+      expect(mockSession.proxyManager).toBeUndefined();
+    });
+
     it('should fail the attach when the threads request keeps failing for the whole verification window', async () => {
       mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
         if (command === 'threads') {


### PR DESCRIPTION
## Problem (part of #337)

An abandoned or failed attach session could leave the proxy worker + codelldb + **lldb-server still ptrace-attached to the target** with no tool able to reach it. Two teardown leaks:

1. **`attachToProcess`'s outer catch never stopped the proxy.** `ProxyManager.start()`'s init-timeout reject (which does not kill the already-spawned worker) landed in a catch that only marked the session ERROR — unlike `startDebugging`'s catch, which tears the proxy down.
2. **Adapter shutdown never signalled the adapter's descendants on POSIX.** `killProcessTree` was win32-only (taskkill /T), and attach mode opted out entirely (the #156 guard). On Linux only the adapter PID got SIGTERM/SIGKILL — `lldb-server` (codelldb's child, the actual ptrace holder) survived **every** teardown, even a clean detach.

## Fix

- The attach catch now runs `stopProxyPreservingSession` (same primitive the verify-failure path uses; idempotent with it).
- `shutdown()` gains POSIX group-kill: the adapter is spawned `detached: true` (its own process group), so signalling `-pid` reaches exactly the adapter + its helpers — SIGTERM, 300ms grace, SIGKILL sweep, **including when the leader already exited** (a pgid cannot be recycled while any member lives; that's precisely the codelldb-exits-but-lldb-server-survives leak). Injectable `signalPid` seam for tests (#183 pattern).
- The worker now requests `killProcessTree: true` in attach mode too. **The #156 invariant is preserved structurally**: an attach target is never a descendant of the adapter, so a tree/group kill cannot touch it — and the DAP disconnect with `terminateDebuggee=false` + grace wait still runs first. The cpp attach e2e (attach → inspect → detach → target still alive) passes.

Side effect (intended): POSIX launch mode gets a real tree kill for the first time — rdbg-style grandchildren no longer leak on Linux.

## Remaining #337 work (separate PRs)

- CLI exit paths never call `DebugMcpServer.stop()` (stdio), unbounded stop on http/sse.
- HTTP mode: crash-abandoned MCP sessions are never reaped — the incident's actual trigger.

## Testing

- New unit tests: attach-catch teardown; POSIX group-kill matrix (live/leader-exited/already-exited/ESRCH/fallback); win32 early-return + taskkill paths preserved; attach tree-kill contract flipped with rationale.
- Full unit suite 3447 passing; e2e smoke 71 passing; cpp attach e2e passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)