### PR TITLE
test(shared): cover the LLDB policy wrappers' own members - cpp 36%->100%, rust 71%->100%

### DIFF
--- a/packages/shared/tests/unit/adapter-policy-cpp.test.ts
+++ b/packages/shared/tests/unit/adapter-policy-cpp.test.ts
@@ -156,6 +156,12 @@ describe('CppAdapterPolicy', () => {
       const env = (config as { env?: NodeJS.ProcessEnv }).env;
       expect(env?.LLDB_USE_NATIVE_PDB_READER).toBe('1');
     });
+
+    it('defaults platform/arch to the host when omitted', () => {
+      const config = CppAdapterPolicy.getAdapterSpawnConfig!(payload);
+      expect((config as { command: string }).command).toBeTruthy();
+      expect((config as { args: string[] }).args).toEqual(['--port', '4711']);
+    });
   });
 
   describe('matchesAdapter', () => {
@@ -168,6 +174,48 @@ describe('CppAdapterPolicy', () => {
   it('reports session ready when paused', () => {
     expect(CppAdapterPolicy.isSessionReady!(SessionState.PAUSED)).toBe(true);
     expect(CppAdapterPolicy.isSessionReady!(SessionState.RUNNING)).toBe(false);
+  });
+
+  it('throws when building child session args', () => {
+    expect(() => CppAdapterPolicy.buildChildStartArgs!('pending-1', {})).toThrow(
+      'CppAdapterPolicy does not support child sessions'
+    );
+  });
+
+  it("treats only 'initialized' as the child-ready event", () => {
+    const event = (name: string): DebugProtocol.Event => ({ seq: 1, type: 'event', event: name });
+    expect(CppAdapterPolicy.isChildReadyEvent!(event('initialized'))).toBe(true);
+    expect(CppAdapterPolicy.isChildReadyEvent!(event('stopped'))).toBe(false);
+  });
+
+  it('reads locals from the shared LLDB scope names', () => {
+    expect(CppAdapterPolicy.getLocalScopeName!()).toEqual(['Local', 'Locals']);
+  });
+
+  it('resolves executable path from inputs only, deferring to the adapter otherwise', () => {
+    expect(CppAdapterPolicy.resolveExecutablePath!('/custom/codelldb')).toBe('/custom/codelldb');
+    // CODELLDB_PATH env var is handled in codelldb-resolver.ts, not here
+    expect(CppAdapterPolicy.resolveExecutablePath!()).toBeUndefined();
+  });
+
+  it('reports CodeLLDB debugger capabilities', () => {
+    expect(CppAdapterPolicy.getDebuggerConfiguration!()).toEqual({
+      requiresStrictHandshake: false,
+      skipConfigurationDone: false,
+      supportsVariableType: true,
+      supportsValueFormat: true,
+      supportsMemoryReferences: true
+    });
+  });
+
+  it('never queues commands', () => {
+    expect(CppAdapterPolicy.requiresCommandQueueing!()).toBe(false);
+    const handling = CppAdapterPolicy.shouldQueueCommand!('next', CppAdapterPolicy.createInitialState!());
+    expect(handling).toEqual({
+      shouldQueue: false,
+      shouldDefer: false,
+      reason: 'C++/CodeLLDB adapter does not queue commands'
+    });
   });
 
   it('tracks initialization state via the shared LLDB state helpers', () => {

--- a/packages/shared/tests/unit/adapter-policy-rust.test.ts
+++ b/packages/shared/tests/unit/adapter-policy-rust.test.ts
@@ -365,9 +365,34 @@ describe('RustAdapterPolicy', () => {
   });
 
   it('never queues commands', () => {
+    expect(RustAdapterPolicy.requiresCommandQueueing!()).toBe(false);
     const result = RustAdapterPolicy.shouldQueueCommand!();
     expect(result.shouldQueue).toBe(false);
     expect(result.shouldDefer).toBe(false);
+  });
+
+  it("treats only 'initialized' as the child-ready event", () => {
+    const event = (name: string): DebugProtocol.Event => ({ seq: 1, type: 'event', event: name });
+    expect(RustAdapterPolicy.isChildReadyEvent!(event('initialized'))).toBe(true);
+    expect(RustAdapterPolicy.isChildReadyEvent!(event('stopped'))).toBe(false);
+  });
+
+  it('reads locals from the shared LLDB scope names', () => {
+    expect(RustAdapterPolicy.getLocalScopeName!()).toEqual(['Local', 'Locals']);
+  });
+
+  it('uses the CodeLLDB adapter type', () => {
+    expect(RustAdapterPolicy.getDapAdapterConfiguration!()).toEqual({ type: 'lldb' });
+  });
+
+  it('reports CodeLLDB debugger capabilities', () => {
+    expect(RustAdapterPolicy.getDebuggerConfiguration!()).toEqual({
+      requiresStrictHandshake: false,
+      skipConfigurationDone: false,
+      supportsVariableType: true,
+      supportsValueFormat: true,
+      supportsMemoryReferences: true
+    });
   });
 
   it('matches CodeLLDB adapter invocations', () => {

--- a/packages/shared/tests/unit/resolve-exception-filters.test.ts
+++ b/packages/shared/tests/unit/resolve-exception-filters.test.ts
@@ -15,6 +15,7 @@ import {
   DotnetAdapterPolicy,
   RubyAdapterPolicy,
   RustAdapterPolicy,
+  CppAdapterPolicy,
   MockAdapterPolicy
 } from '../../src/index.js';
 
@@ -37,6 +38,10 @@ const EXPECTATIONS: PolicyExpectation[] = [
   // Ruby: no uncaught-only filter in rdbg → no launch default; crashes run to termination
   { name: 'ruby', policy: RubyAdapterPolicy, uncaught: [], all: ['any'], defaultMode: undefined },
   { name: 'rust', policy: RustAdapterPolicy, uncaught: ['rust_panic'], all: ['rust_panic', 'cpp_throw'], defaultMode: 'uncaught' },
+  // Cpp: LLDB has no uncaught-only C++ filter — cpp_throw fires on every throw,
+  // and uncaught exceptions reach std::terminate -> SIGABRT, which LLDB stops
+  // on natively. So 'uncaught' maps to NO filters (issue #244 default).
+  { name: 'cpp', policy: CppAdapterPolicy, uncaught: [], all: ['cpp_throw'], defaultMode: 'uncaught' },
   { name: 'mock', policy: MockAdapterPolicy, uncaught: ['uncaught'], all: ['all'], defaultMode: 'uncaught' }
 ];
 


### PR DESCRIPTION
## Why

`adapter-policy-cpp.ts` sat at **35.7% lines / 0% branches** on the coverage leaderboard while every other policy read 70-100%. Investigation showed the number is mostly a measurement artifact of the file's structure, not missing behavioral tests:

- The cpp policy is a thin composition wrapper: 15 of its members are bare references into `lldb-policy-shared.ts` (94% lines, 100% functions). Its 234-line unit test exercises stop-reason normalization, stack filtering, variable extraction, state tracking, and spawn config heavily - but istanbul credits all of that to the shared file.
- Only 14 statements / 11 inline functions belong to the wrapper itself, so the 7 trivial one-liners no test happened to call dragged it to 35%, and always-explicit `platform`/`arch` args left the default-arg branches at 0/4.
- Rust is structurally identical and sat at 70.6% - second-lowest - for the same reason. No compiler, CodeLLDB binary, or platform skip-gate involved.

## Changes (test-only, no source changes)

- **`adapter-policy-cpp.test.ts`**: call the 7 uncalled members (`buildChildStartArgs` throw, `isChildReadyEvent`, `getLocalScopeName`, `resolveExecutablePath` both arms, `getDebuggerConfiguration`, `requiresCommandQueueing`, `shouldQueueCommand`) plus one `getAdapterSpawnConfig` call omitting `platform`/`arch` so the default-arg branches fire.
- **`adapter-policy-rust.test.ts`**: same treatment for rust's 5 missed members (`isChildReadyEvent`, `getLocalScopeName`, `getDapAdapterConfiguration`, `getDebuggerConfiguration`, `requiresCommandQueueing`).
- **`resolve-exception-filters.test.ts`**: add cpp to the guardrail matrix (`uncaught: []`, `all: ['cpp_throw']`, default `'uncaught'`). Cpp was the **only** policy with an exception-filter table missing from the test whose stated purpose is that filter-table changes must be deliberate - a real consistency gap surfaced by the investigation.

## Coverage result (verified locally, istanbul)

| File | Before (lines/branches/funcs) | After |
|---|---|---|
| `adapter-policy-cpp.ts` | 35.7% / 0% / 36.4% | **100% / 100% / 100%** |
| `adapter-policy-rust.ts` | 70.6% / 100% / 58.3% | **100% / 100% / 100%** |

Full unit suite: 214 files / 3844 tests passing; pre-push lint + build + unit + integration all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)