### PR TITLE
chore(release): v0.24.0 release infrastructure and supply-chain conformance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,19 @@ updates:
     cooldown:
       default-days: 3
 
+  # Hash-pinned CI dependencies (requirements/pip.txt, requirements/debugpy.txt)
+  # installed with --require-hashes by CI and the release workflow. Without this
+  # entry they receive no update PRs and drift silently.
+  - package-ecosystem: pip
+    directory: /requirements
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps"
+    cooldown:
+      default-days: 3
+
   # Keep digest-pinned base images (Dockerfile FROM ...@sha256:) fresh.
   - package-ecosystem: docker
     directories:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       ref:
         description: 'Git ref (tag or branch) to release from'
         required: true
-        default: 'refs/tags/v0.22.0'
+        default: 'refs/tags/v0.24.0'
 
 permissions: {}
 
@@ -82,7 +82,10 @@ jobs:
     
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --ignore-scripts
-    
+
+    - name: Audit production dependencies
+      run: pnpm audit --prod --audit-level=high
+
     - name: Build project
       run: pnpm run build
       env:
@@ -232,8 +235,6 @@ jobs:
     permissions:
       contents: read
       id-token: write  # Required for npm trusted publishing (OIDC)
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
 
     steps:
     - name: Checkout code
@@ -241,18 +242,24 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.inputs.ref || github.ref }}
-    
+
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
       with:
         version: 10
 
+    # No registry-url here: setup-node would write an _authToken=${NODE_AUTH_TOKEN}
+    # placeholder into .npmrc, which breaks token-less OIDC publishes when the
+    # env var is unset. The token step below writes its own scoped .npmrc.
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
       with:
         node-version: '22.x'
-        registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
+
+    # npm >= 11.5.1 is required for OIDC trusted publishing; Node 22 bundles npm 10.
+    - name: Upgrade npm for trusted publishing
+      run: npm install -g npm@12.0.2
     
     - name: Setup Java 21
       uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
@@ -292,6 +299,10 @@ jobs:
         node -e 'console.log("ADAPTER_MOCK_VERSION="+require("./packages/adapter-mock/package.json").version)' >> $GITHUB_ENV
         node -e 'console.log("ADAPTER_PYTHON_VERSION="+require("./packages/adapter-python/package.json").version)' >> $GITHUB_ENV
         node -e 'console.log("ADAPTER_RUBY_VERSION="+require("./packages/adapter-ruby/package.json").version)' >> $GITHUB_ENV
+        node -e 'console.log("ADAPTER_JAVASCRIPT_VERSION="+require("./packages/adapter-javascript/package.json").version)' >> $GITHUB_ENV
+        node -e 'console.log("ADAPTER_GO_VERSION="+require("./packages/adapter-go/package.json").version)' >> $GITHUB_ENV
+        node -e 'console.log("ADAPTER_JAVA_VERSION="+require("./packages/adapter-java/package.json").version)' >> $GITHUB_ENV
+        node -e 'console.log("ADAPTER_DOTNET_VERSION="+require("./packages/adapter-dotnet/package.json").version)' >> $GITHUB_ENV
         node -e 'console.log("CLI_VERSION="+require("./packages/mcp-debugger/package.json").version)' >> $GITHUB_ENV
     - name: Set npm dist-tag
       run: |
@@ -306,43 +317,54 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    # npm (unlike pnpm) does not rewrite workspace:* at publish time; without
+    # this step the published adapter packages carry an uninstallable
+    # "workspace:*" dependency on @debugmcp/shared (EUNSUPPORTEDPROTOCOL).
+    # The rewrite happens only in the runner checkout, never committed.
+    - name: Resolve workspace deps for publish
+      run: node scripts/resolve-workspace-deps.cjs
+
     - name: Pack npm tarballs (dry-run)
       run: |
         npm pack --dry-run -w @debugmcp/shared
         npm pack --dry-run -w @debugmcp/adapter-mock
         npm pack --dry-run -w @debugmcp/adapter-python
         npm pack --dry-run -w @debugmcp/adapter-ruby
+        npm pack --dry-run -w @debugmcp/adapter-javascript
+        npm pack --dry-run -w @debugmcp/adapter-go
+        npm pack --dry-run -w @debugmcp/adapter-java
+        npm pack --dry-run -w @debugmcp/adapter-dotnet
         npm pack --dry-run -w @debugmcp/mcp-debugger
-    
-    - name: Publish to npm (workspaces)
-      run: |
-        # Auth via NPM_TOKEN (granular access token scoped to @debugmcp packages)
-        # --provenance adds signed build attestation (requires id-token: write)
-        # Trusted publisher config on npmjs.com verifies provenance against this repo
 
+    # Existing packages publish via OIDC trusted publishing: no token anywhere,
+    # npm mints a short-lived credential from the workflow's OIDC identity and
+    # generates provenance automatically. Each package must have this repo +
+    # workflow configured as a trusted publisher on npmjs.com BEFORE tagging.
+    - name: Publish existing packages to npm (OIDC trusted publishing)
+      run: |
         # Publish packages in dependency order if the target version does NOT yet exist
         if npm view @debugmcp/shared@${SHARED_VERSION} version >/dev/null 2>&1; then
           echo "@debugmcp/shared@${SHARED_VERSION} already exists, skipping"
         else
-          npm publish -w @debugmcp/shared --access public --provenance
+          npm publish -w @debugmcp/shared --access public --provenance --tag ${NPM_TAG}
         fi
 
         if npm view @debugmcp/adapter-mock@${ADAPTER_MOCK_VERSION} version >/dev/null 2>&1; then
           echo "@debugmcp/adapter-mock@${ADAPTER_MOCK_VERSION} already exists, skipping"
         else
-          npm publish -w @debugmcp/adapter-mock --access public --provenance
+          npm publish -w @debugmcp/adapter-mock --access public --provenance --tag ${NPM_TAG}
         fi
 
         if npm view @debugmcp/adapter-python@${ADAPTER_PYTHON_VERSION} version >/dev/null 2>&1; then
           echo "@debugmcp/adapter-python@${ADAPTER_PYTHON_VERSION} already exists, skipping"
         else
-          npm publish -w @debugmcp/adapter-python --access public --provenance
+          npm publish -w @debugmcp/adapter-python --access public --provenance --tag ${NPM_TAG}
         fi
 
         if npm view @debugmcp/adapter-ruby@${ADAPTER_RUBY_VERSION} version >/dev/null 2>&1; then
           echo "@debugmcp/adapter-ruby@${ADAPTER_RUBY_VERSION} already exists, skipping"
         else
-          npm publish -w @debugmcp/adapter-ruby --access public --provenance
+          npm publish -w @debugmcp/adapter-ruby --access public --provenance --tag ${NPM_TAG}
         fi
 
         if npm view @debugmcp/mcp-debugger@${CLI_VERSION} version >/dev/null 2>&1; then
@@ -350,11 +372,45 @@ jobs:
         else
           npm publish -w @debugmcp/mcp-debugger --access public --provenance --tag ${NPM_TAG}
         fi
+
+    # First-time publishes cannot use trusted publishing (the trusted-publisher
+    # config lives on an existing npm package). These four publish with the
+    # scoped NPM_TOKEN this release only; once they exist, configure trusted
+    # publishers for them and move them into the OIDC step above.
+    - name: Publish new packages to npm (token, first publish)
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > "$HOME/.npmrc"
 
