### PR TITLE
fix: CLI exit paths must stop the debug server, bounded (#337)

### DIFF
--- a/src/cli/http-command.ts
+++ b/src/cli/http-command.ts
@@ -209,22 +209,40 @@ export async function handleHttpCommand(
       shutdownStarted = true;
       logger.info('Shutting down HTTP server...');
 
-      // Close every active transport and stop its DebugMcpServer
-      for (const { transport, server: debugServer } of httpSessions.values()) {
-        try {
-          await transport.close();
-        } catch (err) {
-          logger.error('Error closing transport during shutdown', { error: err });
+      // Hard-exit fallback (issue #337): server.close() waits on open
+      // sockets and a wedged proxy can stall stop() — once shutdown has
+      // begun, the process must not park forever holding live proxy chains.
+      const hardExit = setTimeout(() => {
+        logger.error('Graceful shutdown timed out; forcing exit.');
+        exitProcess(1);
+      }, 15000);
+      hardExit.unref?.();
+
+      // Close every active transport and stop its DebugMcpServer, bounded
+      // so one wedged session cannot stall the whole shutdown.
+      const stopWork = (async () => {
+        for (const { transport, server: debugServer } of httpSessions.values()) {
+          try {
+            await transport.close();
+          } catch (err) {
+            logger.error('Error closing transport during shutdown', { error: err });
+          }
+          try {
+            await debugServer.stop();
+          } catch (err) {
+            logger.error('Error stopping debug server during shutdown', { error: err });
+          }
         }
-        try {
-          await debugServer.stop();
-        } catch (err) {
-          logger.error('Error stopping debug server during shutdown', { error: err });
-        }
-      }
+      })();
+      const guard = new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 10000);
+        timer.unref?.();
+      });
+      await Promise.race([stopWork, guard]);
       httpSessions.clear();
 
       server.close(() => {
+        clearTimeout(hardExit);
         exitProcess(0);
       });
     };

--- a/src/cli/sse-command.ts
+++ b/src/cli/sse-command.ts
@@ -239,6 +239,15 @@ export async function handleSSECommand(
       shutdownStarted = true;
       logger.info('Shutting down SSE server...');
 
+      // Hard-exit fallback (issue #337): a wedged proxy can stall stop() and
+      // server.close() waits on open sockets — once shutdown has begun, the
+      // process must not park forever holding live proxy chains.
+      const hardExit = setTimeout(() => {
+        logger.error('Graceful shutdown timed out; forcing exit.');
+        exitProcess(1);
+      }, 15000);
+      hardExit.unref?.();
+
       // Close all SSE connections
       const sseTransports = (app as any).sseTransports as Map<string, SessionData> | undefined; // eslint-disable-line @typescript-eslint/no-explicit-any
       if (sseTransports) {
@@ -247,18 +256,23 @@ export async function handleSSECommand(
         });
       }
 
-      // Stop the shared debug server
+      // Stop the shared debug server, bounded so it cannot stall shutdown
       const sharedDebugServer = (app as any).sharedDebugServer as DebugMcpServer | undefined; // eslint-disable-line @typescript-eslint/no-explicit-any
       if (sharedDebugServer) {
         logger.info('Stopping shared Debug MCP Server...');
+        const guard = new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, 10000);
+          timer.unref?.();
+        });
         try {
-          await sharedDebugServer.stop();
+          await Promise.race([sharedDebugServer.stop(), guard]);
         } catch (error) {
           logger.error('Error stopping shared Debug MCP Server:', error);
         }
       }
 
       server.close(() => {
+        clearTimeout(hardExit);
         exitProcess(0);
       });
     };

