### PR TITLE
perf(startup): lazy-import SSE/HTTP transport stacks in CLI actions

### DIFF
--- a/src/cli/stdio-command.ts
+++ b/src/cli/stdio-command.ts
@@ -1,7 +1,7 @@
 import type { Logger as WinstonLoggerType } from 'winston';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { DebugMcpServer } from '../server.js';
-import { StdioOptions } from './setup.js';
+import type { StdioOptions } from './setup.js';
 import type { ProcessLike } from '../interfaces/process-interfaces.js';
 
 export interface ServerFactoryOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,6 @@ import {
   setupCheckRustBinaryCommand,
 } from './cli/setup.js';
 import { handleStdioCommand } from './cli/stdio-command.js';
-import { handleSSECommand } from './cli/sse-command.js';
-import { handleHttpCommand } from './cli/http-command.js';
 import { handleCheckRustBinaryCommand } from './cli/commands/check-rust-binary.js';
 import { getVersion } from './cli/version.js';
 import fs from 'fs';
@@ -135,13 +133,18 @@ export async function main(): Promise<void> {
     handleStdioCommand(options, { logger, serverFactory: createDebugMcpServer })
   );
   
-  setupSSECommand(program, (options) =>
-    handleSSECommand(options, { logger, serverFactory: createDebugMcpServer })
-  );
+  // The SSE/HTTP command modules pull in express and the SDK's HTTP transport
+  // stacks; import them only when their subcommand actually runs so stdio mode
+  // (the common case) never pays for them (issue #400).
+  setupSSECommand(program, async (options) => {
+    const { handleSSECommand } = await import('./cli/sse-command.js');
+    return handleSSECommand(options, { logger, serverFactory: createDebugMcpServer });
+  });
 
-  setupHttpCommand(program, (options) =>
-    handleHttpCommand(options, { logger, serverFactory: createDebugMcpServer })
-  );
+  setupHttpCommand(program, async (options) => {
+    const { handleHttpCommand } = await import('./cli/http-command.js');
+    return handleHttpCommand(options, { logger, serverFactory: createDebugMcpServer });
+  });
 
   setupCheckRustBinaryCommand(program, (binaryPath, options) =>
     handleCheckRustBinaryCommand(binaryPath, options)
@@ -192,7 +195,9 @@ if (isMainModule) {
   }
 }
 
-// Export for testing
+// Export for testing. handleSSECommand/handleHttpCommand are deliberately not
+// re-exported: their modules are lazy-imported inside the command actions
+// (issue #400) and consumers import them from their own modules directly.
 export {
   setupErrorHandlers,
   createCLI,
@@ -201,7 +206,5 @@ export {
   setupHttpCommand,
   setupCheckRustBinaryCommand,
   handleStdioCommand,
-  handleSSECommand,
-  handleHttpCommand,
   handleCheckRustBinaryCommand
 };

--- a/tests/unit/index-lazy-imports.test.ts
+++ b/tests/unit/index-lazy-imports.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Import-graph test for issue #400: stdio mode (and any mere import of the
+ * entry point) must not evaluate the HTTP transport stacks. Express and the
+ * SSE/HTTP command modules are only loaded when their subcommand actually runs.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const loaded = vi.hoisted(() => ({ express: false }));
+
+// The factory only runs if something in the imported module graph actually
+// imports express — that evaluation is exactly what this test forbids.
+vi.mock('express', () => {
+  loaded.express = true;
+  return { default: vi.fn() };
+});
+
+describe('index.ts import graph (issue #400)', () => {
+  it('does not evaluate express when the entry point is imported', async () => {
+    vi.stubEnv('DEBUG_MCP_SKIP_AUTO_START', '1');
+
+    await import('../../src/index.js');
+
+    expect(loaded.express).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #400

stdio mode — every `claude mcp add` config — statically imported all three transport command modules, dragging express and the SDK's `streamableHttp`/`sse`/`express` stacks (body-parser, qs, send, …) into the module graph of a server that never uses them.

## Change

- `src/index.ts`: the SSE and HTTP command modules are now imported with `await import()` inside their commander action closures, so they only load when that subcommand actually runs (same pattern as `check-rust-binary`). The stdio command module stays static — it has no HTTP dependencies and is the default path.
- The `handleSSECommand`/`handleHttpCommand` re-exports from `index.ts` are dropped. No consumers existed: tests and tooling import the command modules directly.
- `src/cli/stdio-command.ts`: `StdioOptions` becomes an `import type` (it's a type-only use).

## Laziness is locked in by a test

`tests/unit/index-lazy-imports.test.ts` mocks `express` with a factory that flips a flag on evaluation, imports the entry point, and asserts the flag stayed false. Before this change the test fails (express evaluates on import); after, it passes. `vi.mock` intercepts dynamic imports too, so the existing `index.test.ts` handler-closure assertions keep working unchanged.

## Measured (mem-bench, this machine, Windows)

`node scripts/mem-bench.mjs --target dist --scenario idle` — median RSS at `after-initialize`, 5 trials:

| | RSS med | peak med |
|---|---|---|
| main (`2014358c`) | 108.5 MB | 108.5 MB |
| this branch | **97.4 MB** | 97.5 MB |

**−11.1 MB (−10.2%) idle stdio footprint.**

Note: in the docker/npx single-file bundles the bytes still ship, but the express module graph is no longer parsed/executed on stdio startup — the win is parse/execute + heap, as scoped in the issue.

## Verification

- Full `npm test` green (259 files / 3947 tests), `npm run lint` clean
- `tests/unit/index.test.ts` + `tests/unit/cli/*` pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