-    # The packed tarballs become GitHub Release assets; their hashes feed the
-    # SLSA provenance job below (OpenSSF Scorecard Signed-Releases).
+        if npm view @debugmcp/adapter-javascript@${ADAPTER_JAVASCRIPT_VERSION} version >/dev/null 2>&1; then
+          echo "@debugmcp/adapter-javascript@${ADAPTER_JAVASCRIPT_VERSION} already exists, skipping"
+        else
+          npm publish -w @debugmcp/adapter-javascript --access public --provenance --tag ${NPM_TAG}
+        fi
+
+        if npm view @debugmcp/adapter-go@${ADAPTER_GO_VERSION} version >/dev/null 2>&1; then
+          echo "@debugmcp/adapter-go@${ADAPTER_GO_VERSION} already exists, skipping"
+        else
+          npm publish -w @debugmcp/adapter-go --access public --provenance --tag ${NPM_TAG}
+        fi
+
+        if npm view @debugmcp/adapter-java@${ADAPTER_JAVA_VERSION} version >/dev/null 2>&1; then
+          echo "@debugmcp/adapter-java@${ADAPTER_JAVA_VERSION} already exists, skipping"
+        else
+          npm publish -w @debugmcp/adapter-java --access public --provenance --tag ${NPM_TAG}
+        fi
+
+        if npm view @debugmcp/adapter-dotnet@${ADAPTER_DOTNET_VERSION} version >/dev/null 2>&1; then
+          echo "@debugmcp/adapter-dotnet@${ADAPTER_DOTNET_VERSION} already exists, skipping"
+        else
+          npm publish -w @debugmcp/adapter-dotnet --access public --provenance --tag ${NPM_TAG}
+        fi
+
+        rm -f "$HOME/.npmrc"
+
+    # The packed tarballs become GitHub Release assets, attested by the
+    # provenance job below (OpenSSF Scorecard Signed-Releases).
     - name: Pack release artifacts for provenance
       run: |
         mkdir -p release-artifacts
@@ -362,13 +418,11 @@ jobs:
         npm pack -w @debugmcp/adapter-mock --pack-destination release-artifacts
         npm pack -w @debugmcp/adapter-python --pack-destination release-artifacts
         npm pack -w @debugmcp/adapter-ruby --pack-destination release-artifacts
+        npm pack -w @debugmcp/adapter-javascript --pack-destination release-artifacts
+        npm pack -w @debugmcp/adapter-go --pack-destination release-artifacts
+        npm pack -w @debugmcp/adapter-java --pack-destination release-artifacts
+        npm pack -w @debugmcp/adapter-dotnet --pack-destination release-artifacts
         npm pack -w @debugmcp/mcp-debugger --pack-destination release-artifacts
-
-    - name: Compute artifact hashes (SLSA subjects)
-      id: hash
-      run: |
-        cd release-artifacts
-        echo "hashes=$(sha256sum *.tgz | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Upload release artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -523,12 +577,19 @@ jobs:
         pip install debug-mcp-server-launcher==${{ steps.changelog.outputs.VERSION }}
         ```
         
-        **Optional adapters:**
+        **Optional adapters** (for programmatic embedding; the CLI above bundles all of them):
         ```bash
-        npm install -g @debugmcp/adapter-python
-        npm install -g @debugmcp/adapter-ruby
-        npm install -g @debugmcp/adapter-mock
+        npm install @debugmcp/adapter-python   # or: adapter-ruby, adapter-javascript,
+                                               # adapter-go, adapter-java, adapter-dotnet,
+                                               # adapter-mock
         ```
+
+        ### 🔏 Verify this release
+        ```bash
+        gh attestation verify <asset>.tgz --repo debugmcp/mcp-debugger
+        npm audit signatures   # in a project that installs @debugmcp packages
+        ```
+        SBOMs (SPDX + CycloneDX) are attached as release assets.
         
         ### 📚 Documentation
         See the [README](https://github.com/debugmcp/mcp-debugger#readme) for usage instructions.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **debug@sycamore.llc**. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **admin@debugmcp.io**. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 **IMPORTANT**: Never commit personal information to the repository. This includes:
 
 - Personal file paths (e.g., `C:\path\to\` or `/path/to/`)
-- Personal email addresses (project emails like `debug@sycamore.llc` are okay)
+- Personal email addresses (project emails like `admin@debugmcp.io` are okay)
 - Cloud storage paths with personal folders
 - Any other personally identifiable information
 
@@ -247,6 +247,18 @@ Fixed race condition where disconnect during step operations
 could leave the session in an invalid state.
 ```
 
