### PR TITLE
fix(#355,#353,#357,#363): mock stop reason, .NET attach pause, ruby live-sync hint, Docker sourceMap derivation

### DIFF
--- a/docs/cpp/README.md
+++ b/docs/cpp/README.md
@@ -94,6 +94,23 @@ Data breakpoints (hardware watchpoints), disassembly view, instruction stepping,
 - The launch default `"uncaught"` sets **no filter**: LLDB has no uncaught-only C++ filter, and an uncaught exception reaches `std::terminate` → SIGABRT, which the debugger stops on natively — you still land at the crash with stack and locals.
 - `cpp_catch` (break on catch) is available via explicit filter configuration.
 
+## Debugging host-built binaries in Docker
+
+A binary compiled on the host embeds host-absolute source paths (e.g. `/home/you/proj/src/main.cpp`) in its DWARF debug info. When the mcp-debugger container mounts the project at `/workspace`, breakpoint requests use `/workspace/...` paths and CodeLLDB cannot match them against the DWARF paths — file+line breakpoints and logpoints silently never bind (function breakpoints and pause still work; issue #363).
+
+In container mode (`MCP_CONTAINER=true`) the adapter auto-derives a best-effort `sourceMap` for prebuilt binaries by scanning the binary for embedded host paths whose suffixes exist under the workspace mount (`MCP_WORKSPACE_ROOT`, default `/workspace`), so this usually just works. If auto-derivation misses (unusual layouts, stripped path strings), pass the mapping explicitly — a caller-supplied `sourceMap` always wins:
+
+```json
+{
+  "scriptPath": "/workspace/build/app",
+  "dapLaunchArgs": {
+    "sourceMap": { "/home/you/proj": "/workspace" }
+  }
+}
+```
+
+Alternatively, compile inside the container (or with `-fdebug-prefix-map=/home/you/proj=/workspace`) so the DWARF paths match the mount directly.
+
 ## Troubleshooting
 
 - **"CodeLLDB executable not found"** — run `pnpm --filter @debugmcp/codelldb-common run build:adapter`, or set `CODELLDB_PATH`.

--- a/docs/cpp/README.md
+++ b/docs/cpp/README.md
@@ -96,7 +96,7 @@ Data breakpoints (hardware watchpoints), disassembly view, instruction stepping,
 
 ## Debugging host-built binaries in Docker
 
-A binary compiled on the host embeds host-absolute source paths (e.g. `/home/you/proj/src/main.cpp`) in its DWARF debug info. When the mcp-debugger container mounts the project at `/workspace`, breakpoint requests use `/workspace/...` paths and CodeLLDB cannot match them against the DWARF paths — file+line breakpoints and logpoints silently never bind (function breakpoints and pause still work; issue #363).
+A binary compiled on the host embeds host-absolute source paths (e.g. `/home/user/proj/src/main.cpp`) in its DWARF debug info. When the mcp-debugger container mounts the project at `/workspace`, breakpoint requests use `/workspace/...` paths and CodeLLDB cannot match them against the DWARF paths — file+line breakpoints and logpoints silently never bind (function breakpoints and pause still work; issue #363).
 
 In container mode (`MCP_CONTAINER=true`) the adapter auto-derives a best-effort `sourceMap` for prebuilt binaries by scanning the binary for embedded host paths whose suffixes exist under the workspace mount (`MCP_WORKSPACE_ROOT`, default `/workspace`), so this usually just works. If auto-derivation misses (unusual layouts, stripped path strings), pass the mapping explicitly — a caller-supplied `sourceMap` always wins:
 
@@ -104,12 +104,12 @@ In container mode (`MCP_CONTAINER=true`) the adapter auto-derives a best-effort 
 {
   "scriptPath": "/workspace/build/app",
   "dapLaunchArgs": {
-    "sourceMap": { "/home/you/proj": "/workspace" }
+    "sourceMap": { "/home/user/proj": "/workspace" }
   }
 }
 ```
 
-Alternatively, compile inside the container (or with `-fdebug-prefix-map=/home/you/proj=/workspace`) so the DWARF paths match the mount directly.
+Alternatively, compile inside the container (or with `-fdebug-prefix-map=/home/user/proj=/workspace`) so the DWARF paths match the mount directly.
 
 ## Troubleshooting
 

--- a/docs/ruby/README.md
+++ b/docs/ruby/README.md
@@ -207,7 +207,7 @@ target with `<path> is not available`. That warning is topology, not breakage:
     "sessionId": "...",
     "host": "127.0.0.1",
     "port": 12345,
-    "localfsMap": "/app:/home/you/project"
+    "localfsMap": "/app:/home/user/project"
   }
   ```
 

--- a/docs/ruby/README.md
+++ b/docs/ruby/README.md
@@ -187,6 +187,35 @@ Breakpoints, conditional breakpoints, locals, and expression evaluation all work
 the pod exactly as they do locally. For a pod on a real cluster, the only difference is
 where `kubectl port-forward` points.
 
+### Attaching across a container boundary
+
+Attach sessions send breakpoint paths to the remote rdbg **verbatim** — rdbg checks them
+against the debug **target's** filesystem, not yours. When the debugger and the debuggee
+see the project at different paths (host mcp-debugger + containerized app, or a
+containerized mcp-debugger + host app), a path that is valid on your side can fail on the
+target with `<path> is not available`. That warning is topology, not breakage:
+
+- **Prefer target-side paths.** Set breakpoints using the path the debuggee sees
+  (`/app/app.rb` inside the container, as reported by `get_stack_trace`), not the path on
+  your machine.
+- **Or map paths with `localfsMap`.** rdbg accepts a `localfsMap` attach option
+  (`"remote_prefix:local_prefix"`, comma-separated for multiple pairs) that translates
+  paths between the two filesystems. Pass it through `attach_to_process`:
+
+  ```text
+  attach_to_process {
+    "sessionId": "...",
+    "host": "127.0.0.1",
+    "port": 12345,
+    "localfsMap": "/app:/home/you/project"
+  }
+  ```
+
+- **Reaching a host-side rdbg from a containerized mcp-debugger:** use
+  `host.docker.internal` as the attach host (add
+  `--add-host=host.docker.internal:host-gateway` on Linux Docker), and remember the
+  target-side rule still applies — the host rdbg needs host paths.
+
 ## Troubleshooting
 
 | Symptom | Likely cause / fix |

--- a/docs/rust-debugging.md
+++ b/docs/rust-debugging.md
@@ -293,7 +293,7 @@ Response will show Rust types clearly:
 
 ## Debugging host-built binaries in Docker
 
-A binary built by `cargo build` on the host embeds host-absolute source paths (e.g. `/home/you/proj/src/main.rs`) in its DWARF debug info. When the mcp-debugger container mounts the project at `/workspace`, breakpoint requests use `/workspace/...` paths and CodeLLDB cannot match them — file+line breakpoints silently never bind (function breakpoints and pause still work; issue #363).
+A binary built by `cargo build` on the host embeds host-absolute source paths (e.g. `/home/user/proj/src/main.rs`) in its DWARF debug info. When the mcp-debugger container mounts the project at `/workspace`, breakpoint requests use `/workspace/...` paths and CodeLLDB cannot match them — file+line breakpoints silently never bind (function breakpoints and pause still work; issue #363).
 
 In container mode (`MCP_CONTAINER=true`) the adapter auto-derives a best-effort `sourceMap` for prebuilt binaries by scanning the binary for embedded host paths whose suffixes exist under the workspace mount (`MCP_WORKSPACE_ROOT`, default `/workspace`). If derivation misses, pass the mapping explicitly — a caller-supplied `sourceMap` always wins:
 
@@ -301,12 +301,12 @@ In container mode (`MCP_CONTAINER=true`) the adapter auto-derives a best-effort 
 {
   "scriptPath": "/workspace/target/debug/myapp",
   "dapLaunchArgs": {
-    "sourceMap": { "/home/you/proj": "/workspace" }
+    "sourceMap": { "/home/user/proj": "/workspace" }
   }
 }
 ```
 
-Alternatively, build inside the container (or with `RUSTFLAGS="--remap-path-prefix=/home/you/proj=/workspace"`) so the DWARF paths match the mount directly.
+Alternatively, build inside the container (or with `RUSTFLAGS="--remap-path-prefix=/home/user/proj=/workspace"`) so the DWARF paths match the mount directly.
 
 ## Troubleshooting
 

--- a/docs/rust-debugging.md
+++ b/docs/rust-debugging.md
@@ -291,6 +291,23 @@ Response will show Rust types clearly:
 }
 ```
 
+## Debugging host-built binaries in Docker
+
+A binary built by `cargo build` on the host embeds host-absolute source paths (e.g. `/home/you/proj/src/main.rs`) in its DWARF debug info. When the mcp-debugger container mounts the project at `/workspace`, breakpoint requests use `/workspace/...` paths and CodeLLDB cannot match them — file+line breakpoints silently never bind (function breakpoints and pause still work; issue #363).
+
+In container mode (`MCP_CONTAINER=true`) the adapter auto-derives a best-effort `sourceMap` for prebuilt binaries by scanning the binary for embedded host paths whose suffixes exist under the workspace mount (`MCP_WORKSPACE_ROOT`, default `/workspace`). If derivation misses, pass the mapping explicitly — a caller-supplied `sourceMap` always wins:
+
+```json
+{
+  "scriptPath": "/workspace/target/debug/myapp",
+  "dapLaunchArgs": {
+    "sourceMap": { "/home/you/proj": "/workspace" }
+  }
+}
+```
+
+Alternatively, build inside the container (or with `RUSTFLAGS="--remap-path-prefix=/home/you/proj=/workspace"`) so the DWARF paths match the mount directly.
+
 ## Troubleshooting
 
 ### Breakpoints Not Hit

--- a/packages/adapter-cpp/src/cpp-debug-adapter.ts
+++ b/packages/adapter-cpp/src/cpp-debug-adapter.ts
@@ -50,6 +50,7 @@ import {
   buildCodeLLDBArgs,
   configurePythonEnvironment,
   resolveTerminalKind,
+  deriveSourceMapFromBinary,
   BinaryInfo
 } from '@debugmcp/codelldb-common';
 import {
@@ -539,6 +540,11 @@ export class CppDebugAdapter extends EventEmitter implements IDebugAdapter {
       postRunCommands: postRunCommands || []
     };
 
+    // Tracks whether the binary was compiled during this launch — a binary
+    // built inside the container already has container paths in its DWARF,
+    // so sourceMap derivation (issue #363) is unnecessary.
+    let compiledAtLaunch = false;
+
     if (program) {
       const programPath = String(program);
 
@@ -558,6 +564,7 @@ export class CppDebugAdapter extends EventEmitter implements IDebugAdapter {
             throw new Error(`C/C++ compile failed: ${result.error}`);
           }
           launchConfig.program = result.binaryPath!;
+          compiledAtLaunch = true;
         } else {
           this.dependencies.logger?.info('[CppDebugAdapter] Using existing binary (up to date)');
           launchConfig.program = outputPath;
@@ -575,6 +582,27 @@ export class CppDebugAdapter extends EventEmitter implements IDebugAdapter {
 
     if (typeof launchConfig.program === 'string' && launchConfig.program.length > 0) {
       await this.evaluateToolchain(launchConfig.program);
+    }
+
+    // Container mode (issue #363): a host-built binary embeds host-absolute
+    // DWARF paths, so /workspace breakpoint requests never match. Best-effort:
+    // derive a hostPrefix -> workspaceRoot sourceMap from the binary's
+    // embedded path strings. Caller-supplied sourceMap entries always win.
+    if (
+      process.env.MCP_CONTAINER === 'true' &&
+      !compiledAtLaunch &&
+      Object.keys(sourceMap || {}).length === 0 &&
+      typeof launchConfig.program === 'string' &&
+      launchConfig.program.length > 0
+    ) {
+      const workspaceRoot = process.env.MCP_WORKSPACE_ROOT || '/workspace';
+      const derived = deriveSourceMapFromBinary(launchConfig.program, workspaceRoot);
+      if (Object.keys(derived).length > 0) {
+        launchConfig.sourceMap = derived;
+        this.dependencies.logger?.info(
+          `[CppDebugAdapter] Container mode: derived sourceMap from binary DWARF paths: ${JSON.stringify(derived)}`
+        );
+      }
     }
 
     return launchConfig;

--- a/packages/adapter-cpp/tests/cpp-adapter.test.ts
+++ b/packages/adapter-cpp/tests/cpp-adapter.test.ts
@@ -268,7 +268,7 @@ describe('CppDebugAdapter', () => {
       it('injects a derived sourceMap for a prebuilt binary in container mode', async () => {
         vi.stubEnv('MCP_CONTAINER', 'true');
         vi.mocked(deriveSourceMapFromBinary).mockReturnValue({
-          '/home/host/proj': '/workspace'
+          '/home/user/proj': '/workspace'
         });
         try {
           const result = await adapter.transformLaunchConfig({
@@ -280,7 +280,7 @@ describe('CppDebugAdapter', () => {
             path.resolve('/work', 'build/app'),
             '/workspace'
           );
-          expect(result.sourceMap).toEqual({ '/home/host/proj': '/workspace' });
+          expect(result.sourceMap).toEqual({ '/home/user/proj': '/workspace' });
         } finally {
           vi.unstubAllEnvs();
         }

--- a/packages/adapter-cpp/tests/cpp-adapter.test.ts
+++ b/packages/adapter-cpp/tests/cpp-adapter.test.ts
@@ -15,7 +15,8 @@ vi.mock('@debugmcp/codelldb-common', async (importOriginal) => ({
   resolveCodeLLDBExecutable: vi.fn(),
   resolveCodeLLDBExecutableSyncImpl: vi.fn(),
   getCodeLLDBVersion: vi.fn(),
-  detectBinaryFormat: vi.fn()
+  detectBinaryFormat: vi.fn(),
+  deriveSourceMapFromBinary: vi.fn()
 }));
 
 vi.mock('../src/utils/compile-utils.js', async (importOriginal) => ({
@@ -30,7 +31,8 @@ import {
   resolveCodeLLDBExecutable,
   resolveCodeLLDBExecutableSyncImpl,
   getCodeLLDBVersion,
-  detectBinaryFormat
+  detectBinaryFormat,
+  deriveSourceMapFromBinary
 } from '@debugmcp/codelldb-common';
 import {
   findCompiler,
@@ -78,6 +80,7 @@ describe('CppDebugAdapter', () => {
     vi.mocked(findAnyCompiler).mockReset();
     vi.mocked(needsRecompile).mockReset();
     vi.mocked(compileSourceFile).mockReset();
+    vi.mocked(deriveSourceMapFromBinary).mockReset().mockReturnValue({});
     dependencies = createDependencies();
     adapter = new CppDebugAdapter(dependencies);
   });
@@ -258,6 +261,100 @@ describe('CppDebugAdapter', () => {
     it('throws SCRIPT_NOT_FOUND when no program is given', async () => {
       await expect(adapter.transformLaunchConfig({} as never)).rejects.toMatchObject({
         code: 'SCRIPT_NOT_FOUND'
+      });
+    });
+
+    describe('container sourceMap derivation (#363)', () => {
+      it('injects a derived sourceMap for a prebuilt binary in container mode', async () => {
+        vi.stubEnv('MCP_CONTAINER', 'true');
+        vi.mocked(deriveSourceMapFromBinary).mockReturnValue({
+          '/home/host/proj': '/workspace'
+        });
+        try {
+          const result = await adapter.transformLaunchConfig({
+            program: 'build/app',
+            cwd: '/work'
+          } as never);
+
+          expect(deriveSourceMapFromBinary).toHaveBeenCalledWith(
+            path.resolve('/work', 'build/app'),
+            '/workspace'
+          );
+          expect(result.sourceMap).toEqual({ '/home/host/proj': '/workspace' });
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      });
+
+      it('respects MCP_WORKSPACE_ROOT for derivation', async () => {
+        vi.stubEnv('MCP_CONTAINER', 'true');
+        vi.stubEnv('MCP_WORKSPACE_ROOT', '/mnt/project');
+        try {
+          await adapter.transformLaunchConfig({ program: 'build/app', cwd: '/work' } as never);
+
+          expect(deriveSourceMapFromBinary).toHaveBeenCalledWith(
+            path.resolve('/work', 'build/app'),
+            '/mnt/project'
+          );
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      });
+
+      it('skips derivation when the caller supplies sourceMap entries', async () => {
+        vi.stubEnv('MCP_CONTAINER', 'true');
+        try {
+          const result = await adapter.transformLaunchConfig({
+            program: 'build/app',
+            cwd: '/work',
+            sourceMap: { '/custom': '/workspace' }
+          } as never);
+
+          expect(deriveSourceMapFromBinary).not.toHaveBeenCalled();
+          expect(result.sourceMap).toEqual({ '/custom': '/workspace' });
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      });
+
+      it('skips derivation outside container mode', async () => {
+        const result = await adapter.transformLaunchConfig({
+          program: 'build/app',
+          cwd: '/work'
+        } as never);
+
+        expect(deriveSourceMapFromBinary).not.toHaveBeenCalled();
+        expect(result.sourceMap).toEqual({});
+      });
+
+      it('skips derivation when the binary was compiled at launch', async () => {
+        vi.stubEnv('MCP_CONTAINER', 'true');
+        const src = path.resolve('/work/hello.cpp');
+        const out = getDefaultOutputPath(src, process.platform);
+        vi.mocked(needsRecompile).mockResolvedValue(true);
+        vi.mocked(compileSourceFile).mockResolvedValue({ success: true, binaryPath: out });
+        try {
+          await adapter.transformLaunchConfig({ program: src } as never);
+
+          expect(deriveSourceMapFromBinary).not.toHaveBeenCalled();
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      });
+
+      it('leaves sourceMap empty when derivation finds nothing', async () => {
+        vi.stubEnv('MCP_CONTAINER', 'true');
+        vi.mocked(deriveSourceMapFromBinary).mockReturnValue({});
+        try {
+          const result = await adapter.transformLaunchConfig({
+            program: 'build/app',
+            cwd: '/work'
+          } as never);
+
+          expect(result.sourceMap).toEqual({});
+        } finally {
+          vi.unstubAllEnvs();
+        }
       });
     });
   });

--- a/packages/adapter-mock/src/mock-adapter-process.ts
+++ b/packages/adapter-mock/src/mock-adapter-process.ts
@@ -413,15 +413,38 @@ class MockDebugAdapterProcess {
   }
 
   /**
+   * Emit a stopped event for a hit breakpoint. Function breakpoints report
+   * reason 'function breakpoint' (issue #355); plain line breakpoints keep
+   * 'breakpoint'. Both carry hitBreakpointIds when the record has an id.
+   */
+  private sendBreakpointStopped(bp: DebugProtocol.Breakpoint & { isFunctionBreakpoint?: boolean }): void {
+    this.sendEvent({
+      seq: 0,
+      type: 'event',
+      event: 'stopped',
+      body: {
+        reason: bp.isFunctionBreakpoint ? 'function breakpoint' : 'breakpoint',
+        threadId: 1,
+        allThreadsStopped: true,
+        ...(bp.id !== undefined ? { hitBreakpointIds: [bp.id] } : {})
+      }
+    } as DebugProtocol.StoppedEvent);
+  }
+
+  /**
    * Walk the sorted breakpoint list from a line: logpoint lines emit an
    * output event (naive {expr} interpolation) and do NOT stop; the first
    * plain breakpoint after the line is the next stop (issue #235).
    */
-  private findNextStop(fromLine: number): (DebugProtocol.Breakpoint & { logMessage?: string }) | undefined {
-    const allBreakpoints = Array.from(this.breakpoints.values())
-      .flat()
+  private findNextStop(fromLine: number): (DebugProtocol.Breakpoint & { logMessage?: string; isFunctionBreakpoint?: boolean }) | undefined {
+    const allBreakpoints = (Array.from(this.breakpoints.values())
+      .flat() as (DebugProtocol.Breakpoint & { logMessage?: string; isFunctionBreakpoint?: boolean })[])
       .filter(bp => bp.line !== undefined)
-      .sort((a, b) => (a.line || 0) - (b.line || 0));
+      // Sort by line; when a line breakpoint and a function breakpoint share a
+      // line, the plain line breakpoint wins the tiebreak (issue #355)
+      .sort((a, b) =>
+        ((a.line || 0) - (b.line || 0)) ||
+        ((a.isFunctionBreakpoint ? 1 : 0) - (b.isFunctionBreakpoint ? 1 : 0)));
 
     for (const bp of allBreakpoints) {
       if ((bp.line || 0) <= fromLine) continue;
@@ -480,16 +503,7 @@ class MockDebugAdapterProcess {
         if (firstStop) {
           this.currentLine = firstStop.line || 1;
           this.log(`Hit first breakpoint at line ${this.currentLine}`);
-          this.sendEvent({
-            seq: 0,
-            type: 'event',
-            event: 'stopped',
-            body: {
-              reason: 'breakpoint',
-              threadId: 1,
-              allThreadsStopped: true
-            }
-          } as DebugProtocol.StoppedEvent);
+          this.sendBreakpointStopped(firstStop);
         } else if (this.shouldSimulateException()) {
           this.sendExceptionStopped();
         } else {
@@ -603,8 +617,11 @@ class MockDebugAdapterProcess {
           id: Math.floor(Math.random() * 100000),
           verified: true,
           line,
-          source: { path: this.programPath || 'mock://program' }
-        });
+          source: { path: this.programPath || 'mock://program' },
+          // Marker so the run simulation can report 'function breakpoint'
+          // as the stop reason (issue #355)
+          isFunctionBreakpoint: true
+        } as DebugProtocol.Breakpoint & { isFunctionBreakpoint: boolean });
       } else {
         breakpoints.push({
           id: Math.floor(Math.random() * 100000),
@@ -777,16 +794,7 @@ class MockDebugAdapterProcess {
         // Hit the next breakpoint
         this.currentLine = nextBreakpoint.line;
         this.log(`Stopping at breakpoint on line ${this.currentLine}`);
-        this.sendEvent({
-          seq: 0,
-          type: 'event',
-          event: 'stopped',
-          body: {
-            reason: 'breakpoint',
-            threadId: 1,
-            allThreadsStopped: true
-          }
-        } as DebugProtocol.StoppedEvent);
+        this.sendBreakpointStopped(nextBreakpoint);
       } else if (this.shouldSimulateException()) {
         // Crash before completion: uncaught exception past the last breakpoint
         this.sendExceptionStopped();

--- a/packages/adapter-mock/tests/mock-adapter-process.test.ts
+++ b/packages/adapter-mock/tests/mock-adapter-process.test.ts
@@ -1,0 +1,246 @@
+/**
+ * DAP-level tests for the mock adapter process (issue #355): function
+ * breakpoints must stop with reason 'function breakpoint' and carry
+ * hitBreakpointIds; line breakpoints keep reason 'breakpoint' (and also
+ * carry hitBreakpointIds). When a line breakpoint and a function breakpoint
+ * bind to the same line, the plain line breakpoint wins the tiebreak.
+ *
+ * The tests spawn the compiled adapter process in TCP mode and speak DAP
+ * over the socket (building the package first if dist is missing).
+ */
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { spawn, execSync, ChildProcess } from 'child_process';
+import net from 'net';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import type { DebugProtocol } from '@vscode/debugprotocol';
+
+const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PROCESS_JS = path.join(PKG_ROOT, 'dist', 'mock-adapter-process.js');
+
+class DapTestClient {
+  private socket!: net.Socket;
+  private buffer = Buffer.alloc(0);
+  private seq = 1;
+  private pending = new Map<number, (r: DebugProtocol.Response) => void>();
+  readonly events: DebugProtocol.Event[] = [];
+  private eventWaiters: Array<{
+    match: (e: DebugProtocol.Event) => boolean;
+    resolve: (e: DebugProtocol.Event) => void;
+  }> = [];
+
+  async connect(port: number): Promise<void> {
+    // The process needs a moment to open its TCP listener
+    const deadline = Date.now() + 10_000;
+    for (;;) {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const s = net.connect(port, '127.0.0.1');
+          s.once('connect', () => {
+            this.socket = s;
+            resolve();
+          });
+          s.once('error', reject);
+        });
+        break;
+      } catch (err) {
+        if (Date.now() > deadline) throw err;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+    }
+    this.socket.on('data', (chunk) => this.onData(chunk));
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    for (;;) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n');
+      if (headerEnd === -1) break;
+      const header = this.buffer.subarray(0, headerEnd).toString('utf8');
+      const m = header.match(/Content-Length: (\d+)/);
+      if (!m) {
+        this.buffer = this.buffer.subarray(headerEnd + 4);
+        continue;
+      }
+      const len = parseInt(m[1], 10);
+      if (this.buffer.length < headerEnd + 4 + len) break;
+      const body = this.buffer.subarray(headerEnd + 4, headerEnd + 4 + len).toString('utf8');
+      this.buffer = this.buffer.subarray(headerEnd + 4 + len);
+      const msg = JSON.parse(body) as DebugProtocol.ProtocolMessage;
+      if (msg.type === 'response') {
+        const resp = msg as DebugProtocol.Response;
+        const resolve = this.pending.get(resp.request_seq);
+        if (resolve) {
+          this.pending.delete(resp.request_seq);
+          resolve(resp);
+        }
+      } else if (msg.type === 'event') {
+        const event = msg as DebugProtocol.Event;
+        this.events.push(event);
+        this.eventWaiters = this.eventWaiters.filter((w) => {
+          if (w.match(event)) {
+            w.resolve(event);
+            return false;
+          }
+          return true;
+        });
+      }
+    }
+  }
+
+  request<T extends DebugProtocol.Response>(command: string, args?: unknown): Promise<T> {
+    const seq = this.seq++;
+    const json = JSON.stringify({ seq, type: 'request', command, arguments: args });
+    this.socket.write(`Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`);
+    return new Promise((resolve) => {
+      this.pending.set(seq, resolve as (r: DebugProtocol.Response) => void);
+    });
+  }
+
+  waitForEvent(name: string, timeoutMs = 5000): Promise<DebugProtocol.Event> {
+    const existing = this.events.find((e) => e.event === name);
+    if (existing) return Promise.resolve(existing);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`Timed out waiting for '${name}' event`)),
+        timeoutMs
+      );
+      this.eventWaiters.push({
+        match: (e) => e.event === name,
+        resolve: (e) => {
+          clearTimeout(timer);
+          resolve(e);
+        },
+      });
+    });
+  }
+
+  close(): void {
+    this.socket?.destroy();
+  }
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+describe('mock-adapter-process stopped events (issue #355)', () => {
+  let child: ChildProcess | undefined;
+  let client: DapTestClient | undefined;
+
+  beforeAll(() => {
+    if (!fs.existsSync(PROCESS_JS)) {
+      execSync('npx tsc -b', { cwd: PKG_ROOT, stdio: 'inherit' });
+    }
+  }, 120_000);
+
+  afterEach(() => {
+    client?.close();
+    client = undefined;
+    if (child && !child.killed) child.kill('SIGKILL');
+    child = undefined;
+  });
+
+  async function startSession(): Promise<DapTestClient> {
+    const port = await getFreePort();
+    child = spawn(process.execPath, [PROCESS_JS, '--port', String(port)], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    client = new DapTestClient();
+    await client.connect(port);
+    await client.request('initialize', { adapterID: 'mock' });
+    return client;
+  }
+
+  it("stops with reason 'function breakpoint' and hitBreakpointIds when a function breakpoint is hit", async () => {
+    const c = await startSession();
+
+    const fbResp = await c.request<DebugProtocol.SetFunctionBreakpointsResponse>(
+      'setFunctionBreakpoints',
+      { breakpoints: [{ name: 'compute' }] }
+    );
+    expect(fbResp.success).toBe(true);
+    const fnBp = fbResp.body.breakpoints[0];
+    expect(fnBp.verified).toBe(true);
+    expect(fnBp.line).toBe(10);
+
+    await c.request('launch', { program: '/tmp/mock-program.py', stopOnEntry: false });
+
+    const stopped = (await c.waitForEvent('stopped')) as DebugProtocol.StoppedEvent;
+    expect(stopped.body.reason).toBe('function breakpoint');
+    expect(stopped.body.hitBreakpointIds).toEqual([fnBp.id]);
+  }, 15_000);
+
+  it("keeps reason 'breakpoint' (with hitBreakpointIds) for plain line breakpoints", async () => {
+    const c = await startSession();
+
+    const bpResp = await c.request<DebugProtocol.SetBreakpointsResponse>('setBreakpoints', {
+      source: { path: '/tmp/mock-program.py' },
+      breakpoints: [{ line: 7 }],
+    });
+    expect(bpResp.success).toBe(true);
+    const lineBp = bpResp.body.breakpoints[0];
+
+    await c.request('launch', { program: '/tmp/mock-program.py', stopOnEntry: false });
+
+    const stopped = (await c.waitForEvent('stopped')) as DebugProtocol.StoppedEvent;
+    expect(stopped.body.reason).toBe('breakpoint');
+    expect(stopped.body.hitBreakpointIds).toEqual([lineBp.id]);
+  }, 15_000);
+
+  it("prefers reason 'breakpoint' when a line and a function breakpoint share a line", async () => {
+    const c = await startSession();
+
+    // 'compute' binds to line 10 per the mock's function table; put a line
+    // breakpoint on the same line.
+    const bpResp = await c.request<DebugProtocol.SetBreakpointsResponse>('setBreakpoints', {
+      source: { path: '/tmp/mock-program.py' },
+      breakpoints: [{ line: 10 }],
+    });
+    const lineBp = bpResp.body.breakpoints[0];
+    await c.request('setFunctionBreakpoints', { breakpoints: [{ name: 'compute' }] });
+
+    await c.request('launch', { program: '/tmp/mock-program.py', stopOnEntry: false });
+
+    const stopped = (await c.waitForEvent('stopped')) as DebugProtocol.StoppedEvent;
+    expect(stopped.body.reason).toBe('breakpoint');
+    expect(stopped.body.hitBreakpointIds).toEqual([lineBp.id]);
+  }, 15_000);
+
+  it("reports 'function breakpoint' on the continue path too", async () => {
+    const c = await startSession();
+
+    const bpResp = await c.request<DebugProtocol.SetBreakpointsResponse>('setBreakpoints', {
+      source: { path: '/tmp/mock-program.py' },
+      breakpoints: [{ line: 3 }],
+    });
+    const lineBp = bpResp.body.breakpoints[0];
+    const fbResp = await c.request<DebugProtocol.SetFunctionBreakpointsResponse>(
+      'setFunctionBreakpoints',
+      { breakpoints: [{ name: 'compute' }] }
+    );
+    const fnBp = fbResp.body.breakpoints[0];
+
+    await c.request('launch', { program: '/tmp/mock-program.py', stopOnEntry: false });
+
+    // First stop: the line breakpoint at line 3.
+    const first = (await c.waitForEvent('stopped')) as DebugProtocol.StoppedEvent;
+    expect(first.body.reason).toBe('breakpoint');
+    expect(first.body.hitBreakpointIds).toEqual([lineBp.id]);
+
+    // Continue: next stop is the function breakpoint at line 10.
+    c.events.length = 0;
+    await c.request('continue', { threadId: 1 });
+    const second = (await c.waitForEvent('stopped')) as DebugProtocol.StoppedEvent;
+    expect(second.body.reason).toBe('function breakpoint');
+    expect(second.body.hitBreakpointIds).toEqual([fnBp.id]);
+  }, 15_000);
+});

--- a/packages/adapter-mock/tests/mock-adapter-process.test.ts
+++ b/packages/adapter-mock/tests/mock-adapter-process.test.ts
@@ -151,7 +151,9 @@ describe('mock-adapter-process stopped events (issue #355)', () => {
 
   async function startSession(): Promise<DapTestClient> {
     const port = await getFreePort();
-    child = spawn(process.execPath, [PROCESS_JS, '--port', String(port)], {
+    // Bind explicitly to 127.0.0.1: the process's default host 'localhost'
+    // can resolve to ::1 on CI runners while the client dials 127.0.0.1.
+    child = spawn(process.execPath, [PROCESS_JS, '--port', String(port), '--host', '127.0.0.1'], {
       stdio: ['ignore', 'ignore', 'ignore'],
     });
     client = new DapTestClient();

--- a/packages/adapter-rust/src/rust-debug-adapter.ts
+++ b/packages/adapter-rust/src/rust-debug-adapter.ts
@@ -48,7 +48,8 @@ import {
   resolveTerminalKind,
   prepareCodelldbExecutablePath,
   buildCodeLLDBArgs,
-  configurePythonEnvironment
+  configurePythonEnvironment,
+  deriveSourceMapFromBinary
 } from '@debugmcp/codelldb-common';
 
 export type MsvcBehavior = 'warn' | 'error' | 'continue';
@@ -681,6 +682,11 @@ export class RustDebugAdapter extends EventEmitter implements IDebugAdapter {
       postRunCommands: rustConfig.postRunCommands || []
     };
     
+    // Tracks whether the binary was (re)built during this launch — a binary
+    // built inside the container already has container paths in its DWARF,
+    // so sourceMap derivation (issue #363) is unnecessary.
+    let compiledAtLaunch = false;
+
     // Resolve program path - handle source file paths
     if (rustConfig.program) {
       const programPath = rustConfig.program;
@@ -721,8 +727,9 @@ export class RustDebugAdapter extends EventEmitter implements IDebugAdapter {
             if (!buildResult.success) {
               throw new Error(`Cargo build failed: ${buildResult.error}`);
             }
-            
+
             launchConfig.program = buildResult.binaryPath!;
+            compiledAtLaunch = true;
           } else {
             this.dependencies.logger?.info('[Rust Debugger] Using existing binary (up to date)');
             launchConfig.program = binaryPath;
@@ -780,10 +787,31 @@ export class RustDebugAdapter extends EventEmitter implements IDebugAdapter {
     if (typeof launchConfig.program === 'string' && launchConfig.program.length > 0) {
       await this.evaluateToolchain(launchConfig.program);
     }
-    
+
+    // Container mode (issue #363): a host-built binary embeds host-absolute
+    // DWARF paths, so /workspace breakpoint requests never match. Best-effort:
+    // derive a hostPrefix -> workspaceRoot sourceMap from the binary's
+    // embedded path strings. Caller-supplied sourceMap entries always win.
+    if (
+      process.env.MCP_CONTAINER === 'true' &&
+      !compiledAtLaunch &&
+      Object.keys(rustConfig.sourceMap || {}).length === 0 &&
+      typeof launchConfig.program === 'string' &&
+      launchConfig.program.length > 0
+    ) {
+      const workspaceRoot = process.env.MCP_WORKSPACE_ROOT || '/workspace';
+      const derived = deriveSourceMapFromBinary(launchConfig.program, workspaceRoot);
+      if (Object.keys(derived).length > 0) {
+        launchConfig.sourceMap = derived;
+        this.dependencies.logger?.info(
+          `[Rust Debugger] Container mode: derived sourceMap from binary DWARF paths: ${JSON.stringify(derived)}`
+        );
+      }
+    }
+
     return launchConfig;
   }
-  
+
   getDefaultLaunchConfig(): Partial<GenericLaunchConfig> {
     return {
       stopOnEntry: false,

--- a/packages/adapter-rust/tests/rust-adapter.test.ts
+++ b/packages/adapter-rust/tests/rust-adapter.test.ts
@@ -28,6 +28,12 @@ vi.mock('../src/utils/rust-utils.js', async (importOriginal) => ({
   getCargoVersion: vi.fn(async () => 'cargo 1.99.0'),
   getRustHostTriple: vi.fn(async () => 'x86_64-unknown-linux-gnu')
 }));
+vi.mock('@debugmcp/codelldb-common', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  deriveSourceMapFromBinary: vi.fn(() => ({}))
+}));
+
+import { deriveSourceMapFromBinary } from '@debugmcp/codelldb-common';
 
 // Mock dependencies
 const mockDependencies: AdapterDependencies = {
@@ -264,6 +270,55 @@ describe('RustDebugAdapter', () => {
       });
 
       expect(transformed.terminal).toBe('integrated');
+    });
+
+    describe('container sourceMap derivation (#363)', () => {
+      it('injects a derived sourceMap for a prebuilt binary in container mode', async () => {
+        vi.stubEnv('MCP_CONTAINER', 'true');
+        vi.mocked(deriveSourceMapFromBinary).mockReturnValue({
+          '/home/host/proj': '/workspace'
+        });
+        try {
+          const transformed = await adapter.transformLaunchConfig({
+            program: './target/debug/myapp',
+            cwd: '/project'
+          });
+
+          expect(deriveSourceMapFromBinary).toHaveBeenCalledWith(
+            path.resolve('/project', './target/debug/myapp'),
+            '/workspace'
+          );
+          expect(transformed.sourceMap).toEqual({ '/home/host/proj': '/workspace' });
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      });
+
+      it('skips derivation when the caller supplies sourceMap entries', async () => {
+        vi.stubEnv('MCP_CONTAINER', 'true');
+        try {
+          const transformed = await adapter.transformLaunchConfig({
+            program: './target/debug/myapp',
+            cwd: '/project',
+            sourceMap: { '/custom': '/workspace' }
+          });
+
+          expect(deriveSourceMapFromBinary).not.toHaveBeenCalled();
+          expect(transformed.sourceMap).toEqual({ '/custom': '/workspace' });
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      });
+
+      it('skips derivation outside container mode', async () => {
+        const transformed = await adapter.transformLaunchConfig({
+          program: './target/debug/myapp',
+          cwd: '/project'
+        });
+
+        expect(deriveSourceMapFromBinary).not.toHaveBeenCalled();
+        expect(transformed.sourceMap).toEqual({});
+      });
     });
   });
   

--- a/packages/adapter-rust/tests/rust-adapter.test.ts
+++ b/packages/adapter-rust/tests/rust-adapter.test.ts
@@ -276,7 +276,7 @@ describe('RustDebugAdapter', () => {
       it('injects a derived sourceMap for a prebuilt binary in container mode', async () => {
         vi.stubEnv('MCP_CONTAINER', 'true');
         vi.mocked(deriveSourceMapFromBinary).mockReturnValue({
-          '/home/host/proj': '/workspace'
+          '/home/user/proj': '/workspace'
         });
         try {
           const transformed = await adapter.transformLaunchConfig({
@@ -288,7 +288,7 @@ describe('RustDebugAdapter', () => {
             path.resolve('/project', './target/debug/myapp'),
             '/workspace'
           );
-          expect(transformed.sourceMap).toEqual({ '/home/host/proj': '/workspace' });
+          expect(transformed.sourceMap).toEqual({ '/home/user/proj': '/workspace' });
         } finally {
           vi.unstubAllEnvs();
         }

--- a/packages/codelldb-common/src/index.ts
+++ b/packages/codelldb-common/src/index.ts
@@ -22,6 +22,8 @@ export type { CodeLLDBPlatformDir } from './codelldb-resolver.js';
 export { detectBinaryFormat } from './binary-detector.js';
 export type { BinaryInfo } from './binary-detector.js';
 
+export { deriveSourceMapFromBinary } from './source-map-derive.js';
+
 export {
   resolveTerminalKind,
   prepareCodelldbExecutablePath,

--- a/packages/codelldb-common/src/source-map-derive.ts
+++ b/packages/codelldb-common/src/source-map-derive.ts
@@ -1,0 +1,263 @@
+/**
+ * Best-effort source-map derivation for host-built binaries debugged inside a
+ * container (issue #363).
+ *
+ * Host-built binaries embed host-absolute source paths in their DWARF debug
+ * info. When the server runs in a container with the project mounted at
+ * /workspace, breakpoint requests use /workspace paths and CodeLLDB never
+ * matches them against the DWARF paths — file+line breakpoints silently never
+ * bind. This module scans the binary for embedded path strings and derives
+ * `hostPrefix -> containerPath` sourceMap entries by finding path suffixes
+ * that exist under the mounted workspace.
+ *
+ * Two evidence sources, covering the two ways compilers record paths:
+ *  1. Absolute source-FILE strings (gcc/clang invoked with an absolute path):
+ *     the longest path suffix that exists as a file under the workspace
+ *     yields the mapping directly.
+ *  2. Absolute DIRECTORY strings (DW_AT_comp_dir — cargo and relative-path
+ *     gcc/clang invocations record a relative source name plus an absolute
+ *     compilation directory): a directory suffix existing under the
+ *     workspace, validated by joining the binary's RELATIVE source strings
+ *     (e.g. 'src/main.rs', with rustc's '/@/<hash>' decoration stripped),
+ *     yields `compDir -> workspace/<suffix>`. When no suffix matches (the
+ *     comp dir IS the mounted root under a different name), a relative
+ *     source resolving at the workspace root maps `compDir -> workspace`.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Read at most this many bytes from the binary. */
+const MAX_SCAN_BYTES = 64 * 1024 * 1024;
+
+/** Minimum length for an embedded string to be considered. */
+const MIN_STRING_LENGTH = 6;
+
+/** Maximum number of derived sourceMap entries. */
+const MAX_ENTRIES = 3;
+
+/** Source-ish file extensions found in DWARF path strings. */
+const SOURCE_EXT_RE = /\.(c|cc|cpp|cxx|c\+\+|h|hh|hpp|hxx|inl|rs|s|asm|m|mm)$/i;
+
+/** Directory prefixes that are never a user project root. */
+const SYSTEM_DIR_RE = /^\/(usr|lib|lib64|etc|opt|proc|sys|dev|run|rustc|snap|nix)(\/|$)/;
+
+/** Absolute path shapes: POSIX or Windows drive-letter. */
+function isAbsolutePathString(s: string): boolean {
+  return s.startsWith('/') || /^[A-Za-z]:[\\/]/.test(s);
+}
+
+/** Path-plausible strings: no spaces or shell-ish characters. */
+function isPlausiblePath(s: string): boolean {
+  return !/[ \t<>|"'`*?]/.test(s);
+}
+
+/**
+ * Strip rustc's macro-expansion decoration ('src/main.rs/@/<hash>' ->
+ * 'src/main.rs').
+ */
+function stripRustDecoration(s: string): string {
+  const at = s.indexOf('/@/');
+  return at === -1 ? s : s.slice(0, at);
+}
+
+interface ExtractedStrings {
+  /** Absolute paths ending in a source extension */
+  absoluteSources: Set<string>;
+  /** Absolute directory-like paths (no source extension) */
+  absoluteDirs: Set<string>;
+  /** Relative source paths (contain a separator, source extension) */
+  relativeSources: Set<string>;
+}
+
+/** Extract NUL-terminated printable ASCII path strings from a buffer. */
+function extractPathStrings(buf: Buffer): ExtractedStrings {
+  const absoluteSources = new Set<string>();
+  const absoluteDirs = new Set<string>();
+  const relativeSources = new Set<string>();
+  let start = -1;
+  for (let i = 0; i <= buf.length; i++) {
+    const byte = i < buf.length ? buf[i] : 0;
+    const printable = byte >= 0x20 && byte <= 0x7e;
+    if (printable) {
+      if (start === -1) start = i;
+    } else {
+      if (start !== -1 && i - start >= MIN_STRING_LENGTH) {
+        const raw = buf.toString('latin1', start, i);
+        const s = stripRustDecoration(raw);
+        if (isPlausiblePath(s)) {
+          if (isAbsolutePathString(s)) {
+            if (SOURCE_EXT_RE.test(s)) {
+              absoluteSources.add(s);
+            } else if (s.length <= 512) {
+              absoluteDirs.add(s);
+            }
+          } else if (SOURCE_EXT_RE.test(s) && /[\\/]/.test(s) && !s.startsWith('.')) {
+            relativeSources.add(s);
+          }
+        }
+      }
+      start = -1;
+    }
+  }
+  return { absoluteSources, absoluteDirs, relativeSources };
+}
+
+function splitSegments(p: string): { rootAnchor: string; sep: string; segments: string[] } {
+  const isWindowsStyle = /^[A-Za-z]:[\\/]/.test(p);
+  const sep = isWindowsStyle && p.includes('\\') ? '\\' : '/';
+  const rootAnchor = isWindowsStyle ? p.slice(0, 3) : '/';
+  const segments = p
+    .slice(rootAnchor.length)
+    .split(/[\\/]+/)
+    .filter((s) => s.length > 0);
+  return { rootAnchor, sep, segments };
+}
+
+function isUnderWorkspace(embedded: string, normalizedWorkspace: string): boolean {
+  return (
+    embedded === normalizedWorkspace ||
+    embedded.startsWith(normalizedWorkspace + '/') ||
+    embedded.startsWith(normalizedWorkspace + '\\')
+  );
+}
+
+/**
+ * Derive a CodeLLDB sourceMap for a host-built binary whose sources are
+ * mounted under `workspaceRoot`. Best-effort by design: returns {} on any
+ * error or when nothing matches. Entries are ranked by how many embedded
+ * paths they explain, capped at 3.
+ */
+export function deriveSourceMapFromBinary(
+  binaryPath: string,
+  workspaceRoot: string
+): Record<string, string> {
+  try {
+    const stat = fs.statSync(binaryPath);
+    if (!stat.isFile()) return {};
+
+    const bytesToRead = Math.min(stat.size, MAX_SCAN_BYTES);
+    const buf = Buffer.alloc(bytesToRead);
+    const fd = fs.openSync(binaryPath, 'r');
+    try {
+      let offset = 0;
+      while (offset < bytesToRead) {
+        const read = fs.readSync(fd, buf, offset, bytesToRead - offset, offset);
+        if (read <= 0) break;
+        offset += read;
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+
+    const normalizedWorkspace = workspaceRoot.replace(/[\\/]+$/, '');
+    const { absoluteSources, absoluteDirs, relativeSources } = extractPathStrings(buf);
+    // mapping: hostPrefix -> { target, count }
+    const mappings = new Map<string, { target: string; count: number }>();
+    const bump = (hostPrefix: string, target: string, weight = 1): void => {
+      const existing = mappings.get(hostPrefix);
+      if (existing && existing.target === target) {
+        existing.count += weight;
+      } else if (!existing) {
+        mappings.set(hostPrefix, { target, count: weight });
+      }
+    };
+
+    const isDir = (p: string): boolean => {
+      try {
+        return fs.statSync(p).isDirectory();
+      } catch {
+        return false;
+      }
+    };
+    const isFile = (p: string): boolean => {
+      try {
+        return fs.statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    };
+
+    // Evidence 1: absolute source files — longest file suffix under the workspace.
+    for (const embedded of absoluteSources) {
+      if (/^\/rustc\/[0-9a-f]{7,}\//i.test(embedded)) continue;
+      if (isUnderWorkspace(embedded, normalizedWorkspace)) continue;
+
+      const { rootAnchor, sep, segments } = splitSegments(embedded);
+      if (segments.length < 2) continue;
+
+      for (let suffixLen = segments.length - 1; suffixLen >= 1; suffixLen--) {
+        const suffixSegments = segments.slice(segments.length - suffixLen);
+        const candidate = path.join(normalizedWorkspace, ...suffixSegments);
+        if (isFile(candidate)) {
+          const prefixSegments = segments.slice(0, segments.length - suffixLen);
+          const hostPrefix = rootAnchor === '/'
+            ? '/' + prefixSegments.join(sep)
+            : rootAnchor + prefixSegments.join(sep);
+          bump(hostPrefix, normalizedWorkspace);
+          break;
+        }
+      }
+    }
+
+    // Evidence 2: absolute compilation directories, validated by the
+    // binary's relative source strings.
+    if (relativeSources.size > 0) {
+      for (const dir of absoluteDirs) {
+        if (SYSTEM_DIR_RE.test(dir)) continue;
+        if (/^\/rustc\//i.test(dir)) continue;
+        if (isUnderWorkspace(dir, normalizedWorkspace)) continue;
+
+        const { rootAnchor, sep, segments } = splitSegments(dir);
+        if (segments.length < 1) continue;
+        void rootAnchor;
+        void sep;
+
+        // Longest directory suffix that exists under the workspace AND
+        // resolves at least one relative source.
+        let mapped = false;
+        for (let suffixLen = Math.min(segments.length - 1, 8); suffixLen >= 1 && !mapped; suffixLen--) {
+          const suffixSegments = segments.slice(segments.length - suffixLen);
+          const candidateDir = path.join(normalizedWorkspace, ...suffixSegments);
+          if (!isDir(candidateDir)) continue;
+          let matches = 0;
+          for (const rel of relativeSources) {
+            if (isFile(path.join(candidateDir, ...rel.split(/[\\/]+/)))) {
+              matches++;
+            }
+          }
+          if (matches > 0) {
+            bump(dir, candidateDir, matches);
+            mapped = true;
+          }
+        }
+        // Root-rename case: the comp dir IS the mounted root under a
+        // different name (e.g. /home/user/myrepo mounted at /workspace) —
+        // no name suffix matches, but the relative sources resolve at the
+        // workspace root directly.
+        if (!mapped) {
+          let matches = 0;
+          for (const rel of relativeSources) {
+            if (isFile(path.join(normalizedWorkspace, ...rel.split(/[\\/]+/)))) {
+              matches++;
+            }
+          }
+          if (matches > 0) {
+            bump(dir, normalizedWorkspace, matches);
+          }
+        }
+      }
+    }
+
+    const ranked = Array.from(mappings.entries())
+      .sort((a, b) => b[1].count - a[1].count)
+      .slice(0, MAX_ENTRIES);
+
+    const sourceMap: Record<string, string> = {};
+    for (const [hostPrefix, { target }] of ranked) {
+      sourceMap[hostPrefix] = target;
+    }
+    return sourceMap;
+  } catch {
+    return {};
+  }
+}

--- a/packages/codelldb-common/src/source-map-derive.ts
+++ b/packages/codelldb-common/src/source-map-derive.ts
@@ -108,7 +108,7 @@ function splitSegments(p: string): { rootAnchor: string; sep: string; segments: 
   const rootAnchor = isWindowsStyle ? p.slice(0, 3) : '/';
   const segments = p
     .slice(rootAnchor.length)
-    .split(/[\\/]+/)
+    .split(/[\\/]/)
     .filter((s) => s.length > 0);
   return { rootAnchor, sep, segments };
 }
@@ -149,7 +149,10 @@ export function deriveSourceMapFromBinary(
       fs.closeSync(fd);
     }
 
-    const normalizedWorkspace = workspaceRoot.replace(/[\\/]+$/, '');
+    let normalizedWorkspace = workspaceRoot;
+    while (normalizedWorkspace.endsWith('/') || normalizedWorkspace.endsWith('\\')) {
+      normalizedWorkspace = normalizedWorkspace.slice(0, -1);
+    }
     const { absoluteSources, absoluteDirs, relativeSources } = extractPathStrings(buf);
     // mapping: hostPrefix -> { target, count }
     const mappings = new Map<string, { target: string; count: number }>();
@@ -221,7 +224,7 @@ export function deriveSourceMapFromBinary(
           if (!isDir(candidateDir)) continue;
           let matches = 0;
           for (const rel of relativeSources) {
-            if (isFile(path.join(candidateDir, ...rel.split(/[\\/]+/)))) {
+            if (isFile(path.join(candidateDir, ...rel.split(/[\\/]/).filter((seg) => seg.length > 0)))) {
               matches++;
             }
           }
@@ -237,7 +240,7 @@ export function deriveSourceMapFromBinary(
         if (!mapped) {
           let matches = 0;
           for (const rel of relativeSources) {
-            if (isFile(path.join(normalizedWorkspace, ...rel.split(/[\\/]+/)))) {
+            if (isFile(path.join(normalizedWorkspace, ...rel.split(/[\\/]/).filter((seg) => seg.length > 0)))) {
               matches++;
             }
           }

--- a/packages/codelldb-common/tests/source-map-derive.test.ts
+++ b/packages/codelldb-common/tests/source-map-derive.test.ts
@@ -21,7 +21,10 @@ function hasGpp(): boolean {
   }
 }
 
-const GPP_AVAILABLE = hasGpp();
+// The derivation only ever runs inside Linux containers (MCP_CONTAINER);
+// the g++ fixtures are skipped on Windows where MinGW's 8.3 short paths
+// (C:\Users\RUNNER~1\...) make embedded-vs-fixture path comparison unstable.
+const GPP_AVAILABLE = hasGpp() && process.platform !== 'win32';
 
 describe('deriveSourceMapFromBinary', () => {
   let hostRoot: string;      // simulated host project root (embedded in DWARF)

--- a/packages/codelldb-common/tests/source-map-derive.test.ts
+++ b/packages/codelldb-common/tests/source-map-derive.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for deriveSourceMapFromBinary (issue #363).
+ *
+ * Builds a real fixture at test time: a tiny C++ program compiled with g++ -g
+ * from a temp "host" directory (absolute paths embedded in DWARF), then a
+ * fake "workspace" directory with the same relative source layout.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync, execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { deriveSourceMapFromBinary } from '../src/source-map-derive.js';
+
+function hasGpp(): boolean {
+  try {
+    execSync('g++ --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const GPP_AVAILABLE = hasGpp();
+
+describe('deriveSourceMapFromBinary', () => {
+  let hostRoot: string;      // simulated host project root (embedded in DWARF)
+  let workspaceRoot: string; // simulated container workspace mount
+  let binaryPath: string;
+
+  beforeAll(() => {
+    if (!GPP_AVAILABLE) return;
+    hostRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'smd-host-'));
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'smd-ws-'));
+
+    // Host layout: <hostRoot>/src/main.cpp compiled via its absolute path
+    const hostSrcDir = path.join(hostRoot, 'src');
+    fs.mkdirSync(hostSrcDir, { recursive: true });
+    const sourcePath = path.join(hostSrcDir, 'main.cpp');
+    fs.writeFileSync(sourcePath, 'int main(){return 0;}\n');
+    binaryPath = path.join(hostRoot, 'main');
+    execFileSync('g++', ['-g', '-O0', sourcePath, '-o', binaryPath]);
+
+    // Workspace mirrors the same relative layout: <workspaceRoot>/src/main.cpp
+    fs.mkdirSync(path.join(workspaceRoot, 'src'), { recursive: true });
+    fs.copyFileSync(sourcePath, path.join(workspaceRoot, 'src', 'main.cpp'));
+  }, 60_000);
+
+  afterAll(() => {
+    for (const dir of [hostRoot, workspaceRoot]) {
+      if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(!GPP_AVAILABLE)(
+    'derives hostPrefix -> workspaceRoot when the workspace mirrors the source layout',
+    () => {
+      const map = deriveSourceMapFromBinary(binaryPath, workspaceRoot);
+      expect(map[hostRoot]).toBe(workspaceRoot);
+      expect(Object.keys(map).length).toBeLessThanOrEqual(3);
+    }
+  );
+
+  it.skipIf(!GPP_AVAILABLE)(
+    'returns no entries when the embedded paths are already under the workspace root (no-op)',
+    () => {
+      // Pretend the workspace root IS the host project root: every embedded
+      // project path is already valid, so no mapping should be derived for it.
+      const map = deriveSourceMapFromBinary(binaryPath, hostRoot);
+      expect(map[hostRoot]).toBeUndefined();
+      // No entry may map anything to hostRoot from within hostRoot itself
+      for (const [prefix, target] of Object.entries(map)) {
+        expect(prefix.startsWith(hostRoot)).toBe(false);
+        expect(target).toBe(hostRoot);
+      }
+    }
+  );
+
+  it.skipIf(!GPP_AVAILABLE)('returns {} when nothing under the workspace matches', () => {
+    const emptyWs = fs.mkdtempSync(path.join(os.tmpdir(), 'smd-empty-'));
+    try {
+      const map = deriveSourceMapFromBinary(binaryPath, emptyWs);
+      expect(map).toEqual({});
+    } finally {
+      fs.rmSync(emptyWs, { recursive: true, force: true });
+    }
+  });
+
+  it('returns {} for a nonexistent binary', () => {
+    expect(deriveSourceMapFromBinary('/nonexistent/binary', '/workspace')).toEqual({});
+  });
+
+  it('returns {} for a directory path', () => {
+    expect(deriveSourceMapFromBinary(os.tmpdir(), '/workspace')).toEqual({});
+  });
+
+  it.skipIf(!GPP_AVAILABLE)(
+    'derives a root-rename mapping from comp_dir when compiled with a RELATIVE source path (gcc from repo root)',
+    () => {
+      // comp_dir = hostRoot, DW_AT_name = 'src/main.cpp' (relative). No
+      // name suffix of hostRoot exists under the workspace, but the relative
+      // source resolves at the workspace root -> hostRoot maps to workspace.
+      const relBinary = path.join(hostRoot, 'main-rel');
+      execFileSync('g++', ['-g', '-O0', path.join('src', 'main.cpp'), '-o', relBinary], { cwd: hostRoot });
+      const map = deriveSourceMapFromBinary(relBinary, workspaceRoot);
+      expect(map[hostRoot]).toBe(workspaceRoot);
+    },
+    60_000
+  );
+
+  it.skipIf(!GPP_AVAILABLE)(
+    'derives a comp_dir -> workspace/<suffix> mapping for cargo-style project-subdir builds',
+    () => {
+      // Host: <hostRoot>/proj/src/lib.cpp compiled from cwd <hostRoot>/proj
+      // with a relative path; workspace mirrors proj/src/lib.cpp. The
+      // directory suffix 'proj' exists under the workspace and resolves the
+      // relative source, so comp_dir maps to <workspace>/proj.
+      const projDir = path.join(hostRoot, 'proj');
+      fs.mkdirSync(path.join(projDir, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(projDir, 'src', 'lib.cpp'), 'int lib(){return 1;}\nint main(){return lib();}\n');
+      const projBinary = path.join(projDir, 'lib');
+      execFileSync('g++', ['-g', '-O0', path.join('src', 'lib.cpp'), '-o', projBinary], { cwd: projDir });
+
+      fs.mkdirSync(path.join(workspaceRoot, 'proj', 'src'), { recursive: true });
+      fs.copyFileSync(path.join(projDir, 'src', 'lib.cpp'), path.join(workspaceRoot, 'proj', 'src', 'lib.cpp'));
+
+      const map = deriveSourceMapFromBinary(projBinary, workspaceRoot);
+      expect(map[projDir]).toBe(path.join(workspaceRoot, 'proj'));
+    },
+    60_000
+  );
+});

--- a/packages/shared/src/interfaces/adapter-policy-dotnet.ts
+++ b/packages/shared/src/interfaces/adapter-policy-dotnet.ts
@@ -299,6 +299,16 @@ export const DotnetAdapterPolicy: AdapterPolicy = {
   },
 
   /**
+   * netcoredbg does not suspend the target on attach — it reports attach
+   * success while the debuggee keeps running. Without an explicit post-attach
+   * pause the session claims PAUSED while the process is live: stackTrace
+   * fails with 0x80131302 (process not synchronized) and pause_execution
+   * short-circuits with "Already paused" (issue #353). Same contract as the
+   * python/ruby/js policies.
+   */
+  getAttachBehavior: () => ({ pauseAfterAttach: true }),
+
+  /**
    * Filter stack frames to remove .NET runtime/framework internal frames
    */
   filterStackFrames: (frames: StackFrame[], includeInternals: boolean): StackFrame[] => {

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -1302,8 +1302,24 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         error
       );
       const message = error instanceof Error ? error.message : String(error);
-      return { synced: false, warning: `Breakpoint state updated, but live sync failed: ${message}` };
+      return { synced: false, warning: this.buildLiveSyncWarning(session, message) };
     }
+  }
+
+  /**
+   * Compose the live-sync failure warning. For ruby attach sessions whose
+   * error is rdbg's "<path> is not available", append topology guidance
+   * (issue #357): the path was rejected on the debug TARGET's filesystem
+   * (e.g. container server + host rdbg, or vice versa) — expected behavior,
+   * not a debugger fault. Same hint-append style as the netcoredbg
+   * no-symbols guidance above.
+   */
+  private buildLiveSyncWarning(session: ManagedSession, message: string): string {
+    let warning = `Breakpoint state updated, but live sync failed: ${message}`;
+    if (session.attachMode && session.language === 'ruby' && /is not available/.test(message)) {
+      warning += ' (Hint: attach sessions send breakpoint paths to the remote debugger verbatim; the path must be valid on the debug target\'s filesystem. Use target-side paths, or pass localfsMap in the attach config to map local paths to remote ones.)';
+    }
+    return warning;
   }
 
   /**
@@ -1405,7 +1421,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         error
       );
       const message = error instanceof Error ? error.message : String(error);
-      return { synced: false, warning: `Breakpoint state updated, but live sync failed: ${message}` };
+      return { synced: false, warning: this.buildLiveSyncWarning(session, message) };
     }
   }
 

--- a/tests/e2e/mcp-server-smoke-dotnet-attach.test.ts
+++ b/tests/e2e/mcp-server-smoke-dotnet-attach.test.ts
@@ -1,0 +1,215 @@
+/**
+ * .NET attach-by-PID smoke test (issue #353)
+ *
+ * Regression coverage for the attach sequencing bug: netcoredbg does not
+ * suspend the target on attach, so without the policy's post-attach pause the
+ * session reported PAUSED while the debuggee kept running — get_stack_trace
+ * failed with 0x80131302 (process not synchronized), and pause_execution
+ * short-circuited with "Already paused".
+ *
+ * Launches the pause_test loop with `dotnet`, attaches by PID, requires an
+ * immediately-working stack trace, then binds a breakpoint, continues into
+ * it, and evaluates a local. Self-skips without dotnet SDK + netcoredbg.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import path from 'path';
+import { execSync, spawn, type ChildProcess } from 'child_process';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { parseSdkToolResult, callToolSafely } from './smoke-test-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../..');
+
+function hasDotnetDebugSupport(): boolean {
+  try {
+    execSync('dotnet --version', { stdio: 'ignore', timeout: 5000 });
+  } catch {
+    return false;
+  }
+  if (process.env.NETCOREDBG_PATH && existsSync(process.env.NETCOREDBG_PATH)) {
+    return true;
+  }
+  try {
+    execSync('netcoredbg --version', { stdio: 'ignore', timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SKIP_DOTNET = !hasDotnetDebugSupport();
+
+/** Build examples/dotnet/pause_test if needed; returns the DLL path. */
+function ensurePauseTestBuild(): string {
+  const projectDir = path.resolve(ROOT, 'examples', 'dotnet', 'pause_test');
+  const possibleTfms = ['net10.0', 'net9.0', 'net8.0', 'net7.0', 'net6.0'];
+
+  const findDll = (): string | null => {
+    for (const tfm of possibleTfms) {
+      const dllPath = path.join(projectDir, 'bin', 'Debug', tfm, 'pause_test.dll');
+      if (existsSync(dllPath)) return dllPath;
+    }
+    return null;
+  };
+
+  let dll = findDll();
+  if (!dll) {
+    console.log('[.NET Attach Smoke Test] Building pause_test project...');
+    execSync('dotnet build -c Debug', { cwd: projectDir, stdio: 'inherit', timeout: 120000 });
+    dll = findDll();
+  }
+  if (!dll) {
+    throw new Error(`pause_test.dll not found under ${projectDir}/bin/Debug after build`);
+  }
+  return dll;
+}
+
+describe.skipIf(SKIP_DOTNET)('MCP Server .NET Attach Smoke Test @requires-dotnet', () => {
+  let mcpClient: Client | null = null;
+  let transport: StdioClientTransport | null = null;
+  let sessionId: string | null = null;
+  let debuggee: ChildProcess | null = null;
+
+  beforeAll(async () => {
+    const distEntry = path.join(ROOT, 'dist', 'index.js');
+    if (!existsSync(distEntry)) {
+      throw new Error(`Debug MCP dist build missing at ${distEntry}. Run "pnpm build" before executing tests.`);
+    }
+
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [distEntry, '--log-level', 'info'],
+      env: { ...process.env, NODE_ENV: 'test' }
+    });
+
+    mcpClient = new Client(
+      { name: 'dotnet-attach-test-client', version: '1.0.0' },
+      { capabilities: {} }
+    );
+
+    await mcpClient.connect(transport);
+  }, 30000);
+
+  afterEach(async () => {
+    if (sessionId && mcpClient) {
+      await callToolSafely(mcpClient, 'close_debug_session', { sessionId });
+      sessionId = null;
+    }
+    if (debuggee && !debuggee.killed) {
+      debuggee.kill('SIGKILL');
+    }
+    debuggee = null;
+  });
+
+  afterAll(async () => {
+    if (mcpClient) {
+      await mcpClient.close();
+      mcpClient = null;
+    }
+    if (transport) {
+      await transport.close();
+      transport = null;
+    }
+  });
+
+  const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+  async function waitForPaused(): Promise<boolean> {
+    for (let attempt = 0; attempt < 25; attempt++) {
+      const sessions = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'list_debug_sessions',
+        arguments: {}
+      }));
+      const session = ((sessions.sessions ?? []) as Array<{ id: string; state?: string }>)
+        .find(s => s.id === sessionId);
+      if (session?.state === 'paused') return true;
+      await wait(400);
+    }
+    return false;
+  }
+
+  it(
+    'attaches to a running pause_test by PID with an immediately usable stack (issue #353)',
+    async () => {
+      const dllPath = ensurePauseTestBuild();
+      const sourcePath = path.resolve(ROOT, 'examples', 'dotnet', 'pause_test', 'PauseTest.cs');
+
+      debuggee = spawn('dotnet', [dllPath], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true
+      });
+      const pid = debuggee.pid;
+      expect(pid).toBeDefined();
+
+      // Give the runtime a moment to start the loop
+      await wait(1500);
+      expect(debuggee.exitCode).toBeNull();
+
+      const createResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'create_debug_session',
+        arguments: { language: 'dotnet', name: 'dotnet-attach-test' }
+      }));
+      expect(createResponse.success).toBe(true);
+      sessionId = createResponse.sessionId as string;
+
+      const attachResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'attach_to_process',
+        arguments: { sessionId, processId: pid }
+      }));
+      if (!attachResponse.success) {
+        throw new Error(`attach_to_process failed: ${JSON.stringify(attachResponse, null, 2)}`);
+      }
+
+      expect(await waitForPaused(), 'attached session should be paused').toBe(true);
+
+      // The #353 regression: stackTrace must work immediately after attach.
+      // Before the fix netcoredbg was still running and answered with
+      // "Failed command 'stackTrace' : 0x80131302".
+      const stackResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'get_stack_trace',
+        arguments: { sessionId }
+      })) as { success?: boolean; stackFrames?: Array<{ name?: string; file?: string }> };
+      expect(stackResponse.success).toBe(true);
+      expect((stackResponse.stackFrames ?? []).length).toBeGreaterThan(0);
+
+      // Breakpoints must bind against the attached process ("No symbols have
+      // been loaded" was the second #353 symptom).
+      const bpResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'set_breakpoint',
+        arguments: { sessionId, file: sourcePath, line: 10 }
+      })) as { success?: boolean; verified?: boolean };
+      expect(bpResponse.success).toBe(true);
+      expect(bpResponse.verified).toBe(true);
+
+      // Continue into the breakpoint and inspect a local.
+      const continueResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'continue_execution',
+        arguments: { sessionId }
+      }));
+      expect(continueResponse.success).toBe(true);
+
+      expect(await waitForPaused(), 'should stop at the breakpoint after continue').toBe(true);
+
+      const evalResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'evaluate_expression',
+        arguments: { sessionId, expression: 'counter' }
+      })) as { success?: boolean; result?: string };
+      expect(evalResponse.success).toBe(true);
+      expect(Number(evalResponse.result)).toBeGreaterThan(0);
+
+      const closeResponse = parseSdkToolResult(await mcpClient!.callTool({
+        name: 'close_debug_session',
+        arguments: { sessionId }
+      }));
+      expect(closeResponse.success).toBe(true);
+      sessionId = null;
+
+      debuggee.kill('SIGKILL');
+    },
+    120000
+  );
+});

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -454,9 +454,69 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
       // Error is caught and logged, breakpoint is still created but unverified
       const { breakpoint: result } = await operations.setBreakpoint('test-session', { file: 'test.py', line: 10 });
-      
+
       expect(result.verified).toBe(false);
       expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    describe('ruby attach live-sync warning guidance (#357)', () => {
+      const RDBG_ERROR = new Error('/host/path/app.rb is not available');
+      const GUIDANCE = /attach sessions send breakpoint paths to the remote debugger verbatim/i;
+
+      it('appends topology guidance for a ruby attach session when rdbg rejects the path', async () => {
+        mockSession.language = 'ruby';
+        mockSession.attachMode = true;
+        mockSession.state = SessionState.PAUSED;
+        mockProxyManager.sendDapRequest.mockRejectedValue(RDBG_ERROR);
+
+        const { warning } = await operations.setBreakpoint('test-session', { file: '/host/path/app.rb', line: 5 });
+
+        expect(warning).toContain('live sync failed');
+        expect(warning).toContain('is not available');
+        expect(warning).toMatch(GUIDANCE);
+        expect(warning).toContain('localfsMap');
+      });
+
+      it('does not append guidance for a ruby launch session', async () => {
+        mockSession.language = 'ruby';
+        mockSession.attachMode = false;
+        mockSession.state = SessionState.PAUSED;
+        mockProxyManager.sendDapRequest.mockRejectedValue(RDBG_ERROR);
+
+        const { warning } = await operations.setBreakpoint('test-session', { file: '/host/path/app.rb', line: 5 });
+
+        expect(warning).toContain('live sync failed');
+        expect(warning).not.toMatch(GUIDANCE);
+      });
+
+      it('does not append guidance for other languages or other errors', async () => {
+        mockSession.language = 'python';
+        mockSession.attachMode = true;
+        mockSession.state = SessionState.PAUSED;
+        mockProxyManager.sendDapRequest.mockRejectedValue(RDBG_ERROR);
+
+        const { warning: pyWarning } = await operations.setBreakpoint('test-session', { file: 'a.py', line: 5 });
+        expect(pyWarning).not.toMatch(GUIDANCE);
+
+        mockSession.language = 'ruby';
+        mockProxyManager.sendDapRequest.mockRejectedValue(new Error('Connection lost'));
+        const { warning: otherWarning } = await operations.setBreakpoint('test-session', { file: 'a.rb', line: 5 });
+        expect(otherWarning).toContain('live sync failed');
+        expect(otherWarning).not.toMatch(GUIDANCE);
+      });
+
+      it('appends the same guidance on the function-breakpoint sync path', async () => {
+        mockSession.language = 'ruby';
+        mockSession.attachMode = true;
+        mockSession.state = SessionState.PAUSED;
+        mockSession.functionBreakpoints = new Map();
+        mockProxyManager.sendDapRequest.mockRejectedValue(RDBG_ERROR);
+
+        const { warning } = await operations.setFunctionBreakpoint('test-session', { functionName: 'MyClass#run' });
+
+        expect(warning).toContain('live sync failed');
+        expect(warning).toMatch(GUIDANCE);
+      });
     });
   });
 

--- a/tests/unit/shared/adapter-policy-dotnet.test.ts
+++ b/tests/unit/shared/adapter-policy-dotnet.test.ts
@@ -151,6 +151,14 @@ describe('DotnetAdapterPolicy', () => {
     expect(DotnetAdapterPolicy.getDapAdapterConfiguration()).toEqual({ type: 'coreclr' });
   });
 
+  it('pauses the target after attach (issue #353)', () => {
+    // netcoredbg does not suspend a running target on attach; without an
+    // explicit post-attach pause the session reports PAUSED while the
+    // process is live (stackTrace fails with 0x80131302, pause_execution
+    // claims "Already paused").
+    expect(DotnetAdapterPolicy.getAttachBehavior?.()).toEqual({ pauseAfterAttach: true });
+  });
+
   it('getDebuggerConfiguration returns expected values', () => {
     const config = DotnetAdapterPolicy.getDebuggerConfiguration();
     expect(config.requiresStrictHandshake).toBe(false);


### PR DESCRIPTION
## Summary

### #355 — mock adapter reported `breakpoint` for function-breakpoint hits
Function-bp records now carry a marker through `findNextStop`; both stop emitters send `reason: 'function breakpoint'` (line bps keep `'breakpoint'`) plus DAP-standard `hitBreakpointIds`. Line bp wins the same-line tiebreak. New DAP-level test suite for the mock process (4 tests).

### #353 — .NET attach by PID: **reproduced on Linux and fixed**
Repro evidence (dotnet 8 + netcoredbg 3.1.3): `attach_to_process` claimed `paused`, immediate `get_stack_trace` failed with exactly `Failed command 'stackTrace' : 0x80131302`, `pause_execution` said "Already paused" while the loop kept running. Root cause: netcoredbg does not suspend the target on attach and `DotnetAdapterPolicy` had no `getAttachBehavior`, so the post-attach pause mechanism (used by python/ruby/js) never fired — the PAUSED state was a lie. Fix is one attach-scoped policy line: `getAttachBehavior: () => ({ pauseAfterAttach: true })`. Verified post-fix: stack trace works immediately with `stopReason: "pause"`; breakpoint/continue/evaluate all work. New self-skipping `mcp-server-smoke-dotnet-attach.test.ts` pins it.

### #357 — Docker ruby attach "live sync failed: … is not available"
Expected topology behavior (rdbg validates paths on ITS side; the server cannot know the target's filesystem), so the fix is ergonomics: for ruby attach sessions the warning now appends guidance — paths go to the remote debugger verbatim; use target-side paths or `localfsMap` — on both line- and function-bp sync paths, and `docs/ruby/README.md` gains an "Attaching across a container boundary" section.

### #363 — Docker rust/cpp file+line breakpoints never bind (host DWARF paths vs `/workspace`)
New `deriveSourceMapFromBinary` in `codelldb-common`: scans the binary for embedded path strings and derives `hostPrefix → containerPath` sourceMap entries from **two** evidence sources — absolute source-file strings (absolute-path compiles) and absolute `DW_AT_comp_dir` directories validated against the binary's *relative* source strings (cargo and relative-path gcc/clang builds, incl. rustc's `/@/<hash>` decoration and the root-rename case). Injected automatically in `transformLaunchConfig` only when `MCP_CONTAINER=true`, the caller supplied no `sourceMap`, and the binary wasn't compiled during this launch; caller entries always win. Docs cover the manual-`sourceMap` fallback for split-DWARF/remapped builds.

**Verified end-to-end in the container**: host-built cpp binary (host-absolute comp_dir), breakpoint at `/workspace/examples/cpp/hello_world.cpp:17` → binds and stops at line 17 with the frame reported under `/workspace` (previously ran to completion). Derivation also validated against a real host cargo build.

## Testing
- All touched suites green: mock process (4), source-map-derive (7, incl. relative-compile root-rename + cargo-style subdir fixtures built with real g++), cpp adapter (32+), rust adapter (23+), dotnet policy (58), operations coverage (140+4 live-sync-hint cases), dotnet attach e2e (passes ~10s), cpp/dotnet smoke e2e
- `npm run build` + `npm run lint` clean; Docker image rebuilt for the container verification

Fixes #355
Fixes #353
Fixes #357
Fixes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)