### PR TITLE
fix(ci): make Test Summary fail when any needed job did not succeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,12 +274,22 @@ jobs:
 
   test-summary:
     name: Test Summary
-    needs: [build-and-test, container-tests]
+    needs: [build-and-test, windows-python-integration, lint, container-tests]
     runs-on: ubuntu-latest
     if: always()
-    
+
     steps:
     - name: Check test results
       run: |
-        echo "✅ CI pipeline completed"
-        echo "Check the test results in the build-and-test job"
+        echo "build-and-test: ${{ needs.build-and-test.result }}"
+        echo "windows-python-integration: ${{ needs.windows-python-integration.result }}"
+        echo "lint: ${{ needs.lint.result }}"
+        echo "container-tests: ${{ needs.container-tests.result }}"
+        if [ "${{ needs.build-and-test.result }}" != "success" ] \
+          || [ "${{ needs.windows-python-integration.result }}" != "success" ] \
+          || [ "${{ needs.lint.result }}" != "success" ] \
+          || [ "${{ needs.container-tests.result }}" != "success" ]; then
+          echo "❌ One or more required jobs did not succeed"
+          exit 1
+        fi
+        echo "✅ All required jobs succeeded"


### PR DESCRIPTION
Fixes #419

## What

The `test-summary` job ran with `if: always()` and unconditionally echoed "✅ CI pipeline completed", so the job showed green even when `build-and-test` or `container-tests` failed — observed in practice on the PR #392/#393 container-build failures. It also only depended on 2 of the 4 real jobs in the workflow.

## Change

- `needs` expanded to all four jobs: `build-and-test`, `windows-python-integration`, `lint`, `container-tests` (previously omitted `lint` and `windows-python-integration` — a summary that ignores half the workflow isn't a summary).
- The step now echoes each `needs.*.result` and exits non-zero unless **every** result is `success`. This also fails on `cancelled`/`skipped`, which is correct here: no job in this workflow is conditionally skipped by design, so a non-success result always means the pipeline did not fully pass.
- `if: always()` is kept so the job still runs on failure and *names* which job failed.

## Note for branch protection

With this change Test Summary becomes a meaningful single required-check candidate: it now transitively covers every job in ci.yml. SUPPLY-CHAIN-SECURITY.md already lists it among the required checks, while actual branch protection currently requires only ubuntu Build and Test + Lint Code — worth aligning whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)