### PR TITLE
fix(#352,#368,#370): Java attach pause, exitCode, redefine breakpoint re-plant

### DIFF
--- a/packages/adapter-java/java/JdiDapServer.java
+++ b/packages/adapter-java/java/JdiDapServer.java
@@ -30,6 +30,13 @@ public class JdiDapServer {
     private volatile VirtualMachine vm;
     private volatile Process launchedProcess; // non-null only in launch mode
 
+    // --- Debuggee exit tracking (issue #368, launch mode only) ---
+    // targetExitCode is stored by a daemon watcher thread the moment the
+    // launched process exits; exitedSent guards the single 'exited' emission.
+    private volatile Integer targetExitCode = null;
+    private volatile boolean exitedSent = false;
+    private final Object exitedLock = new Object();
+
     // --- Variable references ---
     // All variable references (scopes, expandable objects) use sequential IDs
     // starting from 1. Maps track what each ref points to.
@@ -354,6 +361,11 @@ public class JdiDapServer {
         String classpath = strOr(args, "classpath", ".");
         this.stopOnEntry = boolVal(args, "stopOnEntry", true);
 
+        // Fresh exit tracking per launch (issue #368) — defensive in case a
+        // bridge process ever services more than one launch.
+        this.targetExitCode = null;
+        this.exitedSent = false;
+
         // Find a free port for JDWP
         int jdwpPort;
         try (ServerSocket ss = new ServerSocket(0)) {
@@ -403,6 +415,18 @@ public class JdiDapServer {
         ProcessBuilder pb = new ProcessBuilder(taggedCmd);
         pb.redirectErrorStream(false);
         launchedProcess = pb.start();
+
+        // Issue #368: watch for debuggee exit so the real exit code is on hand
+        // when VMDeath/VMDisconnect arrives (never fabricated — see
+        // maybeSendExitedEvent).
+        final Process watchedProcess = launchedProcess;
+        Thread exitWatcher = new Thread(() -> {
+            try {
+                targetExitCode = watchedProcess.waitFor();
+            } catch (InterruptedException e) { /* shutting down */ }
+        }, "target-exit-watcher");
+        exitWatcher.setDaemon(true);
+        exitWatcher.start();
 
         // Read stderr to find JDWP listen port (and forward output)
         Thread stderrThread = new Thread(() -> {
@@ -1051,14 +1075,8 @@ public class JdiDapServer {
             if (stopOnEntry) {
                 // stopOnEntry=true: send stopped event, keep VM suspended
                 long threadId = 1;
-                try {
-                    for (ThreadReference tr : vm.allThreads()) {
-                        if ("main".equals(tr.name())) {
-                            threadId = tr.uniqueID();
-                            break;
-                        }
-                    }
-                } catch (Exception e) { /* use default */ }
+                ThreadReference reportable = pickReportableThread();
+                if (reportable != null) threadId = reportable.uniqueID();
 
                 sendStoppedEvent("entry", threadId);
             } else {
@@ -1076,7 +1094,19 @@ public class JdiDapServer {
         List<Map<String, Object>> threads = new ArrayList<>();
         if (vm != null) {
             try {
+                // Issue #352: list the reportable thread (usually "main") first.
+                // Clients commonly take threads[0] as the pause / stack-trace
+                // target, and raw allThreads() order starts with JVM system
+                // threads like "Reference Handler" that report no user frames.
+                ThreadReference first = pickReportableThread();
+                if (first != null) {
+                    Map<String, Object> t = new HashMap<>();
+                    t.put("id", first.uniqueID());
+                    t.put("name", first.name());
+                    threads.add(t);
+                }
                 for (ThreadReference tr : vm.allThreads()) {
+                    if (first != null && tr.uniqueID() == first.uniqueID()) continue;
                     Map<String, Object> t = new HashMap<>();
                     t.put("id", tr.uniqueID());
                     t.put("name", tr.name());
@@ -1092,44 +1122,32 @@ public class JdiDapServer {
     private void handleStackTrace(int reqSeq, Map<String, Object> args) {
         long threadId = longVal(args, "threadId");
         List<Map<String, Object>> frames = new ArrayList<>();
+        String message = null;
 
         if (vm != null) {
             try {
                 ThreadReference thread = findThread(threadId);
-                if (thread != null) {
-                    List<StackFrame> jdiFrames = thread.frames();
-                    // Cache frames for variable lookup
-                    threadFrameCache.put(thread.uniqueID(), jdiFrames);
-
-                    for (int i = 0; i < jdiFrames.size(); i++) {
-                        StackFrame sf = jdiFrames.get(i);
-                        Location loc = sf.location();
-                        int frameId = encodeFrameId(threadId, i);
-
-                        Map<String, Object> frame = new HashMap<>();
-                        frame.put("id", frameId);
-                        // Fully qualified names (java.lang.Thread.sleep0, not sleep0)
-                        // match JDWP/IDE conventions and let clients recognize
-                        // JDK-internal frames by name.
-                        frame.put("name", loc.declaringType().name() + "." + loc.method().name());
-                        frame.put("line", loc.lineNumber());
-                        frame.put("column", 0);
-
-                        // Source info
-                        Map<String, Object> source = new HashMap<>();
+                try {
+                    if (thread != null) {
+                        collectFrames(thread, frames);
+                    }
+                } catch (IncompatibleThreadStateException e) {
+                    // Issue #352: the requested thread cannot report frames
+                    // (not suspended, or a system thread with no user frames).
+                    // Retry once against a thread that can.
+                    log("Thread not suspended for stack trace: " + e.getMessage());
+                    ThreadReference retry = pickReportableThread();
+                    if (retry != null && (thread == null || retry.uniqueID() != thread.uniqueID())) {
                         try {
-                            source.put("name", loc.sourceName());
-                            source.put("path", resolveSourcePath(loc));
-                        } catch (AbsentInformationException e) {
-                            source.put("name", loc.declaringType().name());
+                            collectFrames(retry, frames);
+                        } catch (IncompatibleThreadStateException e2) {
+                            // still nothing usable — fall through to the message
                         }
-                        frame.put("source", source);
-
-                        frames.add(frame);
+                    }
+                    if (frames.isEmpty()) {
+                        message = "Thread " + threadId + " is not suspended; no frames available";
                     }
                 }
-            } catch (IncompatibleThreadStateException e) {
-                log("Thread not suspended for stack trace: " + e.getMessage());
             } catch (VMDisconnectedException e) {
                 // VM already gone
             }
@@ -1138,7 +1156,46 @@ public class JdiDapServer {
         Map<String, Object> body = new HashMap<>();
         body.put("stackFrames", frames);
         body.put("totalFrames", frames.size());
+        if (message != null) body.put("message", message);
         sendResponse(reqSeq, "stackTrace", true, body);
+    }
+
+    /** Collect DAP stack frames for one thread into {@code frames}.
+     *  Throws IncompatibleThreadStateException when the thread cannot report
+     *  frames so handleStackTrace can retry against a reportable thread. */
+    private void collectFrames(ThreadReference thread, List<Map<String, Object>> frames)
+            throws IncompatibleThreadStateException {
+        List<StackFrame> jdiFrames = thread.frames();
+        long threadId = thread.uniqueID();
+        // Cache frames for variable lookup
+        threadFrameCache.put(threadId, jdiFrames);
+
+        for (int i = 0; i < jdiFrames.size(); i++) {
+            StackFrame sf = jdiFrames.get(i);
+            Location loc = sf.location();
+            int frameId = encodeFrameId(threadId, i);
+
+            Map<String, Object> frame = new HashMap<>();
+            frame.put("id", frameId);
+            // Fully qualified names (java.lang.Thread.sleep0, not sleep0)
+            // match JDWP/IDE conventions and let clients recognize
+            // JDK-internal frames by name.
+            frame.put("name", loc.declaringType().name() + "." + loc.method().name());
+            frame.put("line", loc.lineNumber());
+            frame.put("column", 0);
+
+            // Source info
+            Map<String, Object> source = new HashMap<>();
+            try {
+                source.put("name", loc.sourceName());
+                source.put("path", resolveSourcePath(loc));
+            } catch (AbsentInformationException e) {
+                source.put("name", loc.declaringType().name());
+            }
+            frame.put("source", source);
+
+            frames.add(frame);
+        }
     }
 
     private void handleScopes(int reqSeq, Map<String, Object> args) {
@@ -1368,9 +1425,11 @@ public class JdiDapServer {
             } else {
                 // Pause all threads (threadId 0 or absent)
                 vm.suspend();
-                // Pick the first thread for the stopped event
-                List<ThreadReference> threads = vm.allThreads();
-                long stoppedThreadId = threads.isEmpty() ? 0 : threads.get(0).uniqueID();
+                // Issue #352: announce a thread that can actually report frames.
+                // allThreads().get(0) is typically a JVM system thread (e.g.
+                // "Reference Handler") whose stackTrace comes back empty.
+                ThreadReference reportable = pickReportableThread();
+                long stoppedThreadId = reportable != null ? reportable.uniqueID() : 0;
                 sendStoppedEvent("pause", stoppedThreadId);
                 sendResponse(reqSeq, "pause", true, new HashMap<>());
             }
@@ -1630,6 +1689,7 @@ public class JdiDapServer {
             List<String> redefined = new ArrayList<>();
             List<Map<String, Object>> failed = new ArrayList<>();
             int skippedNotLoaded = 0;
+            int replantedBreakpoints = 0;
 
             for (java.nio.file.Path classFile : classFiles) {
                 // Convert path to FQCN: com/example/Foo$Bar.class -> com.example.Foo$Bar
@@ -1652,6 +1712,9 @@ public class JdiDapServer {
                     redefMap.put(types.get(0), bytes);
                     vm.redefineClasses(redefMap);
                     redefined.add(fqcn);
+                    // Issue #370: redefineClasses cancels every BreakpointRequest
+                    // in the redefined class (JDI spec) — re-plant them.
+                    replantedBreakpoints += replantBreakpointsAfterRedefine(fqcn);
                 } catch (Exception e) {
                     Map<String, Object> entry = new HashMap<>();
                     entry.put("fqcn", fqcn);
@@ -1669,12 +1732,61 @@ public class JdiDapServer {
             if (!failed.isEmpty()) body.put("failed", failed);
             body.put("scannedFiles", classFiles.size());
             body.put("newestTimestamp", newestTimestamp);
+            body.put("replantedBreakpoints", replantedBreakpoints);
             sendResponse(reqSeq, "redefineClasses", true, body);
 
         } catch (Exception e) {
             sendErrorResponse(reqSeq, "redefineClasses",
                     "Scan/redefine error: " + e.getClass().getSimpleName() + ": " + e.getMessage());
         }
+    }
+
+    /**
+     * Issue #370: per the JDI spec, {@code vm.redefineClasses} cancels all
+     * BreakpointRequests in the redefined classes without any notification —
+     * nothing re-plants them, so pre-existing breakpoints silently stop
+     * firing. After each successful redefine:
+     *   1. delete stale line/function BreakpointRequests still registered for
+     *      the type (some VMs disable rather than remove them, which would
+     *      make the idempotent re-bind checks skip the re-plant),
+     *   2. re-run the deferred-breakpoint machinery (handleClassPrepared /
+     *      handleClassPreparedForFunctionBreakpoints) to plant fresh requests
+     *      against the new bytecode.
+     * A line whose bytecode became obsolete may re-verify false — that is the
+     * correct surface, not suppressed here.
+     *
+     * @return number of line breakpoints re-planted (verified against the
+     *         redefined type)
+     */
+    private int replantBreakpointsAfterRedefine(String fqcn) {
+        if (vm == null) return 0;
+        List<ReferenceType> types = vm.classesByName(fqcn);
+        if (types.isEmpty()) return 0;
+        ReferenceType refType = types.get(0);
+
+        EventRequestManager erm = vm.eventRequestManager();
+        List<BreakpointRequest> stale = new ArrayList<>();
+        for (BreakpointRequest br : erm.breakpointRequests()) {
+            try {
+                if (refType.equals(br.location().declaringType())) {
+                    stale.add(br);
+                }
+            } catch (RuntimeException e) {
+                // location of a cancelled request may be unreadable — leave it
+            }
+        }
+        for (BreakpointRequest br : stale) {
+            try {
+                erm.deleteEventRequest(br);
+            } catch (RuntimeException e) { /* already gone */ }
+        }
+        if (!stale.isEmpty()) {
+            log("Deleted " + stale.size() + " stale breakpoint request(s) on redefined class " + fqcn);
+        }
+
+        int replanted = handleClassPrepared(refType);
+        handleClassPreparedForFunctionBreakpoints(refType);
+        return replanted;
     }
 
     // ========== JDI Event Loop ==========
@@ -1749,12 +1861,14 @@ public class JdiDapServer {
 
                         } else if (event instanceof VMDeathEvent) {
                             log("VM death event");
+                            maybeSendExitedEvent(); // issue #368: exited before terminated
                             sendEvent("terminated", new HashMap<>());
                             running = false;
                             return;
 
                         } else if (event instanceof VMDisconnectEvent) {
                             log("VM disconnect event");
+                            maybeSendExitedEvent(); // issue #368: exited before terminated
                             sendEvent("terminated", new HashMap<>());
                             running = false;
                             return;
@@ -1785,12 +1899,14 @@ public class JdiDapServer {
                 }
             } catch (VMDisconnectedException e) {
                 log("VM disconnected in event loop");
+                maybeSendExitedEvent(); // issue #368: exited before terminated
                 sendEvent("terminated", new HashMap<>());
             } catch (InterruptedException e) {
                 log("Event loop interrupted");
             } catch (Exception e) {
                 log("Event loop error: " + e.getMessage());
                 try {
+                    maybeSendExitedEvent(); // issue #368: exited before terminated
                     sendEvent("terminated", new HashMap<>());
                 } catch (Exception ex) {
                     log("Failed to send terminated event: " + ex.getMessage());
@@ -1802,7 +1918,8 @@ public class JdiDapServer {
         eventThread.start();
     }
 
-    private void handleClassPrepared(ReferenceType refType) {
+    /** @return the number of breakpoints set (verified) on the prepared type */
+    private int handleClassPrepared(ReferenceType refType) {
         // Look up deferred breakpoints by scanning all deferred entries whose className matches
         // the prepared ReferenceType (full name or simple name).
         // The CPR property is set in handleSetBreakpoints / registerPendingBreakpoints.
@@ -1828,12 +1945,13 @@ public class JdiDapServer {
                 if (entryClassName.equals(outerFqn)) { bpInfo = entry; break; }
             }
         }
-        if (bpInfo == null) return;
+        if (bpInfo == null) return 0;
 
         String sourcePath = str(bpInfo, "sourcePath");
         List<Object> breakpointSpecs = list(bpInfo, "breakpoints");
-        if (breakpointSpecs == null) return;
+        if (breakpointSpecs == null) return 0;
 
+        int planted = 0;
         log("Setting deferred breakpoints on " + className);
         for (Object bpObj : breakpointSpecs) {
             Map<String, Object> bpSpec = asMap(bpObj);
@@ -1844,6 +1962,7 @@ public class JdiDapServer {
 
             // Send breakpoint verified event
             if (Boolean.TRUE.equals(bp.get("verified"))) {
+                planted++;
                 Map<String, Object> bpEvent = new HashMap<>();
                 bpEvent.put("reason", "changed");
                 Map<String, Object> bpBody = new HashMap<>();
@@ -1857,6 +1976,7 @@ public class JdiDapServer {
                 sendEvent("breakpoint", bpEvent);
             }
         }
+        return planted;
     }
 
     private boolean evaluateCondition(ThreadReference thread, String condition) {
@@ -1891,6 +2011,54 @@ public class JdiDapServer {
             }
         }
         throw new RuntimeException("SocketAttach connector not found");
+    }
+
+    /**
+     * Issue #352: pick a thread worth announcing in a stopped event / worth
+     * reading a stack from. Preference order:
+     *   1. the thread named "main" (if it can report frames when suspended),
+     *   2. the first thread that is suspended with at least one frame,
+     *   3. allThreads().get(0) as a last resort (guarding the empty list).
+     * Per-thread JDI state exceptions are swallowed so one bad thread never
+     * hides a usable one.
+     */
+    private ThreadReference pickReportableThread() {
+        if (vm == null) return null;
+        List<ThreadReference> threads;
+        try {
+            threads = vm.allThreads();
+        } catch (VMDisconnectedException e) {
+            return null;
+        }
+        if (threads.isEmpty()) return null;
+
+        ThreadReference mainThread = null;
+        for (ThreadReference t : threads) {
+            try {
+                if ("main".equals(t.name())) {
+                    mainThread = t;
+                    break;
+                }
+            } catch (RuntimeException e) { /* skip unreadable thread */ }
+        }
+        if (mainThread != null) {
+            try {
+                if (!mainThread.isSuspended() || mainThread.frameCount() > 0) {
+                    return mainThread;
+                }
+            } catch (IncompatibleThreadStateException e) {
+                return mainThread; // state raced — still the best candidate
+            } catch (RuntimeException e) { /* fall through to scan */ }
+        }
+
+        for (ThreadReference t : threads) {
+            try {
+                if (t.isSuspended() && t.frameCount() > 0) return t;
+            } catch (IncompatibleThreadStateException e) {
+                // resumed between isSuspended() and frameCount() — skip
+            } catch (RuntimeException e) { /* skip unreadable thread */ }
+        }
+        return threads.get(0);
     }
 
     private ThreadReference findThread(long threadId) {
@@ -1945,6 +2113,35 @@ public class JdiDapServer {
             nextFrameId.set(1);
         }
         lastException = null;
+    }
+
+    /**
+     * Issue #368: emit a DAP 'exited' event carrying the debuggee's real exit
+     * code, at most once, BEFORE the corresponding 'terminated' event.
+     * Launch mode only — in attach mode ({@code launchedProcess == null}) we
+     * never owned the process and never fabricate a code. Waits briefly for
+     * the process to finish (VMDeath can arrive slightly before OS-level
+     * process exit); if it is still running (e.g. detach), no event is sent.
+     */
+    private void maybeSendExitedEvent() {
+        Process proc = launchedProcess;
+        if (proc == null) return; // attach mode (or already cleaned up)
+        synchronized (exitedLock) {
+            if (exitedSent) return;
+            Integer code = targetExitCode; // stored by target-exit-watcher
+            if (code == null) {
+                try {
+                    if (proc.waitFor(2, TimeUnit.SECONDS)) {
+                        code = proc.exitValue();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (code == null) return; // process still alive — no code to report
+            exitedSent = true;
+            sendEvent("exited", mapOf("exitCode", code));
+        }
     }
 
     // synchronized so the shutdown-hook thread and the disconnect/terminate

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -66,6 +66,8 @@ export interface RedefineClassesResult {
   failed?: Array<{ fqcn: string; error: string }>;
   scannedFiles?: number;
   newestTimestamp?: number;
+  /** Breakpoints re-planted after redefine (issue #370). */
+  replantedBreakpoints?: number;
   error?: string;
 }
 
@@ -2854,6 +2856,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         failed: body.failed,
         scannedFiles: body.scannedFiles,
         newestTimestamp: body.newestTimestamp,
+        replantedBreakpoints: body.replantedBreakpoints,
       };
     } catch (error) {
       this.logger.error(`[SM redefineClasses ${sessionId}] Error: ${error}`);

--- a/tests/e2e/mcp-server-smoke-java-attach.test.ts
+++ b/tests/e2e/mcp-server-smoke-java-attach.test.ts
@@ -492,4 +492,98 @@ describe('MCP Server Java Attach-Mode Smoke Test @requires-java', () => {
       }
     }
   }, 60000);
+
+  it('pause_execution after attach reports a thread with usable frames (issue #352)', async () => {
+    // Skip if java/javac not available
+    try {
+      execSync('java -version', { stdio: 'ignore' });
+      execSync('javac -version', { stdio: 'ignore' });
+    } catch {
+      console.log('[Attach Pause #352] Skipping — JDK not installed');
+      return;
+    }
+
+    const { classDir: testClassDir, mainClass } = prepareJavaExample('PauseTest');
+
+    try {
+      // Spawn a free-running JVM (suspend=n) — PauseTest loops forever
+      const jdwpPort = await getFreePort();
+      console.log(`[Attach Pause #352] Using JDWP port: ${jdwpPort}`);
+
+      jvmProcess = spawn('java', [
+        `-agentlib:jdwp=transport=dt_socket,server=y,address=${jdwpPort},suspend=n`,
+        '-cp', testClassDir,
+        mainClass
+      ], {
+        cwd: testClassDir,
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+
+      // Wait for JDWP agent to be ready
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Timeout waiting for JDWP agent')), 15000);
+        let outputData = '';
+        let resolved = false;
+
+        const checkOutput = (chunk: Buffer) => {
+          if (resolved) return;
+          outputData += chunk.toString();
+          if (outputData.includes('Listening for transport')) {
+            resolved = true;
+            clearTimeout(timeout);
+            resolve();
+          }
+        };
+
+        jvmProcess!.stdout!.on('data', checkOutput);
+        jvmProcess!.stderr!.on('data', checkOutput);
+        jvmProcess!.on('error', (err) => { if (!resolved) { clearTimeout(timeout); reject(err); } });
+        jvmProcess!.on('exit', (code) => { if (!resolved) { clearTimeout(timeout); reject(new Error(`JVM exited ${code}`)); } });
+      });
+
+      // 1. Create session and attach to the RUNNING (not suspended) JVM
+      const createResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'create_debug_session',
+        arguments: { language: 'java', name: 'java-attach-pause-352' }
+      }));
+      expect(createResponse.sessionId).toBeDefined();
+      sessionId = createResponse.sessionId as string;
+
+      // stopOnEntry: false — the target was started with suspend=n, so the
+      // session must report RUNNING (not the suspend=y default of PAUSED)
+      // for pause_execution to actually send a DAP pause.
+      console.log(`[Attach Pause #352] Attaching to JVM on port ${jdwpPort}...`);
+      const attachResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'attach_to_process',
+        arguments: { sessionId, port: jdwpPort, host: '127.0.0.1', sourcePaths: [testClassDir], stopOnEntry: false }
+      }));
+      expect(attachResponse.success).toBe(true);
+      expect(attachResponse.state).toBe('running');
+
+      // 2. Pause all threads. Issue #352: the bridge previously announced
+      //    vm.allThreads().get(0) — typically a JVM system thread like
+      //    "Reference Handler" — so the follow-up stackTrace was empty.
+      console.log('[Attach Pause #352] Pausing execution...');
+      const pauseResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'pause_execution',
+        arguments: { sessionId }
+      }));
+      expect(pauseResponse.success).toBe(true);
+
+      // 3. Stack trace must be non-empty and contain the user's main frame
+      const stack = await waitForPausedState(mcpClient!, sessionId, 20, 500);
+      expect(stack).not.toBeNull();
+      const frames = stack!.stackFrames!;
+      expect(frames.length).toBeGreaterThan(0);
+      console.log('[Attach Pause #352] Frames:', frames.map(f => f.name));
+      expect(frames.some(f => (f.name ?? '').includes('PauseTest.main'))).toBe(true);
+
+      console.log('[Attach Pause #352] TEST PASSED — pause after attach reported a usable thread');
+    } finally {
+      if (jvmProcess && !jvmProcess.killed) {
+        jvmProcess.kill('SIGKILL');
+        jvmProcess = null;
+      }
+    }
+  }, 60000);
 });

--- a/tests/e2e/mcp-server-smoke-java-pause.test.ts
+++ b/tests/e2e/mcp-server-smoke-java-pause.test.ts
@@ -162,4 +162,59 @@ describe('MCP Server Java PauseTest Smoke Test @requires-java', () => {
     const contResult = await callToolSafely(mcpClient!, 'continue_execution', { sessionId });
     expect(contResult.success).toBe(true);
   }, 60000);
+
+  it('pause_execution on a running launch reports a thread with usable frames (issue #352)', async () => {
+    try {
+      execSync('java -version', { stdio: 'ignore' });
+      execSync('javac -version', { stdio: 'ignore' });
+    } catch {
+      console.log('[Java Pause #352] Skipping — JDK not installed');
+      return;
+    }
+
+    const { sourcePath, classDir, mainClass } = prepareJavaExample('PauseTest');
+
+    // 1. Create session
+    const createResponse = parseSdkToolResult(await mcpClient!.callTool({
+      name: 'create_debug_session',
+      arguments: { language: 'java', name: 'java-pause-352' }
+    }));
+    expect(createResponse.sessionId).toBeDefined();
+    sessionId = createResponse.sessionId as string;
+
+    // 2. Start debugging with NO breakpoints — PauseTest loops forever
+    const startResponse = parseSdkToolResult(await mcpClient!.callTool({
+      name: 'start_debugging',
+      arguments: {
+        sessionId,
+        scriptPath: sourcePath,
+        args: [],
+        dapLaunchArgs: { mainClass, classpath: classDir, cwd: classDir, stopOnEntry: false }
+      }
+    }));
+    expect(startResponse.success).toBe(true);
+
+    // 3. Let the program actually run before pausing
+    await new Promise(r => setTimeout(r, 1500));
+
+    // 4. Pause all threads. Issue #352: the bridge previously announced
+    //    vm.allThreads().get(0) — typically a JVM system thread like
+    //    "Reference Handler" — in the stopped event, so the follow-up
+    //    stackTrace came back with 0 frames.
+    const pauseResponse = parseSdkToolResult(await mcpClient!.callTool({
+      name: 'pause_execution',
+      arguments: { sessionId }
+    }));
+    expect(pauseResponse.success).toBe(true);
+
+    // 5. Stack trace must be non-empty and contain the user's main frame
+    const stack = await waitForPausedState(mcpClient!, sessionId, 20, 500);
+    expect(stack).not.toBeNull();
+    const frames = stack!.stackFrames!;
+    expect(frames.length).toBeGreaterThan(0);
+    console.log('[Java Pause #352] Frames:', frames.map(f => f.name));
+    expect(frames.some(f => (f.name ?? '').includes('PauseTest.main'))).toBe(true);
+
+    console.log('[Java Pause #352] TEST PASSED — pause reported a usable thread');
+  }, 60000);
 });

--- a/tests/e2e/mcp-server-smoke-java-redefine.test.ts
+++ b/tests/e2e/mcp-server-smoke-java-redefine.test.ts
@@ -285,4 +285,174 @@ describe('Java Hot-Reload (redefine_classes) Smoke Test @requires-java', () => {
       }
     }
   }, 90000);
+
+  it('re-plants pre-existing breakpoints after redefine_classes (issue #370)', async () => {
+    // Check JDK availability
+    try {
+      execSync('java -version', { stdio: 'ignore' });
+      execSync('javac -version', { stdio: 'ignore' });
+    } catch {
+      console.log('[Redefine #370] Skipping — JDK not installed');
+      return;
+    }
+
+    // Compile original version (getValue() returns 42)
+    execSync(`javac -g -d "${testJavaDir}" "${mainFile}"`, {
+      cwd: testJavaDir,
+      stdio: 'pipe'
+    });
+
+    try {
+      // Start JVM with JDWP
+      const jdwpPort = await getFreePort();
+      console.log(`[Redefine #370] Using JDWP port: ${jdwpPort}`);
+
+      jvmProcess = spawn('java', [
+        `-agentlib:jdwp=transport=dt_socket,server=y,address=${jdwpPort},suspend=y`,
+        '-cp', testJavaDir,
+        'RedefineTarget'
+      ], {
+        cwd: testJavaDir,
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+
+      // Wait for JDWP ready
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Timeout waiting for JDWP agent')), 15000);
+        let outputData = '';
+        let resolved = false;
+
+        const checkOutput = (chunk: Buffer) => {
+          if (resolved) return;
+          outputData += chunk.toString();
+          if (outputData.includes('Listening for transport')) {
+            resolved = true;
+            clearTimeout(timeout);
+            resolve();
+          }
+        };
+
+        jvmProcess!.stdout!.on('data', checkOutput);
+        jvmProcess!.stderr!.on('data', checkOutput);
+        jvmProcess!.on('error', (err) => { if (!resolved) { clearTimeout(timeout); reject(err); } });
+        jvmProcess!.on('exit', (code) => { if (!resolved) { clearTimeout(timeout); reject(new Error(`JVM exited ${code}`)); } });
+      });
+
+      // 1. Create session
+      const createResult = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'create_debug_session',
+        arguments: { language: 'java', name: 'java-redefine-370' }
+      }));
+      expect(createResult.sessionId).toBeDefined();
+      sessionId = createResult.sessionId as string;
+
+      // 2. Set breakpoints on line 19 (first getValue() call) AND line 22
+      //    (second getValue() call). Line 22 is the one that must survive
+      //    the hot-swap.
+      const bp1 = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'set_breakpoint',
+        arguments: { sessionId, file: mainFile, line: 19 }
+      }));
+      expect(bp1.success).toBe(true);
+      const bp2 = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'set_breakpoint',
+        arguments: { sessionId, file: mainFile, line: 22 }
+      }));
+      expect(bp2.success).toBe(true);
+
+      // 3. Attach and continue past initial suspend
+      const attachResult = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'attach_to_process',
+        arguments: { sessionId, port: jdwpPort, host: '127.0.0.1', sourcePaths: [testJavaDir] }
+      }));
+      expect(attachResult.success).toBe(true);
+
+      const cont1 = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'continue_execution',
+        arguments: { sessionId }
+      }));
+      expect(cont1.success).toBe(true);
+
+      // 4. Wait for the first breakpoint at line 19
+      const stack1 = await waitForPausedState(mcpClient!, sessionId, 30, 500,
+        (frames) => frames[0]?.line === 19
+      );
+      expect(stack1).not.toBeNull();
+      console.log('[Redefine #370] Hit first breakpoint at line 19');
+
+      // 5. Recompile with a SAME-LINE-LAYOUT modification (only the constant
+      //    in getValue() changes) so all breakpoint lines stay meaningful.
+      const originalContent = fs.readFileSync(mainFile, 'utf-8');
+      expect(originalContent).toContain('return 42;');
+      fs.writeFileSync(mainFile, originalContent.replace('return 42;', 'return 99;'));
+      try {
+        execSync(`javac -g -d "${testJavaDir}" "${mainFile}"`, {
+          cwd: testJavaDir,
+          stdio: 'pipe'
+        });
+        console.log('[Redefine #370] Recompiled with getValue()=99 (same line layout)');
+      } finally {
+        fs.writeFileSync(mainFile, originalContent);
+      }
+
+      // 6. Hot-swap while paused at line 19
+      const redefineResult = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'redefine_classes',
+        arguments: { sessionId, classesDir: testJavaDir, sinceTimestamp: 0 }
+      }));
+      console.log('[Redefine #370] Result:', JSON.stringify(redefineResult));
+      expect(redefineResult.success).toBe(true);
+      expect(redefineResult.redefinedCount).toBeGreaterThanOrEqual(1);
+      // Issue #370: the response reports how many breakpoints were re-planted
+      // after JDI cancelled them during redefinition.
+      expect(redefineResult.replantedBreakpoints).toBeGreaterThanOrEqual(2);
+
+      // Confirm the hot-swap took effect
+      const evalRes = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'evaluate_expression',
+        arguments: { sessionId, expression: 'getValue()' }
+      }));
+      expect(evalRes.success).toBe(true);
+      expect(evalRes.result).toBe('99');
+
+      // 7. Continue — the PRE-EXISTING breakpoint on line 22 must still fire.
+      //    Before the fix, vm.redefineClasses silently cancelled it and the
+      //    program ran to completion.
+      const cont2 = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'continue_execution',
+        arguments: { sessionId }
+      }));
+      expect(cont2.success).toBe(true);
+
+      const stack2 = await waitForPausedState(mcpClient!, sessionId, 30, 500,
+        (frames) => frames[0]?.line === 22
+      );
+      expect(stack2).not.toBeNull();
+      expect(stack2!.stackFrames![0].line).toBe(22);
+      console.log('[Redefine #370] Pre-existing breakpoint at line 22 fired after hot-swap');
+
+      // 8. Continue to finish
+      const cont3 = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'continue_execution',
+        arguments: { sessionId }
+      }));
+      expect(cont3.success).toBe(true);
+
+      console.log('[Redefine #370] TEST PASSED — breakpoints survived redefine_classes');
+
+    } finally {
+      // Cleanup compiled classes
+      for (const cls of ['RedefineTarget.class']) {
+        try {
+          const f = path.resolve(testJavaDir, cls);
+          if (fs.existsSync(f)) fs.unlinkSync(f);
+        } catch { /* ignore */ }
+      }
+
+      if (jvmProcess && !jvmProcess.killed) {
+        jvmProcess.kill('SIGKILL');
+        jvmProcess = null;
+      }
+    }
+  }, 90000);
 });

