### PR TITLE
fix: reap crash-abandoned HTTP sessions (#337)

### DIFF
--- a/docs/jit-diagnostics/README.md
+++ b/docs/jit-diagnostics/README.md
@@ -118,6 +118,8 @@ kubectl port-forward "pod/$POD" 3001:3001 &
 
 Register the endpoint with your agent (e.g. `claude mcp add-json sick-pod '{"type":"http","url":"http://127.0.0.1:3001/mcp"}'`).
 
+The HTTP server reaps MCP sessions abandoned by a crashed client (idle, with no open SSE stream) after 30 minutes, closing their debug sessions and releasing any ptrace claim on the target. For a short-lived diagnostic sidecar a tighter window is safer — add `--env=MCP_HTTP_STALE_SESSION_MS=300000` (5 minutes; `0` disables) to the `kubectl debug` command.
+
 Facts that will save you an afternoon (all observed, not assumed):
 
 - **`--profile=general` is what makes attach possible.** It injects `SYS_PTRACE` into the ephemeral container's securityContext (`kubectl get pod -o jsonpath='{.spec.ephemeralContainers[*].securityContext}'` shows `{"capabilities":{"add":["SYS_PTRACE"]}}`). Kubernetes nodes commonly run `kernel.yama.ptrace_scope=1` (the kind node does), which blocks ptrace of non-descendant processes without that capability — the legacy default profile fails there. `--profile=sysadmin` also works but grants far more than needed.
@@ -187,7 +189,7 @@ Diagnosis: `build_cart` returns a **reference to the cached vector**, and `apply
 - Target **staging, canaries, or quarantined sick pods** — pausing a pod that's in a live serving rotation stops its traffic for the duration of the pause. For non-breaking inspection, pass `logMessage` to `set_breakpoint` (a logpoint, [#235](https://github.com/debugmcp/mcp-debugger/issues/235)): the pod keeps serving at full speed while interpolated values stream into `get_output`.
 - The same Part-1 flow works for **Ruby** (`rdbg --open --port`) — see [docs/ruby/README.md](../ruby/README.md) — and **Java** (JDWP agent), covering three of the most common backend runtimes. The containerized server itself can be the attach client for those too: it reports per-mode availability (`ruby` is attach-only in the image — no Ruby runtime needed for a direct rdbg connection).
 - **The ephemeral container's MCP HTTP port is unauthenticated** — reach it via `kubectl port-forward` only, never a Service. Whoever can call it controls a ptrace-capable debugger inside your pod.
-- If an attach session is abandoned uncleanly, an orphaned `lldb-server` can keep tracing the target (check `grep TracerPid /proc/1/status` from the debug container); kill the leftover chain or restart the pod.
+- An uncleanly abandoned attach session no longer leaves an orphaned `lldb-server` tracing the target ([#337](https://github.com/debugmcp/mcp-debugger/issues/337)): teardown kills the adapter's whole process group, and the HTTP server reaps crash-abandoned MCP sessions after the stale window. If you suspect a leftover tracer anyway (e.g. after a hard kill of the debug container's server), check `grep TracerPid /proc/1/status` from the debug container and kill the reported PID.
 
 ## Cleanup
 

--- a/src/cli/http-command.ts
+++ b/src/cli/http-command.ts
@@ -29,6 +29,26 @@ export interface HttpCommandDependencies {
 interface SessionData {
   transport: StreamableHTTPServerTransport;
   server: DebugMcpServer;
+  /** Timestamp of the last routed request (or stream close) for this session. */
+  lastActivity: number;
+  /** Open SSE (GET) streams; a session with a live stream is never idle. */
+  openStreams: number;
+}
+
+/** Idle window before a streamless HTTP session is reaped (issue #337). */
+const DEFAULT_STALE_SESSION_MS = 30 * 60 * 1000;
+const STALE_SWEEP_INTERVAL_MS = 60 * 1000;
+
+function parseStaleSessionMs(raw: string | undefined, logger: WinstonLoggerType): number {
+  if (raw === undefined || raw === '') {
+    return DEFAULT_STALE_SESSION_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    logger.warn(`Ignoring invalid MCP_HTTP_STALE_SESSION_MS value "${raw}"; using default ${DEFAULT_STALE_SESSION_MS}ms.`);
+    return DEFAULT_STALE_SESSION_MS;
+  }
+  return parsed;
 }
 
 export function createHttpApp(
@@ -36,11 +56,41 @@ export function createHttpApp(
   dependencies: HttpCommandDependencies
 ): Express {
   const { logger, serverFactory } = dependencies;
+  const proc = dependencies.proc ?? process;
 
   // createMcpExpressApp wires hostHeaderValidation for localhost binds
   const app = createMcpExpressApp();
 
   const httpSessions = new Map<string, SessionData>();
+
+  // Reap crash-abandoned sessions (issue #337): a client that dies without
+  // DELETE leaves its transport registered forever — transport.onclose only
+  // fires on explicit close — so its DebugMcpServer and every proxy chain
+  // (including lldb-server's ptrace claim on an attach target) stay alive,
+  // invisible to the reconnecting client's fresh session. Sessions holding a
+  // live SSE stream are never reaped; a pure-POST client idle longer than
+  // MCP_HTTP_STALE_SESSION_MS (default 30 min; 0 disables) is closed through
+  // the normal onclose path, which stops its server and debug sessions.
+  const staleSessionMs = parseStaleSessionMs(proc.env.MCP_HTTP_STALE_SESSION_MS, logger);
+  let staleSweepTimer: NodeJS.Timeout | undefined;
+  if (staleSessionMs > 0) {
+    staleSweepTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [sid, session] of httpSessions) {
+        if (session.openStreams === 0 && now - session.lastActivity > staleSessionMs) {
+          logger.warn(`Reaping stale HTTP session ${sid} (idle ${Math.round((now - session.lastActivity) / 1000)}s, no open streams).`);
+          try {
+            void session.transport.close();
+          } catch (err) {
+            logger.error(`Error closing stale HTTP session ${sid}`, { error: err });
+          }
+        }
+      }
+    }, STALE_SWEEP_INTERVAL_MS);
+    staleSweepTimer.unref?.();
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (app as any).staleSweepTimer = staleSweepTimer;
 
   // CORS — Mcp-Session-Id and last-event-id must be exposed for the MCP Inspector
   // and for clients to read the session ID from the Initialize response.
@@ -73,7 +123,18 @@ export function createHttpApp(
 
       if (sessionId && httpSessions.has(sessionId)) {
         // Existing session — route to its transport
-        transport = httpSessions.get(sessionId)!.transport;
+        const session = httpSessions.get(sessionId)!;
+        session.lastActivity = Date.now();
+        if (req.method === 'GET') {
+          // A live SSE stream marks the session as attended; the socket
+          // closing (client crash included) is observed immediately.
+          session.openStreams++;
+          res.on('close', () => {
+            session.openStreams = Math.max(0, session.openStreams - 1);
+            session.lastActivity = Date.now();
+          });
+        }
+        transport = session.transport;
       } else if (!sessionId && req.method === 'POST' && isInitializeRequest(req.body)) {
         // New session — spin up an isolated DebugMcpServer + transport
         const newDebugServer = serverFactory({
@@ -90,7 +151,12 @@ export function createHttpApp(
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (sid: string) => {
             if (createdTransport) {
-              httpSessions.set(sid, { transport: createdTransport, server: newDebugServer });
+              httpSessions.set(sid, {
+                transport: createdTransport,
+                server: newDebugServer,
+                lastActivity: Date.now(),
+                openStreams: 0,
+              });
               logger.info(`HTTP session initialized: ${sid}`);
             }
           },
@@ -208,6 +274,12 @@ export async function handleHttpCommand(
       if (shutdownStarted) return;
       shutdownStarted = true;
       logger.info('Shutting down HTTP server...');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const staleSweepTimer = (app as any).staleSweepTimer as NodeJS.Timeout | undefined;
+      if (staleSweepTimer) {
+        clearInterval(staleSweepTimer);
+      }
 
       // Hard-exit fallback (issue #337): server.close() waits on open
       // sockets and a wedged proxy can stall stop() — once shutdown has

--- a/tests/unit/cli/http-command.test.ts
+++ b/tests/unit/cli/http-command.test.ts
@@ -381,6 +381,126 @@ describe('HTTP Command Handler', () => {
     });
   });
 
+  describe('stale session reaping (issue #337)', () => {
+    // A client that crashes without DELETE leaves its session (and its live
+    // DebugMcpServer + proxy chains) in httpSessions forever — invisible to
+    // the reconnecting client, which gets a fresh server with an empty store.
+    // The sweep closes sessions that are idle with no open SSE stream, which
+    // cascades transport.onclose → server.stop() → closeAllSessions().
+    const INIT_BODY = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'c', version: '1' } },
+    };
+
+    function makeStreamRes() {
+      const res = new EventEmitter() as any;
+      res.status = vi.fn().mockReturnThis();
+      res.json = vi.fn();
+      res.end = vi.fn();
+      res.headersSent = false;
+      return res;
+    }
+
+    function createAppAndHandler(staleMsEnv?: string) {
+      if (staleMsEnv !== undefined) {
+        fakeProc.env.MCP_HTTP_STALE_SESSION_MS = staleMsEnv;
+      }
+      const app = createHttpApp(
+        { port: '3001' },
+        { logger: mockLogger, serverFactory: mockServerFactory, proc: fakeProc }
+      );
+      const postCall = mockApp.post.mock.calls.find((c: any) => c[0] === '/mcp');
+      return { app, handler: postCall![1] as (req: any, res: any) => Promise<void> };
+    }
+
+    async function initSession(handler: (req: any, res: any) => Promise<void>) {
+      await handler({ method: 'POST', headers: {}, body: INIT_BODY }, makeStreamRes());
+      mockTransport.triggerSessionInit();
+      return mockTransport;
+    }
+
+    it('reaps an idle session with no open stream after the staleness window', async () => {
+      vi.useFakeTimers();
+      const { app, handler } = createAppAndHandler('5000');
+      const transport = await initSession(handler);
+      expect((app as any).httpSessions.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(61_000);
+
+      expect(transport.close).toHaveBeenCalled();
+      // The SDK fires onclose from close(); simulate it and confirm the
+      // existing cleanup path runs: server stopped, session forgotten.
+      transport.triggerClose();
+      expect(mockServer.stop).toHaveBeenCalled();
+      expect((app as any).httpSessions.size).toBe(0);
+    });
+
+    it('never reaps a session holding an open stream; reaps after the stream closes and goes idle', async () => {
+      vi.useFakeTimers();
+      const { handler } = createAppAndHandler('5000');
+      const transport = await initSession(handler);
+
+      const streamRes = makeStreamRes();
+      await handler(
+        { method: 'GET', headers: { 'mcp-session-id': transport.sessionId }, body: undefined },
+        streamRes
+      );
+
+      await vi.advanceTimersByTimeAsync(300_000);
+      expect(transport.close).not.toHaveBeenCalled();
+
+      // Client crash: the socket closes without a DELETE.
+      streamRes.emit('close');
+      await vi.advanceTimersByTimeAsync(61_000);
+
+      expect(transport.close).toHaveBeenCalled();
+    });
+
+    it('request activity resets the idle window', async () => {
+      vi.useFakeTimers();
+      const { handler } = createAppAndHandler('90000');
+      const transport = await initSession(handler);
+
+      await vi.advanceTimersByTimeAsync(59_000);
+      await handler(
+        { method: 'POST', headers: { 'mcp-session-id': transport.sessionId }, body: { jsonrpc: '2.0', id: 2, method: 'tools/list' } },
+        makeStreamRes()
+      );
+
+      // Sweep ticks at 60s and 120s see idle 1s and 61s — both under 90s.
+      await vi.advanceTimersByTimeAsync(61_000);
+      expect(transport.close).not.toHaveBeenCalled();
+
+      // Tick at 180s sees idle 121s — over the window.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(transport.close).toHaveBeenCalled();
+    });
+
+    it('MCP_HTTP_STALE_SESSION_MS=0 disables reaping', async () => {
+      vi.useFakeTimers();
+      const { handler } = createAppAndHandler('0');
+      const transport = await initSession(handler);
+
+      await vi.advanceTimersByTimeAsync(3_600_000);
+
+      expect(transport.close).not.toHaveBeenCalled();
+    });
+
+    it('defaults to a 30-minute window', async () => {
+      vi.useFakeTimers();
+      const { handler } = createAppAndHandler();
+      const transport = await initSession(handler);
+
+      await vi.advanceTimersByTimeAsync(29 * 60_000);
+      expect(transport.close).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(3 * 60_000);
+      expect(transport.close).toHaveBeenCalled();
+    });
+  });
+
   describe('handleHttpCommand', () => {
     let mockHttpServer: any;
 


### PR DESCRIPTION
## Problem (final part of #337; follows #339, #340)

HTTP mode creates an isolated `DebugMcpServer` (own session store) per MCP session, but `transport.onclose` only fires on an explicit close/DELETE. A client that **crashes** leaves its session registered forever — its debug sessions (and `lldb-server`'s ptrace claim on an attach target) stay alive, while the reconnecting client gets a fresh MCP session whose `list_debug_sessions` is legitimately empty. That is precisely the incident in #337: a live target-tracing chain with zero sessions listed, no in-band recovery.

## Fix

A 60s sweep closes sessions that are idle beyond `MCP_HTTP_STALE_SESSION_MS` (default 30 min; `0` disables) **and** hold no open SSE stream. Closing the transport cascades through the existing `onclose` path — `server.stop()` → `closeAllSessions()` → proxy teardown (which, since #339, kills the whole adapter chain) — so the ptrace claim is released in-band, no pod restart.

- Sessions holding a live SSE stream are never reaped, however long they idle.
- The stream socket closing (client crash included) is observed immediately via `res.on('close')` and restarts the idle clock.
- The sweep timer is unref'd and cleared in `gracefulShutdown`.
- docs/jit-diagnostics: sidecar recipe now suggests `--env=MCP_HTTP_STALE_SESSION_MS=300000`; the manual `TracerPid` recovery note is updated.

## Testing

- Unit: reaps an idle streamless session (and the close→stop→map-clean cascade); never reaps while a stream is open, reaps after it closes and idles; request activity resets the window; `0` disables; 30-min default.
- Manual, against the built server: initialize via curl, abandon without DELETE, `MCP_HTTP_STALE_SESSION_MS=5000` → `/health` went `connections: 1 → 0` at the first sweep tick.
- Full unit suite 3453 passing.

Closes #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)