### PR TITLE
chore(release): cut v0.24.0 — version sync + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-08-19
+
 ### Changed
 - **Variable responses are size-guarded** — values truncate past 1024 chars, per-call variable count and total response size are capped (all env-tunable), with a `truncation` object explaining what was cut and pointing at the `names: [...]` filter or a targeted `evaluate_expression`; keeps huge scopes from blowing out agent context windows (#356, #359)
 - **BREAKING (behavioral): launch sessions now default to `breakOnExceptions: "uncaught"`** — a crashing script pauses at the uncaught exception (`lastStop.reason: "exception"`, stack/locals inspectable, `exceptionInfo` where supported) instead of running to termination. Applies uniformly to Python, JavaScript, Java, Go (panics), .NET, Rust (panics), and the mock adapter; Ruby keeps the old run-to-termination behavior (rdbg has no uncaught-only filter). Pass `breakOnExceptions: "none"` to restore the old behavior per session. Attach sessions are unchanged — no default is ever applied on attach (fixes #244)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-debugger-monorepo",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Run-time step-through debugging for LLM agents - Monorepo root",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/adapter-cpp/package.json
+++ b/packages/adapter-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-cpp",
-  "version": "0.1.0",
+  "version": "0.24.0",
   "private": true,
   "description": "C/C++ debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",

--- a/packages/adapter-dotnet/package.json
+++ b/packages/adapter-dotnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-dotnet",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": ".NET/C# debug adapter for MCP debugger using netcoredbg",
   "type": "module",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.22.0"
+    "@debugmcp/shared": "0.24.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-go/package.json
+++ b/packages/adapter-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-go",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": "Go debugging adapter for mcp-debugger using Delve",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-java/package.json
+++ b/packages/adapter-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-java",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": "Java debug adapter for MCP Debugger using JDI bridge",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-javascript/package.json
+++ b/packages/adapter-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-javascript",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": "JavaScript/TypeScript debug adapter for MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
     "@vscode/debugprotocol": "^1.68.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.22.0"
+    "@debugmcp/shared": "0.24.0"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-mock",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": "Mock debug adapter for testing MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.22.0"
+    "@debugmcp/shared": "0.24.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-python/package.json
+++ b/packages/adapter-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-python",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": "Python debug adapter for MCP debugger using debugpy",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.22.0"
+    "@debugmcp/shared": "0.24.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-ruby/package.json
+++ b/packages/adapter-ruby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-ruby",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": "Ruby debug adapter for MCP debugger using rdbg",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.22.0"
+    "@debugmcp/shared": "0.24.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-rust",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "private": true,
   "description": "Rust debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",

--- a/packages/codelldb-common/package.json
+++ b/packages/codelldb-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/codelldb-common",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "private": true,
   "description": "Shared CodeLLDB vendoring, resolution, and spawn glue for CodeLLDB-backed MCP Debugger adapters",
   "type": "module",

--- a/packages/mcp-debugger/package.json
+++ b/packages/mcp-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/mcp-debugger",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": "Step-through debugging MCP server for LLMs",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/shared",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "description": "Shared interfaces, types, and utilities for MCP Debugger",
   "homepage": "https://github.com/debugmcp/mcp-debugger/tree/main/packages/shared",
   "repository": {


### PR DESCRIPTION
Release-prep PR 3 of 3 (after #381 infra, #382 docs). Mechanical release cut:

- `node scripts/sync-versions.cjs 0.24.0` — root + all 12 workspace packages to 0.24.0 (heals the drift where workspace packages sat at 0.22.0 and adapter-cpp at 0.1.0 — at the old versions, CI would have silently skip-published shared/mock/python/ruby as "already exists")
- CHANGELOG: `[Unreleased]` renamed to `## [0.24.0] - 2026-08-19` with a fresh empty `[Unreleased]` above (the release workflow's changelog extraction depends on the exact heading)

## Verification
`npm run release:dry-run` fully green: version consistency (all 13), changelog format, build, unit tests, `npm pack --dry-run` + provenance metadata for all 9 published packages, live secret validation (npm/Docker/PyPI), release.yml sanity checks including the workspace-dep resolution step.

After merge: tag `v0.24.0` (pending npm trusted-publisher configuration for the 5 existing packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)