+## ✍️ Developer Certificate of Origin
+
+By contributing to this project, you certify the [Developer Certificate of Origin (DCO) v1.1](https://developercertificate.org/): that you wrote the contribution or otherwise have the right to submit it under the project's MIT license, and that you understand the contribution is public and a record of it is maintained indefinitely.
+
+Sign off each commit to make this certification explicit:
+
+```bash
+git commit -s -m "feat(scope): your change"
+```
+
+which appends a `Signed-off-by: Your Name <you@example.com>` trailer. If you forget, `git commit --amend -s` fixes the latest commit. We do not currently enforce sign-off in CI, but including it is expected for non-trivial contributions.
+
 ## 🚦 Pull Request Process
 
 1. **Before submitting**:
@@ -346,6 +358,6 @@ To see mcp-debugger in action:
 
 - **General questions**: Open a [Discussion](https://github.com/debugmcp/mcp-debugger/discussions)
 - **Bug reports**: Open an [Issue](https://github.com/debugmcp/mcp-debugger/issues)
-- **Direct contact**: debug@sycamore.llc
+- **Direct contact**: admin@debugmcp.io
 
 Thank you for contributing to mcp-debugger! 🙏

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -26,7 +26,7 @@ Day-to-day decisions are made by the lead maintainer. Significant directional ch
 
 ## Security decisions
 
-Vulnerability handling follows [SECURITY.md](SECURITY.md): private disclosure via GitHub Security Advisories or debug@sycamore.llc, coordinated release of fixes, and public advisories after patches ship.
+Vulnerability handling follows [SECURITY.md](SECURITY.md): private disclosure via GitHub Security Advisories or security@debugmcp.io, coordinated release of fixes, and public advisories after patches ship.
 
 ## Changes to this document
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Maintainers
 
-mcp-debugger is maintained by [Sycamore LLC](mailto:debug@sycamore.llc).
+mcp-debugger is maintained by [Sycamore LLC](mailto:admin@debugmcp.io).
 
 | Name | GitHub | Affiliation | Role |
 |---|---|---|---|
@@ -12,7 +12,7 @@ Maintainers review and merge pull requests, cut releases, hold publishing access
 
 | Channel | Identity |
 |---|---|
-| npm | [`@debugmcp` scope](https://www.npmjs.com/org/debugmcp) (OIDC trusted publishing — no personal tokens) |
+| npm | [`@debugmcp` scope](https://www.npmjs.com/org/debugmcp) (OIDC trusted publishing; a scoped token is used only for a package's first-ever publish) |
 | Docker Hub | [`debugmcp` org](https://hub.docker.com/r/debugmcp/mcp-debugger) |
 | PyPI | [`debug-mcp-server-launcher`](https://pypi.org/project/debug-mcp-server-launcher/) |
 | GitHub | [`debugmcp` org](https://github.com/debugmcp) |
@@ -23,4 +23,4 @@ Publishing is tied to the GitHub repository via OIDC where supported, not to ind
 
 ## Becoming a maintainer
 
-Sustained, high-quality contributions (code, adapters, triage) are the path. Open an issue or email debug@sycamore.llc if you're interested in taking on a language adapter or subsystem.
+Sustained, high-quality contributions (code, adapters, triage) are the path. Open an issue or email admin@debugmcp.io if you're interested in taking on a language adapter or subsystem.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.22.x  | :white_check_mark: |
-| < 0.22  | :x:                |
+| 0.24.x  | :white_check_mark: |
+| < 0.24  | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -17,7 +17,7 @@ Report vulnerabilities through [GitHub Security Advisories](https://github.com/d
 
 ### Alternative: Email
 
-Send details to **debug@sycamore.llc** with subject line `[SECURITY] mcp-debugger: <brief description>`.
+Send details to **security@debugmcp.io** with subject line `[SECURITY] mcp-debugger: <brief description>`.
 
 ### What to Include
 
@@ -81,5 +81,5 @@ mcp-debugger follows these security principles:
 - **No credential storage**: The server does not store or manage user credentials
 - **UX-level path validation**: File paths are checked for existence at request boundaries to give the MCP client immediate feedback on bad inputs. This is not an access-control mechanism — see [Trust Model](#trust-model).
 - **Least privilege**: CI workflows use minimal GitHub token permissions
-- **Supply chain hardening**: GitHub Actions are SHA-pinned, dependencies are audited, npm packages are published with sigstore provenance
+- **Supply chain hardening**: GitHub Actions are SHA-pinned, dependencies are audited, npm packages are published with sigstore provenance, SBOMs ship with every release, and vendored debug engines are digest-pinned — see [SUPPLY-CHAIN-SECURITY.md](SUPPLY-CHAIN-SECURITY.md) and the [assurance case](docs/assurance-case.md)
 - **Self-assessed against community baselines**: [OpenSSF Best Practices "passing" badge](https://www.bestpractices.dev/projects/13543) and [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/debugmcp/mcp-debugger)

--- a/SUPPLY-CHAIN-SECURITY.md
+++ b/SUPPLY-CHAIN-SECURITY.md
@@ -1,6 +1,8 @@
 # Supply Chain Security
 
-This document describes the supply chain security controls for mcp-debugger. It covers how code changes are vetted, how packages are published, and how access is governed.
+This document describes the supply chain security controls for mcp-debugger. It covers how code changes are vetted, how packages are published, how consumers can verify what they install, and how access is governed.
+
+A companion [assurance case](docs/assurance-case.md) explains *why* these controls are considered sufficient for this project's threat model.
 
 ## Governance Model
 
@@ -23,21 +25,37 @@ Dependabot automatically proposes SHA updates for GitHub Actions on a weekly sch
 ### Dependency Management
 
 - **Lock file integrity**: `pnpm-lock.yaml` records SHA-512 hashes for every dependency. The lock file is committed and verified on every CI run.
-- **Dependabot**: Configured for npm, pip, and GitHub Actions ecosystems with weekly update schedules.
-- **Dependency audit**: `pnpm audit` runs in CI to flag known vulnerabilities in production dependencies.
+- **Dependabot**: Configured for the npm, pip (both the PyPI launcher and the hash-pinned CI requirements in `requirements/`), GitHub Actions, and Docker (digest-pinned base images) ecosystems, all on weekly schedules.
+- **Cooldown windows**: Every Dependabot ecosystem uses an n-day cooldown (3 days by default, 7 for npm majors) so a compromised or broken upstream release has a public-exposure window before a PR is even opened here.
+- **Dependency audit**: `pnpm audit --prod --audit-level=high` is a hard gate in CI **and** in the release workflow's build job — a tag cannot publish past a known high-severity advisory.
+- **Hash-pinned CI installs**: Python tooling used by CI and the release workflow is installed with `pip --require-hashes` from committed hash manifests (`requirements/pip.txt`, `requirements/debugpy.txt`).
+
+### Embedded Third-Party Components
+
+Two upstream debug engines are vendored (as prebuilt artifacts) into distributed packages rather than expressed as npm dependencies. Because GitHub release assets are *mutable* — the same tag can serve different bytes over time — pinning a version alone is not an integrity guarantee. Both vendor pipelines therefore verify every download against **committed SHA-256 digest manifests** and fail the build on any mismatch:
+
+| Component | Upstream | License | Pin manifest | Embedded in |
+|-----------|----------|---------|--------------|-------------|
+| js-debug (VS Code JavaScript debugger, DAP server build) | [microsoft/vscode-js-debug](https://github.com/microsoft/vscode-js-debug) | MIT | [`packages/adapter-javascript/vendor-manifest.json`](packages/adapter-javascript/vendor-manifest.json) | `@debugmcp/adapter-javascript`, `@debugmcp/mcp-debugger` CLI bundle, Docker image |
+| CodeLLDB (LLDB-based DAP adapter) | [vadimcn/codelldb](https://github.com/vadimcn/codelldb) | MIT | [`packages/codelldb-common/vendor-manifest.json`](packages/codelldb-common/vendor-manifest.json) | `@debugmcp/mcp-debugger` CLI bundle (linux-x64), Docker image |
+
+The manifests pin the upstream version, the SHA-256 of each release asset, and (for js-debug) the digest of the derived server file. Overriding the pinned version requires an explicit `*_ALLOW_UNPINNED=true` escape hatch intended for local experiments only; release builds always verify against the committed digests. Version bumps are deliberate PRs that update the manifest (the bump procedure is documented inside each manifest file).
+
+Note: the SBOMs attached to releases are generated from the source tree and enumerate package-manager dependencies; the table above (plus the pin manifests) is the authoritative disclosure for these embedded binary components.
 
 ### Static Analysis
 
 - **CodeQL**: GitHub's CodeQL runs SAST on every push to main and on pull requests, analyzing TypeScript/JavaScript for security vulnerabilities.
-- **OpenSSF Scorecard**: Automated security health assessment runs weekly, with results published to the OpenSSF dashboard and GitHub Security tab.
+- **OpenSSF Scorecard**: Automated security health assessment runs weekly and on every push to main, with results published to the OpenSSF dashboard and GitHub Security tab.
 
 ### Publishing Security
 
 #### npm (`@debugmcp/*` packages)
 
-- **OIDC trusted publishing**: npm packages are published using GitHub's OIDC token provider, eliminating long-lived npm tokens from CI.
-- **Sigstore provenance**: All npm packages are published with `--provenance`, generating sigstore attestations that link each package version to its source commit and build workflow.
-- **Verification**: `npm audit signatures @debugmcp/mcp-debugger` verifies provenance attestations.
+- **OIDC trusted publishing**: previously published packages are released via npm trusted publishing — CI exchanges its GitHub OIDC identity for a short-lived credential at publish time; no long-lived npm token is involved for these packages.
+- **First-publish exception (transitional)**: npm's trusted-publisher configuration can only be attached to a package that already exists on the registry, so a package's *first* publish uses a granular, `@debugmcp`-scoped access token. As of v0.24.0 this applies to the four newly published adapter packages (`adapter-javascript`, `adapter-go`, `adapter-java`, `adapter-dotnet`); they move to trusted publishing immediately after, and the token is removed from CI once no first-publishes remain.
+- **Sigstore provenance**: All npm packages are published with provenance, generating sigstore attestations that link each package version to its source commit and build workflow.
+- **Workspace-dependency resolution**: `scripts/resolve-workspace-deps.cjs` rewrites pnpm `workspace:*` ranges to concrete pinned versions in the CI checkout before publishing, so published manifests contain only registry-resolvable, exact intra-project dependencies.
 
 #### PyPI (`debug-mcp-server-launcher`)
 
@@ -46,16 +64,45 @@ Dependabot automatically proposes SHA updates for GitHub Actions on a weekly sch
 
 #### Docker Hub (`debugmcp/mcp-debugger`)
 
-- Multi-platform images (linux/amd64, linux/arm64) built in CI.
+- Multi-platform images (linux/amd64, linux/arm64) built in CI from digest-pinned base images.
 - Published only after all tests pass.
 - Credential-based authentication via repository secrets.
+
+### SBOMs
+
+Every GitHub release attaches two Software Bills of Materials generated from the exact release ref:
+
+- `sbom.spdx.json` (SPDX 2.x)
+- `sbom.cyclonedx.json` (CycloneDX)
+
+These enumerate the package-manager dependency graph and support procurement processes (e.g. EO 14028) and downstream vulnerability scanners. Embedded binary components are disclosed separately (see [Embedded Third-Party Components](#embedded-third-party-components)).
 
 ### CI Tool Pinning
 
 All tools installed during CI are pinned to specific versions to ensure reproducible builds:
-- Python packages (debugpy, build tools) pinned with `==` version specifiers
+- Python packages (debugpy, build tools) pinned with `==` version specifiers and, for CI/release installs, `--require-hashes` manifests
 - Go tools (Delve) pinned to specific release tags
 - Node.js, Python, Go, and Java runtime versions are fixed in workflow matrices
+
+## Verifying a Release
+
+What is attested: **the npm package tarballs** (the `.tgz` files published to npm and attached to the GitHub release). The Docker image and the PyPI launcher are built by the same tag-triggered workflow but do not yet carry their own attestations.
+
+**Verify a release asset's build provenance** (proves the tarball was built by this repository's release workflow from the tagged commit):
+
+```bash
+gh attestation verify debugmcp-mcp-debugger-<version>.tgz --repo debugmcp/mcp-debugger
+```
+
+**Verify installed npm packages** (checks registry signatures and provenance attestations for everything in your lockfile):
+
+```bash
+npm audit signatures
+```
+
+**Inspect the release SBOMs**: download `sbom.spdx.json` / `sbom.cyclonedx.json` from the GitHub release and feed them to your scanner of choice (e.g. `grype sbom:./sbom.spdx.json`).
+
+Each release also attaches the raw sigstore bundle as `multiple.sigstore.json` / `multiple.intoto.jsonl` (the same bundle under both names, covering all release tarballs) for tooling that consumes sigstore bundles directly.
 
 ## Branch Protection
 
@@ -75,19 +122,20 @@ Each debug session runs in a separate child process. The MCP server itself never
 - File paths are validated at the MCP server boundary via `SimpleFileChecker` before being passed to session management
 - DAP messages are validated at the proxy layer
 - The server does not store or manage user credentials
+- Variable and evaluation output passes through secret redaction by default (see the [tool reference](docs/tool-reference.md))
 
 ## Access Continuity
 
-The project has multiple contributors to avoid single points of failure:
+The project currently has a single lead maintainer (see [MAINTAINERS.md](MAINTAINERS.md)); continuity is provided by organization-level controls rather than headcount:
 
 | System | Access Holders |
 |--------|---------------|
-| npm (`@debugmcp` scope) | Project maintainers with OIDC (no personal tokens needed) |
+| npm (`@debugmcp` scope) | Trusted publishing bound to this GitHub repository's release workflow (not to individual accounts); scoped token only for first-publishes |
 | Docker Hub (`debugmcp/mcp-debugger`) | Project maintainers via repository secrets |
 | GitHub (admin) | Organization owners of `debugmcp` |
 | PyPI (`debug-mcp-server-launcher`) | Project maintainers via repository secret (OIDC planned) |
 
-If the primary maintainer becomes unavailable, organization-level access on GitHub ensures continuity. npm OIDC publishing is tied to the GitHub repository, not individual accounts.
+If the primary maintainer becomes unavailable, organization-level access on GitHub ensures continuity. npm trusted publishing is tied to the GitHub repository, not individual accounts.
 
 ## Incident Response
 
@@ -95,6 +143,8 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting process and response 
 
 ## References
 
+- [Assurance case](docs/assurance-case.md)
 - [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/debugmcp/mcp-debugger)
 - [npm provenance documentation](https://docs.npmjs.com/generating-provenance-statements)
+- [npm trusted publishing](https://docs.npmjs.com/trusted-publishers)
 - [Sigstore](https://www.sigstore.dev/)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,7 +12,7 @@ Never file public issues for vulnerabilities — see [SECURITY.md](SECURITY.md) 
 
 ## Commercial support
 
-For organizations that need guaranteed response times, private support, integration help, or custom adapter development, contact **debug@sycamore.llc** with subject `[SUPPORT] <your topic>`. Sycamore LLC, the project steward, offers commercial arrangements on request.
+For organizations that need guaranteed response times, private support, integration help, or custom adapter development, contact **admin@debugmcp.io** with subject `[SUPPORT] <your topic>`. Sycamore LLC, the project steward, offers commercial arrangements on request.
 
 ## Supported versions
 

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -1,0 +1,59 @@
+# Security Assurance Case
+
+This document argues *why* mcp-debugger's security controls are sufficient for its threat model. The controls themselves are specified in [SUPPLY-CHAIN-SECURITY.md](../SUPPLY-CHAIN-SECURITY.md) and [SECURITY.md](../SECURITY.md); this page connects threats to controls and states the residual risks plainly. It follows the structure expected by the [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13543) assurance-case criterion: top claim, supporting argument, and evidence.
+
+## Top-level claim
+
+> An operator who installs a released mcp-debugger artifact and follows the [Trust Model](../SECURITY.md#trust-model) deployment guidance gets exactly the code this repository's CI built from the tagged commit, with no unvetted third-party code, and grants the connected MCP client no privileges beyond those the trust model explicitly documents.
+
+The claim decomposes into three sub-claims: **(1)** released artifacts are authentic and traceable, **(2)** third-party code inside them is vetted and pinned, and **(3)** the runtime grants no undocumented privilege.
+
+## Threat model
+
+mcp-debugger is a debugger driven by an AI agent over MCP. The assets worth attacking are (a) the operator's machine and source code, (b) secrets visible in debugged processes, and (c) the distribution channel to every downstream user. The attacker classes we defend against:
+
+| # | Threat | Vector |
+|---|--------|--------|
+| T1 | Malicious code injected into a release | Compromised CI dependency, mutated action tag, compromised upstream release asset, tampered build |
+| T2 | Consumer receives a artifact that differs from what CI built | Registry account compromise, token theft, artifact substitution |
+| T3 | Known-vulnerable dependency ships in a release | Dependency drift, unpatched advisory |
+| T4 | Debugger capabilities abused beyond operator intent | Over-trusted MCP client, network-exposed endpoints, secret exfiltration from variable output |
+| T5 | Maintainer account loss or unavailability | Single-maintainer project reality |
+
+Out of scope (by design, documented in [SECURITY.md](../SECURITY.md#out-of-scope)): constraining what a debugger can do to processes the operator points it at. A debugger that cannot read memory or evaluate expressions is not a debugger; the trust boundary is the deployment.
+
+## Argument: how the controls counter the threats
+
+**T1 — build-time injection.** Every GitHub Action is SHA-pinned (tag mutation is inert). `pnpm-lock.yaml` pins every npm dependency by SHA-512; CI installs with `--frozen-lockfile --ignore-scripts`. Python CI tooling installs with `pip --require-hashes`. The two vendored debug engines (js-debug, CodeLLDB) are the largest third-party blobs we ship; because GitHub release assets are mutable, both vendor pipelines verify downloads against committed SHA-256 manifests and hard-fail on mismatch — "same version" is never trusted to mean "same bytes". Dependabot cooldown windows (3–7 days) mean a compromised upstream release is public for days before any update PR opens here.
+
+**T2 — distribution integrity.** npm packages publish via OIDC trusted publishing (short-lived, repository-bound credentials; a stolen laptop yields no publish token) with sigstore provenance linking each package to the tagged commit and workflow run. Release tarballs are additionally attested with `actions/attest-build-provenance`, and consumers can verify with one command (`gh attestation verify … --repo debugmcp/mcp-debugger`). Residual: the Docker image and PyPI launcher are built by the same tag-triggered workflow but are not yet independently attested, and a first-ever npm publish uses a scoped token once (npm cannot attach a trusted publisher to a package that does not exist). Both gaps are documented rather than papered over.
+
+**T3 — vulnerable dependencies.** `pnpm audit --prod --audit-level=high` is a hard gate in CI and in the release build job, backed by explicit `pnpm.overrides` forcing patched transitive versions. CodeQL runs on every push and PR; OpenSSF Scorecard runs weekly and on every push to main. SBOMs (SPDX + CycloneDX) ship with every release so downstream scanners can re-check continuously as new advisories land.
+
+**T4 — capability abuse.** The [Trust Model](../SECURITY.md#trust-model) states the honest position: the MCP client inherits the privileges of the mcp-debugger process and of any debuggee it attaches to. Defense is therefore containment guidance (containers, OS permissions, loopback binding) plus harm reduction inside the tool: secret redaction on variable/evaluate/output responses by default, an opt-in least-privilege variable mode, per-session DAP mirror endpoints bound to loopback and gated by random tokens that are redacted from logs, and process isolation per session.
+
+**T5 — continuity.** One person maintains this project; pretending otherwise would be false assurance. Continuity rests on organization-level controls instead: npm trusted publishing binds to the repository (not a personal account), the GitHub org owns the repo and secrets, and [MAINTAINERS.md](../MAINTAINERS.md) names the responsible entity (Sycamore LLC) with a monitored contact. Branch protection with required CI keeps a hijacked or hurried maintainer from bypassing the quality gate silently.
+
+## Secure design principles applied
+
+- **Economy of mechanism**: the server never executes user code itself; it delegates to the language's own debug adapter in a child process.
+- **Fail-safe defaults**: secret redaction on by default; exception breakpoints default conservative; unpinned vendor downloads fail closed.
+- **Complete mediation**: all published artifacts flow through one tag-triggered workflow; there is no manual publish path in normal operation.
+- **Open design**: every control named here is inspectable in this repository; nothing relies on secrecy.
+- **Least privilege**: workflow jobs carry minimal `permissions:` grants; the release workflow starts from `permissions: {}`.
+
+## Residual risks, stated plainly
+
+1. Docker/PyPI artifacts lack independent attestation (planned; tracked in the ops backlog).
+2. First-publish npm packages use a scoped token once per package (transitional, self-eliminating).
+3. A fully compromised GitHub organization owner account defeats most controls; 2FA enforcement and minimal-scope tokens reduce but do not eliminate this.
+4. The SBOMs enumerate package-manager dependencies; embedded binaries are disclosed via the pin manifests instead of appearing as SBOM components.
+
+We judge these acceptable because each is either transitional with a defined exit, or is the irreducible risk of any single-org open-source project — and all are disclosed here rather than implied away.
+
+## Evidence
+
+- [SUPPLY-CHAIN-SECURITY.md](../SUPPLY-CHAIN-SECURITY.md) — control specifications and verification commands
+- [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/debugmcp/mcp-debugger) — automated, continuously refreshed assessment
+- [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13543) — self-assessment against community baseline
+- Release assets — provenance bundles and SBOMs on every [GitHub release](https://github.com/debugmcp/mcp-debugger/releases)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -5,7 +5,7 @@ Pre-release validation for mcp-debugger. Run `npm run release:dry-run` to automa
 ## Before Tagging
 
 ### Automated (via `npm run release:dry-run`)
-- [ ] Package versions match (the dry-run script checks root plus all workspace packages including adapter-dotnet)
+- [ ] Package versions match (the dry-run script checks root plus **all 12** workspace packages, including the private/bundle-only `adapter-rust`, `adapter-cpp`, and `codelldb-common`)
 - [ ] `CHANGELOG.md` has `[x.y.z] - YYYY-MM-DD` entry with date
 - [ ] `CHANGELOG.md` has empty `[Unreleased]` section at top
 - [ ] `npm run build` succeeds
@@ -14,28 +14,42 @@ Pre-release validation for mcp-debugger. Run `npm run release:dry-run` to automa
 - [ ] `release.yml` has `setup-java` (JDI bridge compiles with `--release 21`)
 - [ ] `release.yml` has `setup-go` (Go adapter needs Delve)
 - [ ] `release.yml` changelog extraction strips `v` prefix (`refs/tags/v}` not `refs/tags/}`)
+- [ ] `release.yml` runs `scripts/resolve-workspace-deps.cjs` before publishing (published manifests must not contain `workspace:*`)
 
 ### Manual
-- [ ] **npm trusted publishing configured** — each published `@debugmcp/*` package must have trusted publishing enabled at npmjs.com → package Settings → Configure Trusted Publishing (repo: `debugmcp/mcp-debugger`, workflow: `release.yml`). Auth uses a granular access token via `NPM_TOKEN` secret; trusted publishing enables provenance verification.
+- [ ] **npm trusted publishing configured** — every *previously published* `@debugmcp/*` package must have a trusted publisher at npmjs.com → package Settings → Trusted Publisher (GitHub Actions; org/user: `debugmcp`, repo: `mcp-debugger`, workflow: `release.yml`, environment: blank). These packages publish token-free via OIDC; a publish without this config fails (404/permission error) — configure, then re-run via workflow_dispatch.
+- [ ] **First-time packages** — any package that has never been on npm publishes via the `NPM_TOKEN` step in `release.yml` this once. After the release: configure its trusted publisher, then move it from the token step into the OIDC step. When no first-publishes remain, delete the token step and the `NPM_TOKEN` secret.
 - [ ] **Docker Hub credentials** — `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets are current
 - [ ] **PyPI token** — `PYPI_TOKEN` secret is current
 - [ ] `release.yml` default ref updated to current tag (for workflow_dispatch reruns)
 - [ ] All new adapters have their toolchain in `release.yml` **both** `build-and-test` and `npm-publish` jobs
+- [ ] New adapters intended for npm publishing have `publishConfig.access: "public"`, a `git+https` `repository.url` with `directory`, and appear in: `release.yml` (pack dry-run, publish, pack-artifacts) and `PUBLISHED_PKGS` in `scripts/release-dry-run.sh`. Bundle-only packages carry `"private": true`.
+- [ ] Vendored-engine pins current: `packages/adapter-javascript/vendor-manifest.json` and `packages/codelldb-common/vendor-manifest.json` match the versions you intend to ship (digest verification fails the build on drift)
 - [ ] Contributors credited in CHANGELOG (check `git log --format="%an" | sort -u`)
 
 ## Common Failures
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `E404` on `npm publish` PUT | Trusted publishing not configured for the package | npmjs.com → package Settings → Configure Trusted Publishing |
-| `release version 21 not supported` | JDK < 21 in workflow job | Add `actions/setup-java@v4` with `java-version: '21'` |
+| `E404`/permission error on OIDC `npm publish` | Trusted publisher not configured for the package | npmjs.com → package Settings → Trusted Publisher; re-run npm-publish via workflow_dispatch (per-package skip-guards make re-runs safe) |
+| `E422` on `npm publish --provenance` | Missing/mismatched `repository.url` in package.json | Add `git+https://github.com/debugmcp/mcp-debugger.git` + `directory` |
+| Published package uninstallable (`EUNSUPPORTEDPROTOCOL workspace:`) | Publish ran without workspace-dep resolution | Ensure `Resolve workspace deps for publish` step precedes publishing |
+| Vendor script fails `Integrity check FAILED` | Upstream release asset changed since pinning | Investigate before bypassing; if a legitimate re-release, update the vendor-manifest digests in a reviewed PR |
+| `release version 21 not supported` | JDK < 21 in workflow job | Add `actions/setup-java` with `java-version: '21'` |
 | Changelog empty in GitHub Release | `release.yml` doesn't strip `v` from tag | Use `${RELEASE_REF#refs/tags/v}` |
 | Build fails in `npm-publish` | Missing toolchain (Go/Java/etc.) | Mirror `build-and-test` toolchain setup in `npm-publish` job |
-| `workspace:*` resolution error | pnpm pack without resolving workspace deps | Check `scripts/prepare-pack.js` handles new packages |
+| `workspace:*` resolution error in CLI pack | pnpm pack without resolving workspace deps | Check `scripts/prepare-pack.js` handles new packages |
 
 ## After Tagging
 
-- [ ] Monitor GitHub Actions → Release workflow (all 5 jobs: build-and-test, docker-publish, npm-publish, pypi-publish, create-release)
-- [ ] Verify: `npx @debugmcp/mcp-debugger@x.y.z stdio` works
+- [ ] Monitor GitHub Actions → Release workflow (all **6** jobs: build-and-test, docker-publish, npm-publish, pypi-publish, **provenance**, create-release)
+- [ ] GitHub Release has all expected assets: one `.tgz` per published package, `multiple.intoto.jsonl`, `multiple.sigstore.json`, `sbom.spdx.json`, `sbom.cyclonedx.json`
+- [ ] GitHub Release body has the correct changelog content
+- [ ] Verify provenance: `gh attestation verify debugmcp-mcp-debugger-x.y.z.tgz --repo debugmcp/mcp-debugger` (download the asset first)
+- [ ] Verify npm: each published package shows the new version with `latest` dist-tag and a provenance badge on npmjs.com; `npm audit signatures` passes in a scratch project that installs them
+- [ ] Verify: `npx @debugmcp/mcp-debugger@x.y.z stdio` works (if the npx cache misbehaves, `npm install --prefix <tmp-dir>` is the reliable smoke path)
 - [ ] Verify: `docker pull debugmcp/mcp-debugger:x.y.z` works
-- [ ] Verify: GitHub Release has correct changelog content
+- [ ] Verify: PyPI has `debug-mcp-server-launcher==x.y.z`
+- [ ] **Website content review** — audit https://debugmcp.io against what this release shipped (language matrix, tool count, feature claims, comparison table) and update `debugmcp/website`
+- [ ] Update `SECURITY.md` supported-versions table if a new minor line started (should have happened pre-tag)
+- [ ] First-publish follow-up: configure trusted publishers for any packages that just had their first release (see Manual section above)

--- a/mcp_debugger_launcher/pyproject.toml
+++ b/mcp_debugger_launcher/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = "MIT"
 authors = [
-  { name = "debugmcp", email = "debug@sycamore.llc" }
+  { name = "debugmcp", email = "admin@debugmcp.io" }
 ]
 keywords = ["mcp", "dap", "debugger", "debugpy", "ai-agent", "llm"]
 classifiers = [

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "step-through",
     "python"
   ],
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)",
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/debugmcp/mcp-debugger/issues"

--- a/packages/adapter-cpp/package.json
+++ b/packages/adapter-cpp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@debugmcp/adapter-cpp",
   "version": "0.1.0",
+  "private": true,
   "description": "C/C++ debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,5 +36,5 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-dotnet/package.json
+++ b/packages/adapter-dotnet/package.json
@@ -41,5 +41,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-go/package.json
+++ b/packages/adapter-go/package.json
@@ -42,11 +42,14 @@
     "delve",
     "dap"
   ],
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)",
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/debugmcp/mcp-debugger.git",
+    "url": "git+https://github.com/debugmcp/mcp-debugger.git",
     "directory": "packages/adapter-go"
   }
 }

--- a/packages/adapter-java/package.json
+++ b/packages/adapter-java/package.json
@@ -44,11 +44,14 @@
     "jdi-bridge",
     "dap"
   ],
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)",
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/debugmcp/mcp-debugger.git",
+    "url": "git+https://github.com/debugmcp/mcp-debugger.git",
     "directory": "packages/adapter-java"
   }
 }

--- a/packages/adapter-javascript/package.json
+++ b/packages/adapter-javascript/package.json
@@ -8,6 +8,7 @@
   "files": [
     "dist",
     "vendor/js-debug",
+    "vendor-manifest.json",
     "assets"
   ],
   "exports": {
@@ -50,5 +51,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/debugmcp/mcp-debugger.git",
+    "directory": "packages/adapter-javascript"
+  },
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-javascript/scripts/build-js-debug.js
+++ b/packages/adapter-javascript/scripts/build-js-debug.js
@@ -34,12 +34,19 @@ import { ensureDir, copy as fsxCopy } from 'fs-extra';
 import { selectBestAsset, normalizePath } from './lib/js-debug-helpers.js';
 import { determineVendoringPlan } from './lib/vendor-strategy.js';
 
-const VERSION = process.env.JS_DEBUG_VERSION || 'latest';
-const FORCE = (process.env.JS_DEBUG_FORCE_REBUILD || '').trim() === 'true';
-const GH_TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = path.resolve(__dirname, '..');
+
+// Pinned upstream release + expected digests (supply-chain integrity).
+// Downloaded assets are verified against this committed manifest; a version
+// override away from the pin requires JS_DEBUG_ALLOW_UNPINNED=true.
+const PIN_MANIFEST_FILE = path.join(PKG_ROOT, 'vendor-manifest.json');
+const PIN = JSON.parse(fs.readFileSync(PIN_MANIFEST_FILE, 'utf8'))['js-debug'];
+const ALLOW_UNPINNED = (process.env.JS_DEBUG_ALLOW_UNPINNED || '').trim() === 'true';
+
+const VERSION = process.env.JS_DEBUG_VERSION || PIN.version;
+const FORCE = (process.env.JS_DEBUG_FORCE_REBUILD || '').trim() === 'true';
+const GH_TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
 const VENDOR_DIR = path.join(PKG_ROOT, 'vendor', 'js-debug');
 const VENDOR_FILE = path.join(VENDOR_DIR, 'vsDebugServer.js');
 const VENDOR_FILE_CJS = path.join(VENDOR_DIR, 'vsDebugServer.cjs');
@@ -564,6 +571,29 @@ async function main() {
 
     logInfo(`Selected asset: ${best.name} (${best.type}). Downloading...`);
     await downloadWithRetries(best.url, archiveFile);
+
+    // Supply-chain integrity gate: verify the downloaded archive against the
+    // committed digest pin before extracting anything from it. GitHub release
+    // assets are mutable, so "same tag" does not imply "same bytes".
+    const archiveSha = await sha256File(archiveFile);
+    const expectedSha = PIN.assets?.[best.name];
+    if (expectedSha) {
+      if (archiveSha !== expectedSha) {
+        throw new Error(
+          `Integrity check FAILED for ${best.name}: expected sha256 ${expectedSha}, got ${archiveSha}. ` +
+          'The upstream release asset does not match the pinned digest in vendor-manifest.json. ' +
+          'Do NOT bypass this without investigating; if a deliberate upstream re-release is confirmed, update vendor-manifest.json.'
+        );
+      }
+      logInfo(`Integrity check passed: ${best.name} matches pinned sha256.`);
+    } else if (ALLOW_UNPINNED) {
+      logWarn(`UNPINNED asset ${best.name} (sha256 ${archiveSha}) — allowed by JS_DEBUG_ALLOW_UNPINNED. Pin it in vendor-manifest.json before shipping.`);
+    } else {
+      throw new Error(
+        `Asset ${best.name} has no pinned digest in vendor-manifest.json. ` +
+        'Set JS_DEBUG_ALLOW_UNPINNED=true only for local experiments; releases must pin the digest.'
+      );
+    }
 
     const extractDir = path.join(tmpDir, 'extract');
     await extractArchive(archiveFile, best.type, extractDir);

--- a/packages/adapter-javascript/vendor-manifest.json
+++ b/packages/adapter-javascript/vendor-manifest.json
@@ -1,0 +1,15 @@
+{
+  "comment": "Pinned upstream release for the vendored js-debug DAP server. build-js-debug.js verifies every downloaded release asset against these digests and fails the build on mismatch. To bump: pick the new upstream tag, download its js-debug-dap-<tag>.tar.gz, compute sha256 of the archive AND of the extracted js-debug/src/dapDebugServer.js, update this file, re-run the vendor script, and run the adapter test suite. See SUPPLY-CHAIN-SECURITY.md (Embedded third-party components).",
+  "js-debug": {
+    "version": "v1.112.0",
+    "upstream": "https://github.com/microsoft/vscode-js-debug",
+    "license": "MIT",
+    "verifiedAt": "2026-08-19",
+    "assets": {
+      "js-debug-dap-v1.112.0.tar.gz": "31eb1bd9792f62c32f7c22b66ce612e2e54a7664201a2d80bdb49cc4bf4ca925"
+    },
+    "derived": {
+      "vsDebugServer.js": "1a375a9370e46e786c4095b2a0d2fd74fe54b29564dba7f1e2fe34605104d258"
+    }
+  }
+}

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -38,5 +38,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-python/package.json
+++ b/packages/adapter-python/package.json
@@ -40,5 +40,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-ruby/package.json
+++ b/packages/adapter-ruby/package.json
@@ -40,5 +40,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@debugmcp/adapter-rust",
   "version": "0.22.0",
+  "private": true,
   "description": "Rust debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",
   "main": "./dist/index.js",
@@ -37,5 +38,5 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/codelldb-common/package.json
+++ b/packages/codelldb-common/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@debugmcp/codelldb-common",
   "version": "0.22.0",
+  "private": true,
   "description": "Shared CodeLLDB vendoring, resolution, and spawn glue for CodeLLDB-backed MCP Debugger adapters",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,5 +36,5 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/codelldb-common/scripts/vendor-codelldb.js
+++ b/packages/codelldb-common/scripts/vendor-codelldb.js
@@ -18,7 +18,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { Readable, Transform } from 'stream';
 import { pipeline } from 'stream/promises';
-import { createWriteStream, createReadStream } from 'fs';
+import { createWriteStream, createReadStream, readFileSync } from 'fs';
 import extractZip from 'extract-zip';
 import ProgressBar from 'progress';
 import { fileURLToPath } from 'url';
@@ -28,7 +28,21 @@ import { createHash } from 'crypto';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const CODELLDB_VERSION = process.env.CODELLDB_VERSION || '1.11.8';
+// Pinned upstream release + expected digests (supply-chain integrity).
+// Downloaded VSIXs are verified against this committed manifest; a version
+// override away from the pin requires CODELLDB_ALLOW_UNPINNED=true.
+const PIN_MANIFEST_FILE = path.resolve(__dirname, '..', 'vendor-manifest.json');
+const PIN = JSON.parse(readFileSync(PIN_MANIFEST_FILE, 'utf-8')).codelldb;
+const ALLOW_UNPINNED = process.env.CODELLDB_ALLOW_UNPINNED === 'true';
+
+const CODELLDB_VERSION = process.env.CODELLDB_VERSION || PIN.version;
+if (CODELLDB_VERSION !== PIN.version && !ALLOW_UNPINNED) {
+  console.error(
+    `[CodeLLDB vendor] CODELLDB_VERSION=${CODELLDB_VERSION} differs from the pinned ${PIN.version} in vendor-manifest.json. ` +
+    'Set CODELLDB_ALLOW_UNPINNED=true only for local experiments; releases must update the manifest digests.'
+  );
+  process.exit(1);
+}
 const VENDOR_DIR = path.resolve(__dirname, '..', 'vendor', 'codelldb');
 const FORCE_REBUILD = process.env.CODELLDB_FORCE_REBUILD === 'true';
 const IS_CI = process.env.CI === 'true';
@@ -220,6 +234,7 @@ async function tryUseCachedArtifact(platform, platformInfo, vsixName) {
   }
   log(`Using cached ${vsixName} for ${platform} (${formatBytes(cacheEntry.stats.size)})`);
   try {
+    await verifyPinnedDigest(vsixName, cacheEntry.filePath);
     await extractAndCopyFiles(cacheEntry.filePath, platform, platformInfo, vsixName);
     return true;
   } catch (error) {
@@ -276,6 +291,36 @@ function formatBytes(bytes) {
     unitIndex++;
   }
   return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+/**
+ * Supply-chain integrity gate: verify an artifact against the committed digest
+ * pin in vendor-manifest.json. GitHub release assets are mutable, so "same
+ * version" does not imply "same bytes". Throws on mismatch; throws on unpinned
+ * assets unless CODELLDB_ALLOW_UNPINNED=true.
+ */
+async function verifyPinnedDigest(vsixName, filePath) {
+  const actual = await computeSha256(filePath);
+  const expected = CODELLDB_VERSION === PIN.version ? PIN.assets?.[vsixName] : undefined;
+  if (expected) {
+    if (actual !== expected) {
+      throw new Error(
+        `Integrity check FAILED for ${vsixName}: expected sha256 ${expected}, got ${actual}. ` +
+        'The artifact does not match the pinned digest in vendor-manifest.json. ' +
+        'Do NOT bypass this without investigating; if a deliberate upstream re-release is confirmed, update vendor-manifest.json.'
+      );
+    }
+    log(`Integrity check passed: ${vsixName} matches pinned sha256.`);
+    return;
+  }
+  if (ALLOW_UNPINNED) {
+    logWarn(`UNPINNED artifact ${vsixName} (sha256 ${actual}) — allowed by CODELLDB_ALLOW_UNPINNED. Pin it in vendor-manifest.json before shipping.`);
+    return;
+  }
+  throw new Error(
+    `Artifact ${vsixName} has no pinned digest in vendor-manifest.json. ` +
+    'Set CODELLDB_ALLOW_UNPINNED=true only for local experiments; releases must pin the digest.'
+  );
 }
 
 function computeSha256(filePath) {
@@ -568,6 +613,7 @@ async function downloadAndExtract(platform) {
         
         try {
           await downloadFile(downloadUrl, vsixPath);
+          await verifyPinnedDigest(vsixName, vsixPath);
           await extractAndCopyFiles(vsixPath, platform, platformInfo, vsixName);
           await saveArtifactToCache(vsixName, vsixPath);
           successForArtifact = true;

--- a/packages/codelldb-common/src/codelldb-resolver.ts
+++ b/packages/codelldb-common/src/codelldb-resolver.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-/** Keep in sync with the CODELLDB_VERSION default in scripts/vendor-codelldb.js */
+/** Keep in sync with the pinned version in vendor-manifest.json (the vendor script's default) */
 export const DEFAULT_CODELLDB_VERSION = '1.11.8';
 
 /**

--- a/packages/codelldb-common/tests/codelldb-resolver.test.ts
+++ b/packages/codelldb-common/tests/codelldb-resolver.test.ts
@@ -178,12 +178,18 @@ describe('codelldb-resolver', () => {
   });
 
   describe('version drift guard', () => {
-    it('keeps DEFAULT_CODELLDB_VERSION in sync with the vendor script default', () => {
-      const source = readFileSync(new URL('../scripts/vendor-codelldb.js', import.meta.url), 'utf-8');
-      const match = source.match(/CODELLDB_VERSION\s*=\s*process\.env\.CODELLDB_VERSION\s*\|\|\s*'([^']+)'/);
+    it('keeps DEFAULT_CODELLDB_VERSION in sync with the pinned vendor-manifest version', () => {
+      // The vendor script's default version comes from the committed digest
+      // manifest; the resolver's compile-time default must match it.
+      const manifest = JSON.parse(
+        readFileSync(new URL('../vendor-manifest.json', import.meta.url), 'utf-8')
+      ) as { codelldb: { version: string; assets: Record<string, string> } };
 
-      expect(match).not.toBeNull();
-      expect(match![1]).toBe(DEFAULT_CODELLDB_VERSION);
+      expect(manifest.codelldb.version).toBe(DEFAULT_CODELLDB_VERSION);
+      // Every pinned digest must look like a sha256 hex string.
+      for (const [asset, digest] of Object.entries(manifest.codelldb.assets)) {
+        expect(digest, `digest for ${asset}`).toMatch(/^[0-9a-f]{64}$/);
+      }
     });
   });
 

--- a/packages/codelldb-common/vendor-manifest.json
+++ b/packages/codelldb-common/vendor-manifest.json
@@ -1,0 +1,16 @@
+{
+  "comment": "Pinned upstream release for the vendored CodeLLDB binaries. vendor-codelldb.js verifies every downloaded VSIX against these digests and fails the build on mismatch. To bump: set the new version, download each platform VSIX from the upstream release, compute sha256 for each, update this file, re-vendor, and run the rust + cpp adapter test suites. See SUPPLY-CHAIN-SECURITY.md (Embedded third-party components).",
+  "codelldb": {
+    "version": "1.11.8",
+    "upstream": "https://github.com/vadimcn/codelldb",
+    "license": "MIT",
+    "verifiedAt": "2026-08-19",
+    "assets": {
+      "codelldb-win32-x64.vsix": "8dd720faadfb2f05c280f0f37b3f49c750c3baa0c4d6c77bac0259db78fea674",
+      "codelldb-darwin-x64.vsix": "c18f7c64be4b136eb8589549fd3af12c5e97c2dd3d74943d960803f74b39bc51",
+      "codelldb-darwin-arm64.vsix": "a1065e34be3f72954b296657821a06c566a8747d4930c2d9ebb749146a756ed7",
+      "codelldb-linux-x64.vsix": "98c90cc08427d04f83a726931e6cad99a039c3d796788a0d683ed5064e41be42",
+      "codelldb-linux-arm64.vsix": "ea8b93043231e40eca98da58e1c53f1ea4e9431498b29bde11a32c7ad815d1f4"
+    }
+  }
+}

--- a/packages/mcp-debugger/package.json
+++ b/packages/mcp-debugger/package.json
@@ -42,5 +42,5 @@
     "@debugmcp/adapter-rust": "workspace:*",
     "@debugmcp/shared": "workspace:*"
   },
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)"
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     "dap",
     "debug-adapter-protocol"
   ],
-  "author": "Sycamore LLC <debug@sycamore.llc> (https://github.com/debugmcp)",
+  "author": "Sycamore LLC <admin@debugmcp.io> (https://github.com/debugmcp)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/debugmcp/mcp-debugger/issues"

--- a/scripts/release-dry-run.sh
+++ b/scripts/release-dry-run.sh
@@ -30,6 +30,8 @@ JAVA_VER=$(node -e "console.log(require('./packages/adapter-java/package.json').
 JS_VER=$(node -e "console.log(require('./packages/adapter-javascript/package.json').version)")
 RUST_VER=$(node -e "console.log(require('./packages/adapter-rust/package.json').version)")
 DOTNET_VER=$(node -e "console.log(require('./packages/adapter-dotnet/package.json').version)")
+CPP_VER=$(node -e "console.log(require('./packages/adapter-cpp/package.json').version)")
+CODELLDB_VER=$(node -e "console.log(require('./packages/codelldb-common/package.json').version)")
 CLI_VER=$(node -e "console.log(require('./packages/mcp-debugger/package.json').version)")
 
 echo "  Root:               $ROOT_VER"
@@ -42,9 +44,11 @@ echo "  adapter-java:       $JAVA_VER"
 echo "  adapter-javascript: $JS_VER"
 echo "  adapter-rust:       $RUST_VER"
 echo "  adapter-dotnet:     $DOTNET_VER"
+echo "  adapter-cpp:        $CPP_VER"
+echo "  codelldb-common:    $CODELLDB_VER"
 echo "  mcp-debugger:       $CLI_VER"
 
-if [[ "$ROOT_VER" == "$SHARED_VER" && "$ROOT_VER" == "$MOCK_VER" && "$ROOT_VER" == "$PYTHON_VER" && "$ROOT_VER" == "$RUBY_VER" && "$ROOT_VER" == "$GO_VER" && "$ROOT_VER" == "$JAVA_VER" && "$ROOT_VER" == "$JS_VER" && "$ROOT_VER" == "$RUST_VER" && "$ROOT_VER" == "$DOTNET_VER" && "$ROOT_VER" == "$CLI_VER" ]]; then
+if [[ "$ROOT_VER" == "$SHARED_VER" && "$ROOT_VER" == "$MOCK_VER" && "$ROOT_VER" == "$PYTHON_VER" && "$ROOT_VER" == "$RUBY_VER" && "$ROOT_VER" == "$GO_VER" && "$ROOT_VER" == "$JAVA_VER" && "$ROOT_VER" == "$JS_VER" && "$ROOT_VER" == "$RUST_VER" && "$ROOT_VER" == "$DOTNET_VER" && "$ROOT_VER" == "$CPP_VER" && "$ROOT_VER" == "$CODELLDB_VER" && "$ROOT_VER" == "$CLI_VER" ]]; then
   pass "All package versions match ($ROOT_VER)"
 else
   fail "Package versions are inconsistent"
@@ -86,7 +90,7 @@ fi
 # --- 5. npm pack dry-run and provenance readiness ---
 echo ""
 echo "── npm pack dry-run ──"
-PUBLISHED_PKGS=("shared" "adapter-mock" "adapter-python" "adapter-ruby" "mcp-debugger")
+PUBLISHED_PKGS=("shared" "adapter-mock" "adapter-python" "adapter-ruby" "adapter-javascript" "adapter-go" "adapter-java" "adapter-dotnet" "mcp-debugger")
 for pkg_dir in "${PUBLISHED_PKGS[@]}"; do
   pkg_name=$(node -e "console.log(require('./packages/$pkg_dir/package.json').name)")
   if npm pack --dry-run -w "$pkg_name" > /dev/null 2>&1; then
@@ -158,7 +162,7 @@ else
 fi
 
 # Check if packages already exist at this version (would be skipped during publish)
-for pkg in @debugmcp/shared @debugmcp/adapter-mock @debugmcp/adapter-python @debugmcp/adapter-ruby @debugmcp/mcp-debugger; do
+for pkg in @debugmcp/shared @debugmcp/adapter-mock @debugmcp/adapter-python @debugmcp/adapter-ruby @debugmcp/adapter-javascript @debugmcp/adapter-go @debugmcp/adapter-java @debugmcp/adapter-dotnet @debugmcp/mcp-debugger; do
   if npm view "${pkg}@${ROOT_VER}" version > /dev/null 2>&1; then
     warn "${pkg}@${ROOT_VER} already published — will be skipped"
   fi
@@ -184,6 +188,12 @@ if echo "$CHANGELOG_EXTRACT" | grep -q 'tags/v}'; then
   pass "release.yml strips v-prefix for changelog extraction"
 else
   fail "release.yml changelog extraction may not strip v-prefix"
+fi
+
+if grep -q 'resolve-workspace-deps' .github/workflows/release.yml && [[ -f scripts/resolve-workspace-deps.cjs ]]; then
+  pass "release.yml resolves workspace: deps before publish"
+else
+  fail "release.yml missing workspace-dep resolution — published packages would carry uninstallable workspace:* deps"
 fi
 
 # --- 8. Git state ---

--- a/scripts/resolve-workspace-deps.cjs
+++ b/scripts/resolve-workspace-deps.cjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Resolve `workspace:*` protocol dependencies to concrete pinned versions
+ * before `npm publish`.
+ *
+ * npm (unlike pnpm) does NOT rewrite the workspace: protocol at publish time,
+ * so a tarball published straight from the pnpm workspace carries a literal
+ * "workspace:*" dependency that npm cannot install (EUNSUPPORTEDPROTOCOL).
+ * The release workflow runs this script in the runner checkout right before
+ * publishing; the rewrite is never committed.
+ *
+ * Usage: node scripts/resolve-workspace-deps.cjs
+ */
+const fs = require('fs');
+const path = require('path');
+
+const packagesDir = path.join(__dirname, '..', 'packages');
+const pkgJsonPaths = fs
+  .readdirSync(packagesDir)
+  .map((dir) => path.join(packagesDir, dir, 'package.json'))
+  .filter((p) => fs.existsSync(p));
+
+// name -> version map for every workspace package
+const versions = {};
+for (const p of pkgJsonPaths) {
+  const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+  versions[pkg.name] = pkg.version;
+}
+
+let rewrites = 0;
+for (const p of pkgJsonPaths) {
+  const raw = fs.readFileSync(p, 'utf8');
+  const pkg = JSON.parse(raw);
+  let changed = false;
+  // devDependencies never ship in the published manifest; leave them alone.
+  for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+    const deps = pkg[field];
+    if (!deps) continue;
+    for (const [name, range] of Object.entries(deps)) {
+      if (typeof range === 'string' && range.startsWith('workspace:')) {
+        const resolved = versions[name];
+        if (!resolved) {
+          console.error(`ERROR: ${p}: ${field}.${name} is "${range}" but ${name} is not a workspace package`);
+          process.exit(1);
+        }
+        deps[name] = resolved;
+        changed = true;
+        rewrites++;
+        console.log(`${pkg.name}: ${field}.${name} workspace:* -> ${resolved}`);
+      }
+    }
+  }
+  if (changed) {
+    fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
+  }
+}
+console.log(`Resolved ${rewrites} workspace dependency range(s) across ${pkgJsonPaths.length} packages.`);


### PR DESCRIPTION
Release-prep PR 1 of 3 for v0.24.0. Infrastructure + supply-chain positioning; docs/README currency lands in PR 2, the version bump + changelog cut in PR 3.

## Release pipeline
- **Publish 4 more adapter packages** (`adapter-javascript`, `adapter-go`, `adapter-java`, `adapter-dotnet`) — metadata completed (`publishConfig.access`, `git+https` repository URLs); bundle-only packages (`adapter-rust`, `adapter-cpp`, `codelldb-common`) marked `"private": true`
- **npm OIDC trusted publishing** for previously published packages (token-free; provenance automatic). First-ever publishes use the scoped `NPM_TOKEN` once — npm can't attach a trusted publisher to a nonexistent package — then move to OIDC
- **Fix: published adapters were uninstallable standalone** — `npm publish -w` ships literal `workspace:*` ranges (`EUNSUPPORTEDPROTOCOL` on install; affects the already-published adapter packages at 0.22.0). New `scripts/resolve-workspace-deps.cjs` rewrites them to pinned versions in the CI checkout before publish
- dist-tag applied to every published package; `pnpm audit --prod` gate added to the release build job; dead SLSA hash plumbing removed; `workflow_dispatch` default ref updated; dry-run script now checks all 12 packages and the new publish set

## Vendor integrity (supply-chain hardening)
- js-debug pinned to v1.112.0 (default was floating `latest`); CodeLLDB pinned 1.11.8
- Committed digest manifests (`packages/*/vendor-manifest.json`); both vendor scripts verify every download against pinned SHA-256s and fail closed (`*_ALLOW_UNPINNED=true` escape hatch for local experiments only)
- Digests computed from fresh upstream downloads and cross-checked byte-identical against the tested vendored copies

## Docs & policy
- `SUPPLY-CHAIN-SECURITY.md`: npm auth story corrected (OIDC real, transition stated honestly), new SBOM / release-verification / embedded-components sections, dependabot docker ecosystem + cooldowns documented, contributor-count claim fixed
- New `docs/assurance-case.md` (threats → controls → residual risks)
- `CONTRIBUTING.md`: DCO section; `SECURITY.md`: supported versions → 0.24.x
- Contact swap to debugmcp.io (`security@` / `admin@`); sycamore.llc mailboxes stay live for already-published artifacts
- dependabot now watches the hash-pinned `/requirements` manifests
- Release checklist: 6 jobs, OIDC/first-publish procedure, post-release verification (attestation, SBOM assets, npm dist-tags, website content review)

## Verification
- Full unit suite: 205 files / 3647 passed; lint clean
- `npm pack --dry-run` clean for all 4 new packages (js-debug vendor confirmed inside the adapter-javascript tarball)
- Vendor scripts exercised: pinned fetch + integrity pass (both engines, download and cache paths), unpinned-version and missing-digest failure paths confirmed
- `release.yml` YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)