### PR TITLE
chore(deps): remove unused eventsource dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "@vscode/debugprotocol": "^1.68.0",
     "commander": "^15.0.0",
     "debug": "^4.4.3",
-    "eventsource": "^4.1.1",
     "express": "^5.2.1",
     "fs-extra": "^11.4.0",
     "lru-cache": "^11.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       debug:
         specifier: ^4.4.3
         version: 4.4.3
-      eventsource:
-        specifier: ^4.1.1
-        version: 4.1.1
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -1614,10 +1611,6 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
-
-  eventsource@4.1.1:
-    resolution: {integrity: sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==}
-    engines: {node: '>=20.0.0'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -3646,10 +3639,6 @@ snapshots:
   eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.1.0
-
-  eventsource@4.1.1:
     dependencies:
       eventsource-parser: 3.1.0
 


### PR DESCRIPTION
## Summary

Removes the root `eventsource` dependency, which has been unused since the initial commit — nothing in the repo imports it (the only mentions are comments in `src/cli/sse-command.ts` and `tools/dev-proxy/dev-proxy.mjs`).

The actual EventSource implementation exercised by the SSE transport and its tests is `@modelcontextprotocol/sdk`'s own pinned `eventsource@3.0.7`, which is untouched by this change (verified still present in the lockfile).

## Why remove instead of merging #385

Dependabot's #385 bumps this dep 4.1.1 → 5.0.0, but since nothing loads it, the bump is untestable by CI and the dep would keep generating major-version PRs forever. Removing it shrinks the published dependency tree instead. Closes the loop on #385 (will be closed with a pointer here).

## Verification

- Repo-wide search: zero imports/requires of `eventsource`
- `pnpm install` regenerated the lockfile; SDK's `eventsource@3.0.7` remains
- Pre-push suite: lint, clean build, 3647 unit + 23 integration tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)