### PR TITLE
fix(docker): vendor CodeLLDB explicitly in the image build; cut v0.24.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       ref:
         description: 'Git ref (tag or branch) to release from'
         required: true
-        default: 'refs/tags/v0.24.0'
+        default: 'refs/tags/v0.24.1'
 
 permissions: {}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-08-19
+
+### Fixed
+- **Published Docker image ships CodeLLDB again** — the v0.24.0 image was missing the CodeLLDB engine entirely, so Rust and C/C++ debugging reported "CodeLLDB not found" in the container (#387). Nothing in the Docker build invoked the vendor step (the root postinstall that does it on dev machines is skipped by `--ignore-scripts`), and a committed `vendor/.gitkeep` kept the build from failing loudly; local image builds were masked by developer machines' pre-populated vendor trees. The Dockerfile now vendors CodeLLDB explicitly per image architecture (linux-x64 / linux-arm64, digest-verified against the pinned manifest), points `CODELLDB_PATH` at an architecture-independent `current` symlink (the old hardcoded linux-x64 path was also silently wrong for the arm64 image), and **fails the image build if the engine is missing**
+
 ## [0.24.0] - 2026-08-19
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,22 @@ COPY packages/adapter-cpp/tsconfig*.json ./packages/adapter-cpp/
 COPY src ./src
 COPY scripts ./scripts/
 
-# 4) Build workspace packages and main project (root build runs build:packages); then bundle
-# Download Linux CodeLLDB artifacts during the container build if they are not already vendored.
+# 4) Vendor the CodeLLDB engine for this image's architecture (rust + cpp adapters).
+# This MUST be explicit: the root postinstall that vendors on dev machines is
+# skipped by --ignore-scripts, and codelldb-common's package build is tsc-only —
+# without this step a fresh CI context ships an image with no CodeLLDB (#387;
+# the committed vendor/.gitkeep kept the later cp -r from failing, so v0.24.0
+# shipped silently broken). The download is verified against the pinned SHA-256
+# digests in packages/codelldb-common/vendor-manifest.json. A "current" symlink
+# gives the runtime stage an architecture-independent CODELLDB_PATH.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in arm64) CODELLDB_ARCH=linux-arm64;; *) CODELLDB_ARCH=linux-x64;; esac; \
+    CODELLDB_PLATFORMS="$CODELLDB_ARCH" pnpm --filter @debugmcp/codelldb-common run build:adapter; \
+    test -x "/app/packages/codelldb-common/vendor/codelldb/$CODELLDB_ARCH/adapter/codelldb"; \
+    ln -sfn "$CODELLDB_ARCH" /app/packages/codelldb-common/vendor/codelldb/current
+
+# 5) Build workspace packages and main project (root build runs build:packages); then bundle
 RUN CODELLDB_VENDOR_ALL=false CODELLDB_PLATFORMS=linux-x64 pnpm run build --silent
 RUN node scripts/bundle.js
 
@@ -175,8 +189,13 @@ COPY --from=builder /app/node_modules/@debugmcp /app/node_modules/@debugmcp
 # Single shared CodeLLDB copy for the rust and cpp adapters (issue #328).
 # Both adapters probe their own package roots first (dead in this image) and
 # fall back to CODELLDB_PATH; the sibling lldb/ tree next to the binary
-# supplies liblldb and the Python support files.
-ENV CODELLDB_PATH=/app/node_modules/@debugmcp/codelldb-common/vendor/codelldb/linux-x64/adapter/codelldb
+# supplies liblldb and the Python support files. "current" is a symlink to
+# this image's architecture dir, created in the builder stage.
+ENV CODELLDB_PATH=/app/node_modules/@debugmcp/codelldb-common/vendor/codelldb/current/adapter/codelldb
+
+# Fail the image build if the debug engine is missing — the v0.24.0 image
+# shipped without CodeLLDB because nothing guarded this (#387).
+RUN test -x "$CODELLDB_PATH"
 
 # Pre-compile JDI bridge for instant Java debugging (no on-demand compilation at runtime)
 RUN mkdir -p /app/node_modules/@debugmcp/adapter-java/java/out && \

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-debugger-monorepo",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Run-time step-through debugging for LLM agents - Monorepo root",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/adapter-cpp/package.json
+++ b/packages/adapter-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-cpp",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": true,
   "description": "C/C++ debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",

--- a/packages/adapter-dotnet/package.json
+++ b/packages/adapter-dotnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-dotnet",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": ".NET/C# debug adapter for MCP debugger using netcoredbg",
   "type": "module",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.0"
+    "@debugmcp/shared": "0.24.1"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-go/package.json
+++ b/packages/adapter-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-go",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Go debugging adapter for mcp-debugger using Delve",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-java/package.json
+++ b/packages/adapter-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-java",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Java debug adapter for MCP Debugger using JDI bridge",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-javascript/package.json
+++ b/packages/adapter-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-javascript",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "JavaScript/TypeScript debug adapter for MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
     "@vscode/debugprotocol": "^1.68.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.0"
+    "@debugmcp/shared": "0.24.1"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-mock",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Mock debug adapter for testing MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.0"
+    "@debugmcp/shared": "0.24.1"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-python/package.json
+++ b/packages/adapter-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-python",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Python debug adapter for MCP debugger using debugpy",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.0"
+    "@debugmcp/shared": "0.24.1"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-ruby/package.json
+++ b/packages/adapter-ruby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-ruby",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Ruby debug adapter for MCP debugger using rdbg",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.0"
+    "@debugmcp/shared": "0.24.1"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-rust",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": true,
   "description": "Rust debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",

--- a/packages/codelldb-common/package.json
+++ b/packages/codelldb-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/codelldb-common",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": true,
   "description": "Shared CodeLLDB vendoring, resolution, and spawn glue for CodeLLDB-backed MCP Debugger adapters",
   "type": "module",

--- a/packages/mcp-debugger/package.json
+++ b/packages/mcp-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/mcp-debugger",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Step-through debugging MCP server for LLMs",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/shared",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Shared interfaces, types, and utilities for MCP Debugger",
   "homepage": "https://github.com/debugmcp/mcp-debugger/tree/main/packages/shared",
   "repository": {


### PR DESCRIPTION
Fixes #387 — the published v0.24.0 Docker image shipped without CodeLLDB, so rust/cpp launch reported "CodeLLDB not found" in the container.

## Root cause
Nothing in the Docker build ever downloaded CodeLLDB: the root `postinstall` that vendors on dev machines is skipped by `pnpm install --ignore-scripts`, `@debugmcp/codelldb-common`'s package `build` is tsc-only (unlike adapter-javascript, whose `postbuild` hook is why js-debug made it in), and the committed `vendor/.gitkeep` kept the `cp -r` into node_modules from failing loudly. Local image builds were masked by developer machines' pre-populated vendor trees — the gap only manifests in fresh CI contexts, i.e. exactly and only the published image, ever since #328 enabled rust/cpp.

## Fix
- Explicit vendor step in the builder stage, keyed on `TARGETARCH` (linux-x64 / linux-arm64) — the download is verified against the pinned SHA-256 digests in `vendor-manifest.json`
- `CODELLDB_PATH` now points through an architecture-independent `current` symlink (the old hardcoded linux-x64 path was also silently wrong for the arm64 image — latent second bug)
- **Hard guard**: `RUN test -x "$CODELLDB_PATH"` in the runtime stage — an image missing the engine can never build again
- Rides with the v0.24.1 cut: `sync-versions 0.24.1`, CHANGELOG `[0.24.1]`, release.yml dispatch ref

## Verification
- CI-faithful local build with the local vendor tree stashed away: image downloads + digest-verifies CodeLLDB, guard passes
- Fixed image: `list_supported_languages` reports rust launch and cpp launch+attach **available**
- Live C++ session in-container: source auto-compile via image g++, statement-anchored breakpoint hit, stack + STL locals correct, `evaluate_expression` returns 42, clean close
- `npm run release:dry-run` fully green for 0.24.1 (30 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)