### PR TITLE
fix: surface adapter errors during attach verification; cpp attach test under Yama ptrace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ __pycache__/
 
 # Rust build artifacts
 target/
+target-linux/
 Cargo.lock
 # Fixture lockfiles ARE tracked: the docker cross-compile builds with --locked,
 # and a fresh CI checkout without them fails ("lock file needs to be updated")
@@ -158,6 +159,7 @@ examples/dotnet/pause_test/obj/
 
 # Java build artifacts
 examples/java/*.class
+examples/java/**/*.class
 
 # Test results and analysis files
 test-results*.json
@@ -192,6 +194,11 @@ eslint-*.json
 packages/adapter-javascript/vendor/js-debug/
 packages/adapter-javascript/vendor/js-debug/**
 
+# Vendored CodeLLDB in the legacy per-adapter location (canonical copy lives in
+# packages/codelldb-common/vendor, ignored by that package's own .gitignore)
+packages/adapter-rust/vendor/
+packages/adapter-cpp/vendor/
+
 # Build artifacts from mcp-debugger bundling (generated during build; do not commit)
 packages/mcp-debugger/proxy/
 packages/mcp-debugger/vendor/
@@ -208,6 +215,7 @@ undefined/
 examples/go/**/*.exe
 examples/go/**/hello_world
 examples/go/**/hello_world_bin
+examples/go/**/hello_world_test
 examples/go/**/pause_test_bin
 __debug_bin*
 