--- a/src/cli/stdio-command.ts
+++ b/src/cli/stdio-command.ts
@@ -51,13 +51,35 @@ export async function handleStdioCommand(
     await debugMcpServer.server.connect(transport);
     logger.info('[MCP] Server connected to stdio transport successfully');
 
+    // Every exit path must tear down the debug sessions first (issue #337):
+    // exiting without DebugMcpServer.stop() → closeAllSessions() leaves the
+    // proxy chains — and, for attach sessions, lldb-server's ptrace claim on
+    // the target — running with no owner. Bounded so a wedged proxy cannot
+    // block exit (ProxyManager.stop() is internally bounded but runs
+    // serially per session).
+    let shutdownStarted = false;
+    const shutdownAndExit = (code: number, why: string) => {
+      if (shutdownStarted) return;
+      shutdownStarted = true;
+      try { clearInterval(keepAlive); } catch { /* already cleared */ }
+      logger.warn(`[MCP] ${why} — stopping debug server and exiting.`);
+      const guard = new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 5000);
+        timer.unref?.();
+      });
+      void Promise.race([
+        debugMcpServer.stop().catch((err) => {
+          logger.error('[MCP] Error stopping debug server during exit:', { err });
+        }),
+        guard
+      ]).finally(() => exitProcess(code));
+    };
+
     // Ensure deterministic shutdown on transport close
     // NOTE: `onclose` relies on an undocumented MCP SDK property
     const transportWithClose = transport as unknown as { onclose?: () => void };
     transportWithClose.onclose = () => {
-      logger.warn('[MCP] Transport closed; exiting.');
-      try { clearInterval(keepAlive); } catch {}
-      exitProcess(0);
+      shutdownAndExit(0, 'Transport closed');
     };
     
     // Start the debug server
@@ -84,21 +106,15 @@ export async function handleStdioCommand(
         logger.warn('[MCP] Stdin ended; ignoring in container mode and waiting for transport close or signal.');
         return;
       }
