### PR TITLE
fix(docker): shell-based CodeLLDB vendoring in the image build; cut v0.24.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       ref:
         description: 'Git ref (tag or branch) to release from'
         required: true
-        default: 'refs/tags/v0.24.1'
+        default: 'refs/tags/v0.24.2'
 
 permissions: {}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-08-19
+
+### Fixed
+- **Docker image build: CodeLLDB vendoring moved to plain shell** — the node vendor script dies mid-extraction with exit code 0 under CI buildkit (#389; deterministic there, intermittent locally), which made the v0.24.1 `docker-publish` job fail on its own missing-engine guard, so **v0.24.1 shipped to npm and PyPI only** (no Docker image, no GitHub release). The Dockerfile now downloads the VSIX with curl, verifies it against the pinned SHA-256 from `vendor-manifest.json` with `sha256sum -c`, and extracts with unzip — same integrity guarantee, no node in the loop. The `test -x` guard and per-architecture `current` symlink from #388 are unchanged
+
 ## [0.24.1] - 2026-08-19
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,18 +73,37 @@ COPY scripts ./scripts/
 # skipped by --ignore-scripts, and codelldb-common's package build is tsc-only —
 # without this step a fresh CI context ships an image with no CodeLLDB (#387;
 # the committed vendor/.gitkeep kept the later cp -r from failing, so v0.24.0
-# shipped silently broken). The download is verified against the pinned SHA-256
-# digests in packages/codelldb-common/vendor-manifest.json. A "current" symlink
-# gives the runtime stage an architecture-independent CODELLDB_PATH.
+# shipped silently broken). Implemented in plain shell (curl + sha256sum +
+# unzip) because the node vendor script dies mid-extraction with exit 0 under
+# buildkit (#389); the download is verified against the pinned SHA-256 digests
+# in packages/codelldb-common/vendor-manifest.json. A "current" symlink gives
+# the runtime stage an architecture-independent CODELLDB_PATH. If the build
+# context already carries a vendored engine (local dev builds), it is reused.
 ARG TARGETARCH
 RUN set -eux; \
     case "${TARGETARCH:-amd64}" in arm64) CODELLDB_ARCH=linux-arm64;; *) CODELLDB_ARCH=linux-x64;; esac; \