--- a/tests/e2e/mcp-server-smoke-java.test.ts
+++ b/tests/e2e/mcp-server-smoke-java.test.ts
@@ -453,4 +453,69 @@ describe('MCP Server Java Debugging Smoke Test @requires-java', () => {
 
     console.log('[Conditional BP] TEST PASSED — conditional breakpoint worked');
   }, 60000);
+
+  it('surfaces debuggee exitCode 0 after run to completion (issue #368)', async () => {
+    // Check for java and javac
+    try {
+      execSync('java -version', { stdio: 'ignore' });
+      execSync('javac -version', { stdio: 'ignore' });
+    } catch {
+      console.log('[Java ExitCode Test] Skipping — JDK not installed');
+      return;
+    }
+
+    const { sourcePath: testJavaFile, classDir: testClassDir, mainClass } = prepareJavaExample('HelloWorld');
+
+    // 1. Create session
+    const createResponse = parseSdkToolResult(await mcpClient!.callTool({
+      name: 'create_debug_session',
+      arguments: { language: 'java', name: 'java-exit-code-test' }
+    }));
+    expect(createResponse.sessionId).toBeDefined();
+    sessionId = createResponse.sessionId as string;
+
+    // 2. Start debugging with no breakpoints — program runs straight to completion
+    const startResponse = parseSdkToolResult(await mcpClient!.callTool({
+      name: 'start_debugging',
+      arguments: {
+        sessionId,
+        scriptPath: testJavaFile,
+        args: [],
+        dapLaunchArgs: {
+          mainClass,
+          classpath: testClassDir,
+          cwd: testClassDir,
+          stopOnEntry: false
+        }
+      }
+    }));
+    expect(startResponse.success).toBe(true);
+
+    // 3. Poll list_debug_sessions until the session reaches a terminal state.
+    //    'error' is terminal too, so a regression fails fast instead of timing out.
+    interface SessionSnapshot { id: string; state?: string; exitCode?: number }
+    let terminal: SessionSnapshot | undefined;
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      const listResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'list_debug_sessions',
+        arguments: {}
+      }));
+      const sessions = (listResponse.sessions ?? []) as SessionSnapshot[];
+      const snap = sessions.find(s => s.id === sessionId);
+      if (snap && (snap.state === 'stopped' || snap.state === 'error')) {
+        terminal = snap;
+        break;
+      }
+      await new Promise(r => setTimeout(r, 250));
+    }
+
+    // HARD ASSERTIONS: clean run ends 'stopped' with the debuggee's real
+    // exit code surfaced (issue #368: the JDI bridge previously never sent a
+    // DAP 'exited' event, so exitCode stayed undefined).
+    expect(terminal).toBeDefined();
+    expect(terminal!.state).toBe('stopped');
+    expect(terminal!.exitCode).toBe(0);
+    console.log('[Java ExitCode Test] TEST PASSED — exitCode 0 surfaced');
+  }, 60000);
 });