-      logger.warn('[MCP] Stdin ended; MCP client disconnected — exiting.');
-      try { clearInterval(keepAlive); } catch { /* already cleared */ }
-      exitProcess(0);
+      shutdownAndExit(0, 'Stdin ended; MCP client disconnected');
     });
 
     // Add robust exit/signal diagnostics (logged to file; console output is silenced for protocol safety)
     proc.on('SIGTERM', () => {
-      logger.warn('[MCP] SIGTERM received, exiting.');
-      try { clearInterval(keepAlive); } catch {}
-      exitProcess(0);
+      shutdownAndExit(0, 'SIGTERM received');
     });
     proc.on('SIGINT', () => {
-      logger.warn('[MCP] SIGINT received, exiting.');
-      try { clearInterval(keepAlive); } catch {}
-      exitProcess(0);
+      shutdownAndExit(0, 'SIGINT received');
     });
     proc.on('exit', (code) => {
       logger.error('[MCP] Process exiting', {

--- a/tests/unit/cli/http-command.test.ts
+++ b/tests/unit/cli/http-command.test.ts
@@ -462,6 +462,60 @@ describe('HTTP Command Handler', () => {
       expect(mockExitProcess).toHaveBeenCalledWith(0);
     });
 
+    it('proceeds past a hung session stop after the guard and still exits 0 (issue #337)', async () => {
+      const listen = vi.fn((_port: number, cb: Function) => {
+        cb();
+        return mockHttpServer;
+      });
+      mockApp.listen = listen;
+
+      await handleHttpCommand(
+        { port: '3001' },
+        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, proc: fakeProc }
+      );
+
+      const sigintHandler = fakeProc.lastListener('SIGINT');
+      const sessions = (mockApp as any).httpSessions as Map<string, any>;
+      // A wedged proxy makes stop() hang — shutdown must not hang with it.
+      sessions.set('wedged', {
+        transport: { close: vi.fn() },
+        server: { stop: vi.fn().mockReturnValue(new Promise(() => {})) }
+      });
+
+      vi.useFakeTimers();
+      const shutdownPromise = sigintHandler();
+      await vi.advanceTimersByTimeAsync(10_000);
+      await shutdownPromise;
+
+      expect(mockHttpServer.close).toHaveBeenCalled();
+      expect(mockExitProcess).toHaveBeenCalledWith(0);
+    });
+
+    it('hard-exits 1 when even the HTTP listener refuses to close (issue #337)', async () => {
+      // server.close() waits on open sockets — a stuck keep-alive connection
+      // must not park the process forever once shutdown has begun.
+      mockHttpServer.close = vi.fn();
+      const listen = vi.fn((_port: number, cb: Function) => {
+        cb();
+        return mockHttpServer;
+      });
+      mockApp.listen = listen;
+
+      await handleHttpCommand(
+        { port: '3001' },
+        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, proc: fakeProc }
+      );
+
+      const sigintHandler = fakeProc.lastListener('SIGINT');
+
+      vi.useFakeTimers();
+      const shutdownPromise = sigintHandler();
+      await vi.advanceTimersByTimeAsync(15_000);
+      await shutdownPromise;
+
+      expect(mockExitProcess).toHaveBeenCalledWith(1);
+    });
+
     describe('stdin watchdog (MCP_EXIT_ON_STDIN_CLOSE, issue #122)', () => {
       function makeFakeStdin() {
         const stdin = new EventEmitter() as unknown as NodeJS.ReadStream & {

--- a/tests/unit/cli/sse-command.test.ts
+++ b/tests/unit/cli/sse-command.test.ts
@@ -791,6 +791,49 @@ describe('SSE Command Handler', () => {
       expect(mockExitProcess).toHaveBeenCalledWith(0);
     });
 
+    it('proceeds past a hung shared-server stop after the guard and still exits 0 (issue #337)', async () => {
+      const options = { port: '3001' };
+
+      const mockApp = {
+        use: vi.fn(),
+        get: vi.fn(),
+        post: vi.fn(),
+        listen: vi.fn((port: number, callback: Function) => {
+          callback();
+          return mockServer;
+        }),
+        sseTransports: new Map(),
+        sharedDebugServer: null as any
+      };
+      vi.mocked(express).mockReturnValue(mockApp as any);
+
+      await handleSSECommand(options, {
+        logger: mockLogger,
+        serverFactory: mockServerFactory,
+        exitProcess: mockExitProcess,
+        proc: fakeProc
+      });
+
+      const sigintHandler = fakeProc.lastListener('SIGINT');
+      // A wedged proxy makes stop() hang — shutdown must not hang with it.
+      mockApp.sharedDebugServer = { stop: vi.fn().mockReturnValue(new Promise(() => {})) };
+      mockServer.close.mockImplementation((callback: Function) => {
+        callback();
+      });
+
+      vi.useFakeTimers();
+      try {
+        const shutdownPromise = sigintHandler();
+        await vi.advanceTimersByTimeAsync(10_000);
+        await shutdownPromise;
+
+        expect(mockServer.close).toHaveBeenCalled();
+        expect(mockExitProcess).toHaveBeenCalledWith(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should fall back to proc.exit if exitProcess is not provided', async () => {
       const error = new Error('Server start failed');
 

--- a/tests/unit/cli/stdio-command.test.ts
+++ b/tests/unit/cli/stdio-command.test.ts
@@ -108,9 +108,9 @@ describe('STDIO Command Handler', () => {
     expect(fakeProc.listenerCount('SIGINT')).toBe(1);
     expect(fakeProc.listenerCount('exit')).toBe(1);
 
-    // SIGINT exits 0 through the injected exitProcess
+    // SIGINT exits 0 through the injected exitProcess (after awaiting server stop)
     fakeProc.emit('SIGINT');
-    expect(mockExitProcess).toHaveBeenCalledWith(0);
+    await vi.waitFor(() => expect(mockExitProcess).toHaveBeenCalledWith(0));
 
     // 'exit' diagnostics read argv/env/uptime from the handle
     fakeProc.emit('exit', 0);
@@ -216,7 +216,7 @@ describe('STDIO Command Handler', () => {
 
       stdin.emit('end');
 
-      expect(mockExitProcess).toHaveBeenCalledWith(0);
+      await vi.waitFor(() => expect(mockExitProcess).toHaveBeenCalledWith(0));
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining('MCP client disconnected')
       );
@@ -237,9 +237,84 @@ describe('STDIO Command Handler', () => {
       stdin.emit('end');
 
       expect(mockExitProcess).not.toHaveBeenCalled();
+      expect(mockServer.stop).not.toHaveBeenCalled();
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining('ignoring in container mode')
       );
+    });
+  });
+
+  describe('server teardown on exit paths (issue #337)', () => {
+    // Every exit path must run DebugMcpServer.stop() → closeAllSessions()
+    // before exiting — otherwise the proxy chains (and lldb-server's ptrace
+    // claim on an attach target) outlive the server.
+    async function startWithStdin() {
+      const stdin = makeFakeStdin();
+      await handleStdioCommand({}, {
+        logger: mockLogger,
+        serverFactory: mockServerFactory,
+        exitProcess: mockExitProcess,
+        stdin,
+        proc: fakeProc
+      });
+      return stdin;
+    }
+
+    it('stops the debug server before exiting when stdin ends', async () => {
+      const stdin = await startWithStdin();
+
+      stdin.emit('end');
+
+      await vi.waitFor(() => expect(mockExitProcess).toHaveBeenCalledWith(0));
+      expect(mockServer.stop).toHaveBeenCalled();
+      expect((mockServer.stop as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0])
+        .toBeLessThan(mockExitProcess.mock.invocationCallOrder[0]);
+    });
+
+    it('stops the debug server before exiting on SIGTERM', async () => {
+      await startWithStdin();
+
+      fakeProc.emit('SIGTERM');
+
+      await vi.waitFor(() => expect(mockExitProcess).toHaveBeenCalledWith(0));
+      expect(mockServer.stop).toHaveBeenCalled();
+    });
+
+    it('exits after the guard delay when stop hangs', async () => {
+      mockServer.stop = vi.fn().mockReturnValue(new Promise(() => {}));
+      const stdin = await startWithStdin();
+      vi.useFakeTimers();
+      try {
+        stdin.emit('end');
+        expect(mockExitProcess).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(mockExitProcess).toHaveBeenCalledWith(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('still exits when stop rejects', async () => {
+      mockServer.stop = vi.fn().mockRejectedValue(new Error('stop failed'));
+      const stdin = await startWithStdin();
+
+      stdin.emit('end');
+
+      await vi.waitFor(() => expect(mockExitProcess).toHaveBeenCalledWith(0));
+    });
+
+    it('runs the teardown only once when several exit triggers fire', async () => {
+      const stdin = await startWithStdin();
+
+      stdin.emit('end');
+      fakeProc.emit('SIGTERM');
+      fakeProc.emit('SIGINT');
+
+      await vi.waitFor(() => expect(mockExitProcess).toHaveBeenCalled());
+      expect(mockServer.stop).toHaveBeenCalledTimes(1);
+      expect(mockExitProcess).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Problem (part of #337, follows #339)

The stdio CLI's exit paths — transport close, stdin EOF (client crash), SIGTERM, SIGINT — called `exitProcess()` directly and never ran `DebugMcpServer.stop()` → `closeAllSessions()`. Every proxy chain (and, for attach sessions, lldb-server's ptrace claim on the target) outlived the server with no owner.

http/sse already stopped their servers in `gracefulShutdown`, but unbounded: a wedged proxy's `stop()` or an http `server.close()` waiting on open keep-alive sockets parked the process forever after shutdown had begun.

## Fix

- **stdio**: all four exit paths funnel through an idempotent `shutdownAndExit` — awaits `stop()` raced against a 5s unref'd guard, then exits. Container-mode stdin-EOF ignore unchanged.
- **http/sse**: the stop work is bounded (10s race), plus a 15s unref'd hard-exit(1) fallback armed at shutdown start and cleared on clean close.

Exit is delayed by at most 5s (stdio) / 15s (http/sse) — well within k8s's default 30s grace.

## Testing

New unit tests: each stdio exit path stops the server before exiting (order asserted), hung stop exits after the guard (fake timers), rejecting stop still exits, multi-trigger teardown runs once, container-mode unchanged; http proceeds past a hung per-session stop and hard-exits 1 when the listener refuses to close; sse proceeds past a hung shared-server stop. Full unit suite 3448 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)