-    CODELLDB_PLATFORMS="$CODELLDB_ARCH" pnpm --filter @debugmcp/codelldb-common run build:adapter; \
-    test -x "/app/packages/codelldb-common/vendor/codelldb/$CODELLDB_ARCH/adapter/codelldb"; \
+    DEST="/app/packages/codelldb-common/vendor/codelldb/${CODELLDB_ARCH}"; \
+    if [ ! -x "$DEST/adapter/codelldb" ]; then \
+      apt-get update && apt-get install -y --no-install-recommends curl ca-certificates unzip && rm -rf /var/lib/apt/lists/*; \
+      MANIFEST=/app/packages/codelldb-common/vendor-manifest.json; \
+      CODELLDB_VERSION="$(node -p "require('$MANIFEST').codelldb.version")"; \
+      EXPECTED_SHA="$(node -p "require('$MANIFEST').codelldb.assets['codelldb-${CODELLDB_ARCH}.vsix']")"; \
+      curl -fsSL --retry 3 -o /tmp/codelldb.vsix "https://github.com/vadimcn/codelldb/releases/download/v${CODELLDB_VERSION}/codelldb-${CODELLDB_ARCH}.vsix"; \
+      echo "${EXPECTED_SHA}  /tmp/codelldb.vsix" | sha256sum -c -; \
+      unzip -q /tmp/codelldb.vsix -d /tmp/codelldb-extract; \
+      rm -rf "$DEST"; mkdir -p "$DEST"; \
+      cp -r /tmp/codelldb-extract/extension/adapter "$DEST/adapter"; \
+      cp -r /tmp/codelldb-extract/extension/lldb "$DEST/lldb"; \
+      if [ -d /tmp/codelldb-extract/extension/lang_support ]; then cp -r /tmp/codelldb-extract/extension/lang_support "$DEST/lang_support"; fi; \
+      chmod 755 "$DEST/adapter/codelldb"; \
+      printf '{\n  "version": "%s",\n  "platform": "%s"\n}\n' "$CODELLDB_VERSION" "$CODELLDB_ARCH" > "$DEST/version.json"; \
+      rm -rf /tmp/codelldb.vsix /tmp/codelldb-extract; \
+    fi; \
+    test -x "$DEST/adapter/codelldb"; \
     ln -sfn "$CODELLDB_ARCH" /app/packages/codelldb-common/vendor/codelldb/current
 
 # 5) Build workspace packages and main project (root build runs build:packages); then bundle
-RUN CODELLDB_VENDOR_ALL=false CODELLDB_PLATFORMS=linux-x64 pnpm run build --silent
+RUN pnpm run build --silent
 RUN node scripts/bundle.js
 
 # Optional: quick diagnostics for bundle

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-debugger-monorepo",
   "private": true,
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Run-time step-through debugging for LLM agents - Monorepo root",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/adapter-cpp/package.json
+++ b/packages/adapter-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-cpp",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "description": "C/C++ debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",

--- a/packages/adapter-dotnet/package.json
+++ b/packages/adapter-dotnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-dotnet",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": ".NET/C# debug adapter for MCP debugger using netcoredbg",
   "type": "module",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.1"
+    "@debugmcp/shared": "0.24.2"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-go/package.json
+++ b/packages/adapter-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-go",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Go debugging adapter for mcp-debugger using Delve",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-java/package.json
+++ b/packages/adapter-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-java",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Java debug adapter for MCP Debugger using JDI bridge",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-javascript/package.json
+++ b/packages/adapter-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-javascript",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "JavaScript/TypeScript debug adapter for MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
     "@vscode/debugprotocol": "^1.68.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.1"
+    "@debugmcp/shared": "0.24.2"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-mock",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Mock debug adapter for testing MCP debugger",
   "type": "module",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.1"
+    "@debugmcp/shared": "0.24.2"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-python/package.json
+++ b/packages/adapter-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-python",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Python debug adapter for MCP debugger using debugpy",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.1"
+    "@debugmcp/shared": "0.24.2"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-ruby/package.json
+++ b/packages/adapter-ruby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-ruby",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Ruby debug adapter for MCP debugger using rdbg",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@debugmcp/shared": "0.24.1"
+    "@debugmcp/shared": "0.24.2"
   },
   "repository": {
     "type": "git",

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/adapter-rust",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "description": "Rust debug adapter for MCP Debugger using CodeLLDB",
   "type": "module",

--- a/packages/codelldb-common/package.json
+++ b/packages/codelldb-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/codelldb-common",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "description": "Shared CodeLLDB vendoring, resolution, and spawn glue for CodeLLDB-backed MCP Debugger adapters",
   "type": "module",

--- a/packages/mcp-debugger/package.json
+++ b/packages/mcp-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/mcp-debugger",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Step-through debugging MCP server for LLMs",
   "homepage": "https://github.com/debugmcp/mcp-debugger",
   "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debugmcp/shared",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Shared interfaces, types, and utilities for MCP Debugger",
   "homepage": "https://github.com/debugmcp/mcp-debugger/tree/main/packages/shared",
   "repository": {


### PR DESCRIPTION
The #388 vendor step used the node vendor script in the Docker build; under CI buildkit that script dies mid-extraction **with exit code 0** (#389 — deterministic in CI, intermittent locally, download + pinned-digest verification always pass first). The v0.24.1 `docker-publish` job therefore failed on its own `test -x` guard — the guard worked; the vendoring didn't — and v0.24.1 shipped to npm/PyPI only (no Docker image, no GitHub release).

## Change
Replace the in-Docker node vendor invocation with plain shell:
- `curl` the VSIX for the image's `TARGETARCH` (linux-x64 / linux-arm64)
- verify with `sha256sum -c` against the pinned digest in `packages/codelldb-common/vendor-manifest.json` (same integrity guarantee as the script path)
- `unzip` + copy `extension/{adapter,lldb,lang_support}` and write `version.json` (same layout the resolver expects)
- keep the `current` symlink and the `test -x` build guard from #388; reuse a context-provided vendor tree when present (local dev builds)

Rides with the v0.24.2 cut (versions, CHANGELOG, dispatch ref). #389 stays open for the script-level root cause (the exit-0 is the real defect there).

## Verification
- CI-faithful `--no-cache` local build with the vendor tree stashed: download → digest pass → engine shipped; `test -x` guard green
- Built image: rust launch and cpp launch+attach report **available**; earlier live C++ in-container session (auto-compile, breakpoint, STL locals, evaluate) passed on the same vendored layout
- `npm run release:dry-run` fully green for 0.24.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)