### PR TITLE
fix(build): drop wall-clock timestamps from shipped vendor outputs

### DIFF
--- a/packages/adapter-javascript/docs/README.md
+++ b/packages/adapter-javascript/docs/README.md
@@ -86,7 +86,7 @@ Expected outputs
 - vendor/js-debug/watchdog.js (optional sidecar — copied if present)
 - vendor/js-debug/package.json (forces `type: 'commonjs'`)
 - vendor/js-debug/vsDebugServer.js.sha256
-- vendor/js-debug/manifest.json (metadata: source, repo, version, asset, sha256, fetchedAt)
+- vendor/js-debug/manifest.json (metadata: source, repo, version, asset, sha256)
 - vendor/ subdirectory (contains the js-debug vendored files)
 
 Determinism and safety

--- a/packages/adapter-javascript/scripts/build-js-debug.js
+++ b/packages/adapter-javascript/scripts/build-js-debug.js
@@ -350,8 +350,7 @@ async function writeManifest({ source, repo, version, asset, sha256, original })
     version,
     asset,
     sha256,
-    ...(original ? { original } : {}),
-    fetchedAt: new Date().toISOString()
+    ...(original ? { original } : {})
   };
   await fsp.writeFile(MANIFEST_FILE, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
 }

--- a/packages/codelldb-common/scripts/vendor-codelldb.js
+++ b/packages/codelldb-common/scripts/vendor-codelldb.js
@@ -533,8 +533,7 @@ async function extractAndCopyFiles(vsixPath, platform, platformInfo, vsixName) {
     const versionFile = path.join(VENDOR_DIR, platformInfo.targetDir, 'version.json');
     await fs.writeFile(versionFile, JSON.stringify({
       version: CODELLDB_VERSION,
-      platform: platform,
-      downloadedAt: new Date().toISOString()
+      platform: platform
     }, null, 2));
     
     log(`Success: ${platform} vendored successfully`);


### PR DESCRIPTION
Fixes #421

## What

Two identical clean builds from the same commit did not produce byte-identical vendored outputs, because the vendor scripts stamped wall-clock time into files that ship:

- `packages/adapter-javascript/scripts/build-js-debug.js` — `fetchedAt: new Date().toISOString()` in the js-debug vendor manifest, which ships in `@debugmcp/adapter-javascript` (`files` includes `vendor/js-debug`).
- `packages/codelldb-common/scripts/vendor-codelldb.js` — `downloadedAt: new Date().toISOString()` in each platform `version.json`, which ships in **six** packages: `@debugmcp/codelldb-common` and the five `@debugmcp/codelldb-*` platform packages (staged by `scripts/stage-codelldb-packages.mjs`).

This blocked the OpenSSF Best Practices `build_repeatable` criterion (independent verification that a rebuild matches what was published).

## Approach: remove, don't derive

The issue offered `SOURCE_DATE_EPOCH`-derived stamps as one option. Removal is simpler and strictly better here:

- **Nothing consumes either field.** Integrity lives in the committed `vendor-manifest.json` digest pins; the CodeLLDB resolver and the staging script read only `version`/`platform` from `version.json`; nothing reads the js-debug manifest at runtime. No test asserts on either field.
- With the fields gone, **no timestamps remain in any shipped output**, so there is nothing for `SOURCE_DATE_EPOCH` to control.
- The `cachedAt` stamp is left alone — it lands in cache metadata under the user cache dir and never ships.

Also updated the manifest field list in `packages/adapter-javascript/docs/README.md`. The "Deterministic output" claim in the build-js-debug.js header is now actually true.

## Verification (the issue's acceptance criterion)

Ran `pnpm run vendor:force && npm run build` twice on win32 from this commit:

- Recursive sha256 of `packages/adapter-javascript/vendor/js-debug/` and `packages/codelldb-common/vendor/codelldb/` (all five platforms): **byte-identical across runs**.
- `pnpm pack` of `@debugmcp/adapter-javascript`, `@debugmcp/codelldb-common`, and the staged `@debugmcp/codelldb-win32-x64`: **identical tarball sha256s across runs**.
- `vitest run packages/codelldb-common/tests` (81 tests) and adapter-javascript package tests (146 tests): all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)