### PR DESCRIPTION
## Summary
All three fixes live in the JDI bridge (`JdiDapServer.java`); one additive TS change plumbs the new `replantedBreakpoints` response field.

### #352 — attach `pause_execution` doesn't actually suspend usefully
- New `pickReportableThread()`: prefers "main" (when it can report frames), else the first suspended thread with frames, else `allThreads().get(0)`. Used by `handlePause` and `handleConfigurationDone`'s entry stop.
- `handleStackTrace` retries once against a reportable thread on `IncompatibleThreadStateException`; if still frameless, stays `success:true` with an explanatory `message` instead of a silent empty stack.
- `handleThreads` lists the reportable thread first — necessary because the TS pause/stack paths auto-discover `threads[0].id`, and raw `allThreads()` order starts with JVM system threads like "Reference Handler" that report no user frames (without this the fix never engages through MCP).

### #368 — terminated Java sessions had no `exitCode`
A daemon watcher thread stores `launchedProcess.waitFor()`; VMDeath/VMDisconnect (and event-loop error paths) wait ≤2s for the code and send a DAP `exited {exitCode}` exactly once before `terminated`. Launch mode only — attach has no process to report, and a still-alive process (detach) sends nothing; codes are never fabricated. The existing TS pipeline (proxy → `session.exitCode` → `list_debug_sessions`) needed no changes.

### #370 — `redefine_classes` silently drops breakpoints
Per the JDI spec, `vm.redefineClasses` cancels every BreakpointRequest in the redefined classes. After each successful redefine the bridge now deletes stale line/function requests for the type and re-runs the deferred-breakpoint machinery (`handleClassPrepared` + `handleClassPreparedForFunctionBreakpoints`) to plant fresh requests against the new bytecode. The response gains `replantedBreakpoints`. Obsolete-bytecode lines re-verify `false` — the honest surface.

## Testing
- 4 new/extended e2e tests: java run-to-completion asserts `exitCode: 0`; pause on a running launch reaches `PauseTest.main`; attach (`suspend=n`, `stopOnEntry:false`) → pause → user frames; redefine hot-swap with a same-line-layout V2 asserts the pre-existing breakpoint fires post-redefine (`replantedBreakpoints >= 2`, `getValue() == 99`)
- Full Java surface green: 171/171 (target e2e + java unit), remaining java e2e 7/7, break-on-exceptions 18/18, session unit 136/136
- Bridge explicitly recompiled; `npm run build` + `npm run lint` clean

Fixes #352
Fixes #368
Fixes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)