--- a/examples/cpp/pause_test.cpp
+++ b/examples/cpp/pause_test.cpp
@@ -3,8 +3,16 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 
 int main() {
+#ifdef __linux__
+    // Yama ptrace_scope=1 only lets ancestors attach; the attach tests spawn
+    // this process outside the debugger's process tree, so opt in to any tracer.
+    prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0);
+#endif
     long long counter = 0;
     std::cout << "PAUSE_TEST_START" << std::endl;
     while (true) {

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -2560,9 +2560,33 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         let threads: DebugProtocol.Thread[] | undefined;
         let lastFailure = 'no threads response received';
 
+        // Some adapters reject the attach only after reporting themselves
+        // configured (CodeLLDB does this for e.g. ptrace EPERM). The proxy
+        // then dies mid-verify and every remaining 'threads' poll would throw
+        // a generic "Proxy not initialized", masking the real error — so latch
+        // the first proxy error/exit as the failure and stop polling.
+        let proxyGone = false;
+        const onProxyError = (err: Error): void => {
+          if (!proxyGone) {
+            proxyGone = true;
+            lastFailure = err.message;
+          }
+        };
+        const onProxyExit = (code: number | null, signal?: string): void => {
+          if (!proxyGone) {
+            proxyGone = true;
+            lastFailure = `debug adapter exited during attach verification (code=${code}${signal ? `, signal=${signal}` : ''})`;
+          }
+        };
+        proxyManager.on('error', onProxyError);
+        proxyManager.on('exit', onProxyExit);
+
         const requestThreads = async (): Promise<void> => {
           const remainingMs = Math.max(deadline - Date.now(), 1);
           const threadsResponse = await this.sendThreadsRequestBounded(proxyManager, remainingMs);
+          if (proxyGone) {
+            return;
+          }
           if (threadsResponse?.success === false) {
             lastFailure = threadsResponse.message || `'threads' request failed`;
             return;
@@ -2575,30 +2599,41 @@ export abstract class SessionManagerOperations extends SessionManagerData {
           }
         };
 
-        // First discovery attempt.
         try {
-          await requestThreads();
-        } catch (err) {
-          lastFailure = err instanceof Error ? err.message : String(err);
-          this.logger.warn(`[SessionManager] Initial thread discovery for attach failed: ${lastFailure}`);
-        }
-
-        // Retry until the deadline if the debugger has not reported threads yet.
-        while (!threads && Date.now() < deadline) {
-          const sleepMs = Math.min(pollIntervalMs, Math.max(deadline - Date.now(), 1));
-          await new Promise((resolve) => setTimeout(resolve, sleepMs));
-          if (Date.now() >= deadline) {
-            break;
-          }
+          // First discovery attempt.
           try {
             await requestThreads();
           } catch (err) {
-            lastFailure = err instanceof Error ? err.message : String(err);
+            if (!proxyGone) {
+              lastFailure = err instanceof Error ? err.message : String(err);
+            }
+            this.logger.warn(`[SessionManager] Initial thread discovery for attach failed: ${lastFailure}`);
           }
+
+          // Retry until the deadline if the debugger has not reported threads yet.
+          while (!threads && !proxyGone && Date.now() < deadline) {
+            const sleepMs = Math.min(pollIntervalMs, Math.max(deadline - Date.now(), 1));
+            await new Promise((resolve) => setTimeout(resolve, sleepMs));
+            if (proxyGone || Date.now() >= deadline) {
+              break;
+            }
+            try {
+              await requestThreads();
+            } catch (err) {
+              if (!proxyGone) {
+                lastFailure = err instanceof Error ? err.message : String(err);
+              }
+            }
+          }
+        } finally {
+          proxyManager.removeListener('error', onProxyError);
+          proxyManager.removeListener('exit', onProxyExit);
         }
 
         if (!threads) {
-          const reason = ErrorMessages.attachVerifyFailed(verifyTimeoutMs, lastFailure);
+          const reason = proxyGone
+            ? ErrorMessages.attachAdapterFailed(lastFailure)
+            : ErrorMessages.attachVerifyFailed(verifyTimeoutMs, lastFailure);
           this.logger.error(`[SessionManager] ${reason} — tearing down proxy for session ${sessionId}`);
           // Tear down the proxy using the same mechanics as closeSession, but
           // keep the session record so the failure is inspectable as ERROR.

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -84,6 +84,17 @@ export const ErrorMessages = {
     `(e.g. a busy or warming JVM), retry with a larger 'verifyTimeout' (ms) on attach_to_process.`,
 
   /**
+   * Error message for attaches rejected by the debug adapter itself
+   * Occurs when: The adapter rejects the attach after reporting itself
+   * configured (e.g. CodeLLDB on ptrace EPERM) and the proxy dies mid-verify —
+   * a retry with a larger timeout cannot help
+   * Used in: src/session/session-manager-operations.ts
+   * @param failure - The adapter's error, or the proxy exit description
+   */
+  attachAdapterFailed: (failure: string) =>
+    `Attach failed: the debug adapter reported an error and exited during attach verification: ${failure}`,
+
+  /**
    * Error message for adapter ready timeouts
    * Occurs when: Waiting for the debug adapter to be configured times out
    * Used in: src/session/session-manager.ts (logged as warning)

--- a/tests/e2e/mcp-server-smoke-cpp-attach.test.ts
+++ b/tests/e2e/mcp-server-smoke-cpp-attach.test.ts
@@ -4,9 +4,12 @@
  * Launches the pause_test binary directly, attaches by PID via CodeLLDB,
  * inspects threads/stack, detaches (target must survive), then kills it.
  * Self-skips without a compiler; on Linux, also self-skips when
- * kernel.yama.ptrace_scope blocks attaching to non-child processes... except
- * the debuggee IS spawned by this process's test runner, so ptrace_scope=1
- * (children allowed) still works — only scope>=2 blocks it.
+ * kernel.yama.ptrace_scope blocks the attach. Note Yama scope 1 requires the
+ * tracer to be an ANCESTOR of the tracee — the debuggee here is spawned by
+ * vitest while the tracer (lldb-server, under the MCP server's proxy) is a
+ * sibling tree, so scope 1 would block it. pause_test.cpp therefore calls
+ * prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY) to allow any tracer; only
+ * scope>=2 (needs CAP_SYS_PTRACE) or scope 3 still forces a skip.
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import path from 'path';

--- a/tests/e2e/mcp-server-smoke-ruby.test.ts
+++ b/tests/e2e/mcp-server-smoke-ruby.test.ts
@@ -260,13 +260,20 @@ describe('MCP Server Ruby Debugging Smoke Test @requires-ruby', () => {
     expect(marker).toBeDefined();
     expect(marker!.category).toBe('stdout');
 
-    // Prove mid-run capture: the session must still be paused (iteration 2's
+    // Prove mid-run capture: the session must end up paused (iteration 2's
     // stop), so the marker cannot have arrived via the exit-flush drain.
-    const listResponse = parseSdkToolResult(await mcpClient!.callTool({
-      name: 'list_debug_sessions',
-      arguments: {}
-    })) as { sessions?: Array<{ id: string; state: string }> };
-    expect(listResponse.sessions?.find(s => s.id === sessionId)?.state).toBe('paused');
+    // The marker beats rdbg's next 'stopped' event by ~30-40ms (synced stdout
+    // is fast, the DAP socket isn't), so poll instead of sampling once; a
+    // run-to-completion settles on 'stopped' and still fails the assertion.
+    const settledState = await pollUntil(async () => {
+      const listResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'list_debug_sessions',
+        arguments: {}
+      })) as { sessions?: Array<{ id: string; state: string }> };
+      const state = listResponse.sessions?.find(s => s.id === sessionId)?.state;
+      return state === 'paused' || state === 'stopped' ? state : undefined;
+    }, 15000);
+    expect(settledState).toBe('paused');
   }, 90000);
 
   it('applies dapLaunchArgs.env to the debuggee (issue #318)', async () => {

--- a/tests/e2e/rust-example-utils.ts
+++ b/tests/e2e/rust-example-utils.ts
@@ -10,6 +10,10 @@ const WINDOWS_GNU_TARGET = 'x86_64-pc-windows-gnu';
 const ROOT = path.resolve(process.cwd(), '.');
 const DOCKER_RUST_IMAGE = process.env.RUST_EXAMPLE_DOCKER_IMAGE || 'rust:1.83-slim';
 const LINUX_BUILD_STAMP = '.debug-mcp-linux-build';
+// Docker builds get their own target dir: they mount `examples` at /workspace,
+// so writing to `target/` would clobber the host build with a binary whose
+// DWARF paths say /workspace — breaking every host-path breakpoint/logpoint.
+const LINUX_TARGET_DIR = 'target-linux';
 type RustTarget = 'host' | 'linux';
 
 interface ExamplePaths {
@@ -96,7 +100,7 @@ async function resolveBinaryPath(
   const extension = process.platform === 'win32' ? '.exe' : '';
 
   if (target === 'linux') {
-    const linuxBinary = path.join(exampleRoot, 'target', 'debug', binaryName);
+    const linuxBinary = path.join(exampleRoot, LINUX_TARGET_DIR, 'debug', binaryName);
     if (!(await pathExistsAsync(linuxBinary))) {
       throw new Error(`Linux binary not found at ${linuxBinary}. Did the docker build succeed?`);
     }
@@ -131,7 +135,7 @@ async function resolveBinaryPath(
 }
 
 async function buildExampleBinaryInDocker(exampleRoot: string, exampleName: RustExampleName): Promise<void> {
-  const binaryPath = path.join(exampleRoot, 'target', 'debug', exampleName);
+  const binaryPath = path.join(exampleRoot, LINUX_TARGET_DIR, 'debug', exampleName);
   const sourcePath = path.join(exampleRoot, 'src', 'main.rs');
   const examplesRootFs = path.resolve(ROOT, 'examples');
   const relativeExamplePathFs = path.relative(examplesRootFs, exampleRoot);
@@ -151,6 +155,8 @@ async function buildExampleBinaryInDocker(exampleRoot: string, exampleName: Rust
     `${examplesRoot}:/workspace`,
     '-e',
     'CARGO_HOME=/workspace/.cargo',
+    '-e',
+    `CARGO_TARGET_DIR=${workdir}/${LINUX_TARGET_DIR}`,
     '--workdir',
     workdir,
     DOCKER_RUST_IMAGE,
@@ -158,6 +164,11 @@ async function buildExampleBinaryInDocker(exampleRoot: string, exampleName: Rust
     '-c',
     'cargo build --locked --color never'
   ];
+  // Build as the host user (Linux/macOS dev runs) so artifacts under the
+  // mounted examples tree aren't left root-owned and un-deletable.
+  if (process.platform !== 'win32' && typeof process.getuid === 'function' && typeof process.getgid === 'function') {
+    dockerArgs.splice(2, 0, '--user', `${process.getuid()}:${process.getgid()}`);
+  }
 
   await runDockerCommand(dockerArgs);
   const stampPath = path.join(exampleRoot, LINUX_BUILD_STAMP);

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -1644,6 +1644,49 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(mockProxyManager.setCurrentThreadId).not.toHaveBeenCalled();
     });
 
+    it('surfaces the adapter error and aborts early when the proxy dies during verification', async () => {
+      // CodeLLDB rejects an attach (e.g. ptrace EPERM) only after the worker
+      // has reported adapter_configured_and_launched; the proxy then exits and
+      // every further 'threads' poll throws "Proxy not initialized". The
+      // verify loop must report the adapter's error, not the generic poll
+      // failure, and must stop polling instead of running out the window.
+      (operations as unknown as { attachVerifyTimeoutMs: number }).attachVerifyTimeoutMs = 5000;
+
+      let errorHandler: ((err: Error) => void) | undefined;
+      mockProxyManager.on.mockImplementation((event: string, handler: (err: Error) => void) => {
+        if (event === 'error') errorHandler = handler;
+        return mockProxyManager;
+      });
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'threads') {
+          // The adapter rejection lands while the first poll is in flight.
+          errorHandler?.(new Error('Critical initialization error: attach failed: Operation not permitted'));
+          throw new Error('Proxy not initialized');
+        }
+        return {};
+      });
+
+      vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+      });
+
+      const startedAt = Date.now();
+      const result = await operations.attachToProcess('test-session', {
+        port: 5005,
+        host: 'localhost',
+        stopOnEntry: true
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.state).toBe(SessionState.ERROR);
+      expect(result.error).toContain('Operation not permitted');
+      expect(result.error).not.toContain('Proxy not initialized');
+      expect(result.error).not.toContain('verifyTimeout');
+      expect(Date.now() - startedAt).toBeLessThan(2000);
+      expect(mockProxyManager.stop).toHaveBeenCalled();
+      expect(mockSession.proxyManager).toBeUndefined();
+    });
+
     it('should invoke the adapter policy performHandshake for attach when the policy defines it', async () => {
       // js-debug's DAP attach sequence is driven by performHandshake; before
       // issue #124 attachToProcess never called it, so no attach request ever


### PR DESCRIPTION
## Summary
- Latch the first proxy error/exit during attach thread-discovery polling so the real adapter failure (e.g. CodeLLDB ptrace EPERM) is reported instead of a generic verify-timeout; adds `ErrorMessages.attachAdapterFailed`
- `examples/cpp/pause_test.cpp` opts in to any tracer via `prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY)` so the cpp attach e2e works under `kernel.yama.ptrace_scope=1` (the tracer is a sibling process tree, not an ancestor)
- Ruby smoke: accept the paused-or-stopped race in the mid-run capture assertion
- Ignore legacy per-adapter CodeLLDB vendor dirs and misc build artifacts

## Testing
- `npm run lint` clean
- `npx vitest run tests/unit/session-manager-operations-coverage.test.ts` — 137 passed
- `npx vitest run tests/e2e/mcp-server-smoke-cpp-attach.test.ts tests/e2e/mcp-server-smoke-ruby.test.ts` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)