### PR TITLE
fix(js-debug): tag vsDebugServer argv and reap stranded instances (#431)

### DIFF
--- a/packages/adapter-javascript/src/javascript-debug-adapter.ts
+++ b/packages/adapter-javascript/src/javascript-debug-adapter.ts
@@ -25,7 +25,9 @@ import {
   type LanguageSpecificAttachConfig,
   type FeatureRequirement,
   type AdapterCapabilities,
-  type AdapterLaunchBarrier
+  type AdapterLaunchBarrier,
+  OWNER_PID_ARG_PREFIX,
+  SESSION_ID_ARG_PREFIX
 } from '@debugmcp/shared';
 import { DebugLanguage } from '@debugmcp/shared';
 import type { AdapterDependencies } from '@debugmcp/shared';
@@ -280,7 +282,22 @@ export class JavascriptDebugAdapter extends EventEmitter implements IDebugAdapte
       typeof config?.adapterHost === 'string' && config.adapterHost.trim().length > 0
         ? config.adapterHost
         : '127.0.0.1';
-    const args = [adapterPath, String(port), host];
+    // Reaper markers (issue #431): vsDebugServer.cjs reads only argv[2] (port)
+    // and argv[3] (host) and ignores trailing tokens, so these tags are inert
+    // at runtime — but they let the startup janitor recognize an instance
+    // stranded by a hard-killed proxy worker (spawned detached+unref'd, it
+    // survives every tree-kill path) and reap it by owner pid. Constraints:
+    // tokens must stay whitespace-free (the win32 process scan splits
+    // CommandLine on whitespace) and must never contain `--help` (vsDebugServer
+    // prints usage and exits if --help appears anywhere in argv).
+    const ownerPid = Number(process.env.MCP_DEBUGGER_MAIN_PID) || process.pid;
+    const args = [
+      adapterPath,
+      String(port),
+      host,
+      `${OWNER_PID_ARG_PREFIX}${ownerPid}`,
+      `${SESSION_ID_ARG_PREFIX}${config.sessionId}`
+    ];
 
     // Environment: clone from process.env (string values only), safely ensure NODE_OPTIONS memory flag
     const env: Record<string, string> = {};

--- a/packages/adapter-javascript/tests/unit/javascript-debug-adapter.command.test.ts
+++ b/packages/adapter-javascript/tests/unit/javascript-debug-adapter.command.test.ts
@@ -73,6 +73,41 @@ describe('JavascriptDebugAdapter.buildAdapterCommand (stdio)', () => {
     expect(path.isAbsolute(adapterPath as string)).toBe(true);
   });
 
+  it('tags the adapter argv with owner-pid and session-id reaper markers (issue #431)', () => {
+    const adapter = new JavascriptDebugAdapter(deps);
+
+    vi.stubEnv('MCP_DEBUGGER_MAIN_PID', '4242');
+    const cmd = adapter.buildAdapterCommand(defaultConfig);
+
+    // vsDebugServer.cjs reads only argv[2] (port) and argv[3] (host); trailing
+    // tokens are inert, which is what makes these markers safe to append.
+    expect(cmd.args[3]).toBe('--mcp-owner-pid=4242');
+    expect(cmd.args[4]).toBe('--mcp-session-id=test-session');
+  });
+
+  it('falls back to process.pid for the owner marker when MCP_DEBUGGER_MAIN_PID is unset', () => {
+    const adapter = new JavascriptDebugAdapter(deps);
+
+    vi.stubEnv('MCP_DEBUGGER_MAIN_PID', undefined);
+    const cmd = adapter.buildAdapterCommand(defaultConfig);
+
+    expect(cmd.args[3]).toBe(`--mcp-owner-pid=${process.pid}`);
+  });
+
+  it('marker tokens contain no whitespace and never the string --help', () => {
+    // Whitespace would fragment under the win32 CommandLine split; --help
+    // anywhere in argv makes vsDebugServer print usage instead of serving.
+    const adapter = new JavascriptDebugAdapter(deps);
+
+    const cmd = adapter.buildAdapterCommand(defaultConfig);
+
+    for (const token of cmd.args.slice(3)) {
+      expect(token).not.toMatch(/\s/);
+      expect(token).not.toContain('--help');
+    }
+    expect(cmd.args.slice(3).length).toBeGreaterThan(0);
+  });
+
   it('environment includes NODE_OPTIONS and does not mutate process.env', () => {
     const adapter = new JavascriptDebugAdapter(deps);
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -234,3 +234,11 @@ export {
 export type { SecretRule, RedactionHit, RedactionResult } from './utils/secret-redaction.js';
 export { LineBuffer } from './utils/line-buffer.js';
 export { toSourceBreakpoint, type BreakpointFields, toFunctionBreakpoint, type FunctionBreakpointFields } from './utils/to-source-breakpoint.js';
+// Argv marker constants shared by spawn-time tagging and the startup orphan
+// reapers (issues #343, #431).
+export {
+  PROXY_BOOTSTRAP_MARKER,
+  JS_DEBUG_ADAPTER_MARKER,
+  OWNER_PID_ARG_PREFIX,
+  SESSION_ID_ARG_PREFIX
+} from './utils/process-markers.js';

--- a/packages/shared/src/utils/process-markers.ts
+++ b/packages/shared/src/utils/process-markers.ts
@@ -1,0 +1,31 @@
+/**
+ * Argv marker constants shared between the processes that tag child argv at
+ * spawn time (the server's proxy launcher, adapter packages) and the startup
+ * reapers that later recognize those tags in system-wide process scans
+ * (issues #343, #431).
+ *
+ * Marker constraints, imposed by the scan/matcher machinery:
+ * - Tokens must be whitespace-free: the win32 scan splits a process's
+ *   CommandLine on whitespace, so a marker containing a space would fragment
+ *   and never match.
+ * - Identity markers are matched with `String.includes` against every token
+ *   (paths may fragment), so they must be substrings that cannot appear in
+ *   unrelated cmdlines by accident.
+ * - No token may be or contain `--help`: vsDebugServer.cjs prints usage and
+ *   exits when `--help` appears anywhere in its argv.
+ */
+
+/** Substring of the proxy worker's script-path argv token used as its identity marker. */
+export const PROXY_BOOTSTRAP_MARKER = 'proxy-bootstrap';
+
+/**
+ * Substring of the js-debug DAP server's script-path argv token used as its
+ * identity marker (issue #431). On its own this also matches VS Code's own
+ * js-debug instances — matchers must additionally require the owner-pid
+ * marker below, which only our spawns carry.
+ */
+export const JS_DEBUG_ADAPTER_MARKER = 'vsDebugServer';
+
+/** Records the PID of the mcp-debugger server that owned the session. */
+export const OWNER_PID_ARG_PREFIX = '--mcp-owner-pid=';
+export const SESSION_ID_ARG_PREFIX = '--mcp-session-id=';

--- a/src/implementations/process-launcher-impl.ts
+++ b/src/implementations/process-launcher-impl.ts
@@ -32,7 +32,9 @@ class ProxyProcessAdapter extends EventEmitter implements IProxyProcess {
 
   constructor(
     public readonly childProcess: IChildProcess,
-    public readonly sessionId: string
+    public readonly sessionId: string,
+    private readonly platform: NodeJS.Platform = process.platform,
+    private readonly treeKill?: (pid: number) => void
   ) {
     super();
 
@@ -377,12 +379,32 @@ class ProxyProcessAdapter extends EventEmitter implements IProxyProcess {
     if (this.killed || this.disposed) {
       return false; // Already killed or disposed
     }
-    
+
     // If waiting for initialization, fail it
     if (this.initializationState === 'waiting') {
       this.failInitialization(new Error('Process killed during initialization'));
     }
-    
+
+    // win32: any cross-process signal is TerminateProcess on the single PID —
+    // the worker's JS never runs, so its own adapter tree-kill cascade cannot
+    // fire, stranding detached adapter children like js-debug's vsDebugServer
+    // (issue #431). Sweep the tree FIRST, while the worker is still alive:
+    // taskkill /T can only discover children through a live parent. Skipped
+    // once the worker has exited — its PID may already be recycled.
+    if (
+      this.platform === 'win32' &&
+      this.treeKill &&
+      this._exitCode === null &&
+      this._signalCode === null &&
+      typeof this.childProcess.pid === 'number'
+    ) {
+      try {
+        this.treeKill(this.childProcess.pid);
+      } catch {
+        // Best-effort: fall through to the plain kill below.
+      }
+    }
+
     try {
       return this.childProcess.kill(signal);
     } catch {
@@ -396,7 +418,9 @@ class ProxyProcessAdapter extends EventEmitter implements IProxyProcess {
  */
 export class ProxyProcessLauncherImpl implements IProxyProcessLauncher {
   constructor(
-    private processManager: IProcessManager
+    private processManager: IProcessManager,
+    private platform: NodeJS.Platform = process.platform,
+    private treeKill?: (pid: number) => void
   ) {}
 
   launchProxy(
@@ -474,8 +498,21 @@ export class ProxyProcessLauncherImpl implements IProxyProcessLauncher {
       options
     );
     
-    // Create the proxy process adapter with the raw child process
-    return new ProxyProcessAdapter(childProcess, sessionId);
+    // Create the proxy process adapter with the raw child process. The
+    // win32 tree-kill (issue #431) defaults to spawning taskkill through the
+    // same process manager; injectable for tests.
+    const treeKill =
+      this.treeKill ??
+      ((pid: number) => {
+        const killer = this.processManager.spawn(
+          'taskkill',
+          ['/PID', String(pid), '/T', '/F'],
+          { stdio: 'ignore', windowsHide: true } as IProcessOptions
+        );
+        // Fire-and-forget: a missing taskkill must not crash the server.
+        killer.on('error', () => {});
+      });
+    return new ProxyProcessAdapter(childProcess, sessionId, this.platform, treeKill);
   }
 
 }

--- a/src/utils/proxy-orphan-reaper.ts
+++ b/src/utils/proxy-orphan-reaper.ts
@@ -32,15 +32,21 @@
  */
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import {
+  PROXY_BOOTSTRAP_MARKER,
+  JS_DEBUG_ADAPTER_MARKER,
+  OWNER_PID_ARG_PREFIX,
+  SESSION_ID_ARG_PREFIX
+} from '@debugmcp/shared';
 import { isPidAlive, SignalFn } from './jvm-orphan-reaper.js';
 import { scanLinux, scanDarwin, scanWindows, scanProcessArgs, type ScannedProcess } from './process-scan.js';
 
 const execFileAsync = promisify(execFile);
 
-/** Substring of the worker's script-path argv token used as the identity marker. */
-export const PROXY_BOOTSTRAP_MARKER = 'proxy-bootstrap';
-export const OWNER_PID_ARG_PREFIX = '--mcp-owner-pid=';
-export const SESSION_ID_ARG_PREFIX = '--mcp-session-id=';
+// Marker constants live in @debugmcp/shared so adapter packages can tag their
+// own spawns with the same markers this reaper matches (issue #431); re-exported
+// here to keep this module the reaper-side import point.
+export { PROXY_BOOTSTRAP_MARKER, JS_DEBUG_ADAPTER_MARKER, OWNER_PID_ARG_PREFIX, SESSION_ID_ARG_PREFIX };
 
 const LIST_TIMEOUT_MS = 5000;
 /** How often the POSIX escalation path polls for the SIGTERM cascade to finish. */
@@ -171,18 +177,17 @@ export async function listWindowsProxies(): Promise<TaggedProxy[]> {
 }
 
 /**
- * Two-factor identification: a token containing the proxy-bootstrap script
- * name AND a valid --mcp-owner-pid marker. Untagged bootstrap processes
- * (pre-upgrade workers) and malformed tags are ignored, never killed.
- *
- * @internal Exposed for unit tests; not part of the public module API.
+ * Two-factor identification: a token containing the identity marker AND a
+ * valid --mcp-owner-pid marker. Untagged processes (pre-upgrade workers,
+ * VS Code's own js-debug instances) and malformed tags are ignored, never
+ * killed.
  */
-export function parseProxyArgs(pid: number, args: string[]): TaggedProxy | null {
+function parseTaggedArgs(pid: number, args: string[], identityMarker: string): TaggedProxy | null {
   let hasMarker = false;
   let ownerPid = -1;
   let sessionId = '';
   for (const a of args) {
-    if (a.includes(PROXY_BOOTSTRAP_MARKER)) {
+    if (a.includes(identityMarker)) {
       hasMarker = true;
     } else if (a.startsWith(OWNER_PID_ARG_PREFIX)) {
       const v = Number(a.slice(OWNER_PID_ARG_PREFIX.length));
@@ -193,6 +198,24 @@ export function parseProxyArgs(pid: number, args: string[]): TaggedProxy | null 
   }
   if (!hasMarker || ownerPid <= 0) return null;
   return { pid, ownerPid, sessionId };
+}
+
+/** @internal Exposed for unit tests; not part of the public module API. */
+export function parseProxyArgs(pid: number, args: string[]): TaggedProxy | null {
+  return parseTaggedArgs(pid, args, PROXY_BOOTSTRAP_MARKER);
+}
+
+/**
+ * Matcher for js-debug DAP server processes (vsDebugServer.cjs) tagged at
+ * spawn time by JavascriptDebugAdapter.buildAdapterCommand (issue #431).
+ * These are spawned detached+unref'd by the proxy worker, so a hard-killed
+ * worker strands them outside every tree-kill path; the startup janitor
+ * feeds scan rows through this matcher to find them.
+ *
+ * @internal Exposed for unit tests; not part of the public module API.
+ */
+export function parseJsDebugAdapterArgs(pid: number, args: string[]): TaggedProxy | null {
+  return parseTaggedArgs(pid, args, JS_DEBUG_ADAPTER_MARKER);
 }
 
 const defaultSignal: SignalFn = (pid, signal) => process.kill(pid, signal);

--- a/src/utils/startup-janitor.ts
+++ b/src/utils/startup-janitor.ts
@@ -5,8 +5,9 @@
  * transport from coming up.
  *
  * Covers:
- * - Orphan debuggee JVMs and proxy workers, via ONE shared process scan
- *   feeding both reapers' matchers (previously two independent walks).
+ * - Orphan debuggee JVMs, proxy workers, and js-debug DAP servers (#431), via
+ *   ONE shared process scan feeding all reaper matchers (previously
+ *   independent walks).
  *   `MCP_SKIP_ORPHAN_REAPERS=1` skips this part for PID-namespaced containers
  *   where orphans are impossible.
  * - Stale per-session run logs (proxy-<id>.log / dap-trace-<id>.ndjson) under
@@ -22,7 +23,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { scanProcessArgs, type ProcessScanOptions, type ScannedProcess } from './process-scan.js';
 import { reapOrphanJvms, parseArgs, type ReapResult as JvmReapResult, type ReapOptions as JvmReapOptions } from './jvm-orphan-reaper.js';
-import { reapOrphanProxies, parseProxyArgs, type ReapResult as ProxyReapResult, type ReapOptions as ProxyReapOptions } from './proxy-orphan-reaper.js';
+import { reapOrphanProxies, parseProxyArgs, parseJsDebugAdapterArgs, type ReapResult as ProxyReapResult, type ReapOptions as ProxyReapOptions } from './proxy-orphan-reaper.js';
 
 export interface JanitorLogger {
   info?: (msg: string) => void;
@@ -39,6 +40,7 @@ export interface StartupJanitorOptions {
   scan?: (options: ProcessScanOptions) => Promise<ScannedProcess[]>;
   reapJvms?: (opts: JvmReapOptions) => Promise<JvmReapResult>;
   reapProxies?: (opts: ProxyReapOptions) => Promise<ProxyReapResult>;
+  reapJsDebugAdapters?: (opts: ProxyReapOptions) => Promise<ProxyReapResult>;
   sweep?: (opts: SweepOptions) => Promise<SweepResult>;
 }
 
@@ -77,16 +79,24 @@ async function runOrphanReapers(opts: StartupJanitorOptions, selfPid: number): P
     return;
   }
 
-  // Matchers are marker-based, so feeding every row to both is harmless —
-  // JVM -D markers only appear in java cmdlines and vice versa.
+  // Matchers are marker-based, so feeding every row to all three is harmless —
+  // each identity marker only appears in its own family's cmdlines.
   const jvmLister = async () =>
     processes.map((p) => parseArgs(p.pid, p.args)).filter((t): t is NonNullable<typeof t> => t !== null);
   const proxyLister = async () =>
     processes.map((p) => parseProxyArgs(p.pid, p.args)).filter((t): t is NonNullable<typeof t> => t !== null);
+  // js-debug DAP servers are spawned detached+unref'd, so a hard-killed worker
+  // strands them outside every tree-kill path (issue #431). Reusing the proxy
+  // reaper works because its win32 kill is taskkill /T /F — while the stranded
+  // vsDebugServer is alive, the tree kill also reaches the debuggee/watchdog
+  // children js-debug spawned beneath it.
+  const jsDebugAdapterLister = async () =>
+    processes.map((p) => parseJsDebugAdapterArgs(p.pid, p.args)).filter((t): t is NonNullable<typeof t> => t !== null);
 
-  const [jvmOutcome, proxyOutcome] = await Promise.allSettled([
+  const [jvmOutcome, proxyOutcome, jsDebugOutcome] = await Promise.allSettled([
     (opts.reapJvms ?? reapOrphanJvms)({ selfPid, logger: log, lister: jvmLister }),
     (opts.reapProxies ?? reapOrphanProxies)({ selfPid, logger: log, lister: proxyLister }),
+    (opts.reapJsDebugAdapters ?? reapOrphanProxies)({ selfPid, logger: log, lister: jsDebugAdapterLister }),
   ]);
 
   if (jvmOutcome.status === 'fulfilled') {
@@ -102,6 +112,13 @@ async function runOrphanReapers(opts: StartupJanitorOptions, selfPid: number): P
     }
   } else {
     log.warn?.(`[startup-janitor] Orphan proxy reaper failed: ${(proxyOutcome.reason as Error)?.message ?? String(proxyOutcome.reason)}`);
+  }
+  if (jsDebugOutcome.status === 'fulfilled') {
+    if (jsDebugOutcome.value.killed.length > 0) {
+      log.info?.(`[startup-janitor] Reaped ${jsDebugOutcome.value.killed.length} orphan js-debug adapter(s) from prior runs`);
+    }
+  } else {
+    log.warn?.(`[startup-janitor] Orphan js-debug adapter reaper failed: ${(jsDebugOutcome.reason as Error)?.message ?? String(jsDebugOutcome.reason)}`);
   }
 }
 

--- a/tests/unit/implementations/process-launcher-impl.test.ts
+++ b/tests/unit/implementations/process-launcher-impl.test.ts
@@ -172,4 +172,76 @@ describe('ProxyProcessLauncherImpl', () => {
     const result = proxyProcess.kill('SIGTERM');
     expect(result).toBe(false);
   });
+
+  // On win32 any cross-process signal is TerminateProcess on the single PID,
+  // which strands the detached js-debug adapter subtree (issue #431). kill()
+  // must sweep the worker's tree first, while the worker is still alive.
+  describe('win32 tree-kill on kill()', () => {
+    it('tree-kills via the injected treeKill before terminating the worker on win32', () => {
+      const treeKill = vi.fn();
+      const launcher = new ProxyProcessLauncherImpl(processManager, 'win32', treeKill);
+      const proxyProcess = launcher.launchProxy('./dist/proxy.js', 'session-tree');
+
+      const result = proxyProcess.kill('SIGKILL');
+
+      expect(result).toBe(true);
+      expect(treeKill).toHaveBeenCalledWith(2222);
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+      // Tree-kill must strike first: taskkill /T can only discover children
+      // while the parent is alive.
+      expect(treeKill.mock.invocationCallOrder[0]).toBeLessThan(
+        (child.kill as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]
+      );
+    });
+
+    it('does not tree-kill when the worker already exited (PID may be recycled)', () => {
+      const treeKill = vi.fn();
+      const launcher = new ProxyProcessLauncherImpl(processManager, 'win32', treeKill);
+      const proxyProcess = launcher.launchProxy('./dist/proxy.js', 'session-tree-exited');
+
+      child.emit('exit', 0, null);
+      proxyProcess.kill('SIGKILL');
+
+      expect(treeKill).not.toHaveBeenCalled();
+    });
+
+    it('does not tree-kill on POSIX platforms', () => {
+      const treeKill = vi.fn();
+      const launcher = new ProxyProcessLauncherImpl(processManager, 'linux', treeKill);
+      const proxyProcess = launcher.launchProxy('./dist/proxy.js', 'session-tree-posix');
+
+      proxyProcess.kill('SIGKILL');
+
+      expect(treeKill).not.toHaveBeenCalled();
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('still terminates the worker when treeKill throws', () => {
+      const treeKill = vi.fn(() => {
+        throw new Error('taskkill missing');
+      });
+      const launcher = new ProxyProcessLauncherImpl(processManager, 'win32', treeKill);
+      const proxyProcess = launcher.launchProxy('./dist/proxy.js', 'session-tree-throw');
+
+      const result = proxyProcess.kill('SIGKILL');
+
+      expect(result).toBe(true);
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('spawns taskkill /PID <pid> /T /F via the process manager by default on win32', () => {
+      const spawnSpy = vi.spyOn(processManager, 'spawn');
+      const launcher = new ProxyProcessLauncherImpl(processManager, 'win32');
+      const proxyProcess = launcher.launchProxy('./dist/proxy.js', 'session-tree-default');
+      spawnSpy.mockClear();
+
+      proxyProcess.kill('SIGKILL');
+
+      expect(spawnSpy).toHaveBeenCalledWith(
+        'taskkill',
+        ['/PID', '2222', '/T', '/F'],
+        expect.objectContaining({ windowsHide: true })
+      );
+    });
+  });
 });

--- a/tests/unit/utils/proxy-orphan-reaper-internals.test.ts
+++ b/tests/unit/utils/proxy-orphan-reaper-internals.test.ts
@@ -23,6 +23,7 @@ import { execFile } from 'node:child_process';
 import * as fsp from 'node:fs/promises';
 import {
   parseProxyArgs,
+  parseJsDebugAdapterArgs,
   killPosixWithEscalation,
   killWindows,
   listLinuxProxies,
@@ -109,6 +110,66 @@ describe('parseProxyArgs', () => {
         '--mcp-session-id=s',
       ]),
     ).toEqual({ pid: 9001, ownerPid: 42, sessionId: 's' });
+  });
+});
+
+describe('parseJsDebugAdapterArgs', () => {
+  /** A js-debug adapter cmdline exactly as spawned via buildAdapterCommand (issue #431). */
+  const adapterArgs = (ownerPid: number | string, sessionId = 'sess-1') => [
+    'C:\\nodejs\\node.exe',
+    'C:\\repo\\packages\\adapter-javascript\\vendor\\js-debug\\vsDebugServer.cjs',
+    '5679',
+    '127.0.0.1',
+    `--mcp-owner-pid=${ownerPid}`,
+    `--mcp-session-id=${sessionId}`,
+  ];
+
+  it('parses the full spawn shape including session id', () => {
+    expect(parseJsDebugAdapterArgs(9001, adapterArgs(42, 'abc-123'))).toEqual({
+      pid: 9001,
+      ownerPid: 42,
+      sessionId: 'abc-123',
+    });
+  });
+
+  it("returns null for VS Code's own js-debug instances (no owner marker)", () => {
+    expect(
+      parseJsDebugAdapterArgs(9001, [
+        'C:\\nodejs\\node.exe',
+        'c:\\Users\\x\\.vscode\\extensions\\ms-vscode.js-debug\\src\\vsDebugServer.cjs',
+        '5680',
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns null when the owner marker is present but the vsDebugServer token is absent', () => {
+    // e.g. a tagged proxy worker row — must stay matched by parseProxyArgs only
+    expect(
+      parseJsDebugAdapterArgs(9001, [
+        'node',
+        '/app/dist/proxy/proxy-bootstrap.js',
+        '--mcp-owner-pid=42',
+        '--mcp-session-id=s',
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns null when owner pid is non-numeric, zero, or negative', () => {
+    expect(parseJsDebugAdapterArgs(9001, adapterArgs('not-a-pid'))).toBeNull();
+    expect(parseJsDebugAdapterArgs(9001, adapterArgs(0))).toBeNull();
+    expect(parseJsDebugAdapterArgs(9001, adapterArgs(-5))).toBeNull();
+  });
+
+  it('tolerates a missing session id by leaving it empty', () => {
+    expect(
+      parseJsDebugAdapterArgs(9001, [
+        'node',
+        '/repo/vendor/js-debug/vsDebugServer.cjs',
+        '5679',
+        '127.0.0.1',
+        '--mcp-owner-pid=42',
+      ]),
+    ).toEqual({ pid: 9001, ownerPid: 42, sessionId: '' });
   });
 });
 

--- a/tests/unit/utils/startup-janitor.test.ts
+++ b/tests/unit/utils/startup-janitor.test.ts
@@ -24,11 +24,33 @@ describe('runStartupJanitor', () => {
     args: ['node', 'dist/proxy/proxy-bootstrap.js', '--mcp-owner-pid=7', '--mcp-session-id=s1']
   };
   const noiseRow: ScannedProcess = { pid: 300, args: ['bash'] };
+  // A js-debug DAP server tagged at spawn by buildAdapterCommand (issue #431)
+  const vsDebugServerRow: ScannedProcess = {
+    pid: 400,
+    args: [
+      'C:\\nodejs\\node.exe',
+      'C:\\repo\\packages\\adapter-javascript\\vendor\\js-debug\\vsDebugServer.cjs',
+      '5679',
+      '127.0.0.1',
+      '--mcp-owner-pid=7',
+      '--mcp-session-id=s2'
+    ]
+  };
+  // VS Code's own js-debug instance — unmarked, must never be reaped
+  const foreignVsDebugServerRow: ScannedProcess = {
+    pid: 500,
+    args: [
+      'C:\\nodejs\\node.exe',
+      'c:\\Users\\x\\.vscode\\extensions\\ms-vscode.js-debug\\src\\vsDebugServer.cjs',
+      '5680'
+    ]
+  };
 
-  it('scans once and feeds both reapers from the same result', async () => {
-    const scan = vi.fn().mockResolvedValue([jvmRow, proxyRow, noiseRow]);
+  it('scans once and feeds all three reapers from the same result', async () => {
+    const scan = vi.fn().mockResolvedValue([jvmRow, proxyRow, noiseRow, vsDebugServerRow, foreignVsDebugServerRow]);
     const reapJvms = vi.fn().mockResolvedValue({ scanned: 1, killed: [], skipped: [], errors: [] });
     const reapProxies = vi.fn().mockResolvedValue({ scanned: 1, killed: [], skipped: [], errors: [] });
+    const reapJsDebugAdapters = vi.fn().mockResolvedValue({ scanned: 1, killed: [], skipped: [], errors: [] });
 
     await runStartupJanitor({
       logger: makeLogger(),
@@ -37,6 +59,7 @@ describe('runStartupJanitor', () => {
       scan,
       reapJvms,
       reapProxies,
+      reapJsDebugAdapters,
       sweep: vi.fn().mockResolvedValue({ removedRuns: 0 })
     });
 
@@ -52,12 +75,19 @@ describe('runStartupJanitor', () => {
     await expect(proxyLister()).resolves.toEqual([
       { pid: 200, ownerPid: 7, sessionId: 's1' }
     ]);
+    // The marked vsDebugServer row reaches only the adapter reaper; VS Code's
+    // unmarked instance reaches none.
+    const adapterLister = reapJsDebugAdapters.mock.calls[0][0].lister;
+    await expect(adapterLister()).resolves.toEqual([
+      { pid: 400, ownerPid: 7, sessionId: 's2' }
+    ]);
   });
 
   it('skips the reapers entirely when MCP_SKIP_ORPHAN_REAPERS=1', async () => {
     const scan = vi.fn();
     const reapJvms = vi.fn();
     const reapProxies = vi.fn();
+    const reapJsDebugAdapters = vi.fn();
 
     await runStartupJanitor({
       logger: makeLogger(),
@@ -66,12 +96,14 @@ describe('runStartupJanitor', () => {
       scan,
       reapJvms,
       reapProxies,
+      reapJsDebugAdapters,
       sweep: vi.fn().mockResolvedValue({ removedRuns: 0 })
     });
 
     expect(scan).not.toHaveBeenCalled();
     expect(reapJvms).not.toHaveBeenCalled();
     expect(reapProxies).not.toHaveBeenCalled();
+    expect(reapJsDebugAdapters).not.toHaveBeenCalled();
   });
 
   it('logs kill counts and never throws when a reaper rejects', async () => {
@@ -84,6 +116,12 @@ describe('runStartupJanitor', () => {
       errors: []
     });
     const reapProxies = vi.fn().mockRejectedValue(new Error('reaper exploded'));
+    const reapJsDebugAdapters = vi.fn().mockResolvedValue({
+      scanned: 1,
+      killed: [{ pid: 400, ownerPid: 7, sessionId: 's2' }],
+      skipped: [],
+      errors: []
+    });
 
     await expect(runStartupJanitor({
       logger,
@@ -92,10 +130,12 @@ describe('runStartupJanitor', () => {
       scan,
       reapJvms,
       reapProxies,
+      reapJsDebugAdapters,
       sweep: vi.fn().mockResolvedValue({ removedRuns: 0 })
     })).resolves.toBeUndefined();
 
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Reaped 1 orphan JVM'));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Reaped 1 orphan js-debug adapter'));
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('reaper exploded'));
   });
 });


### PR DESCRIPTION
## Problem

Fixes #431. js-debug DAP servers (`vsDebugServer.cjs`) are spawned `detached:true` + `unref()` by the proxy worker, and their PID never leaves the worker's memory. When the worker dies hard (win32 `TerminateProcess` — force-kill escalations, interrupted test runs), nothing can reach them: the startup orphan reaper's matcher requires the `proxy-bootstrap` marker, and win32 has no process-group kill. On the reporting dev box 14 of them had accumulated, holding file locks into `vendor/js-debug/` that broke `pnpm run clean:vendor` with `EPERM`.

## Fix (two prongs)

**Cleanup — make stranded instances findable and reapable:**
- `JavascriptDebugAdapter.buildAdapterCommand` now appends `--mcp-owner-pid=<pid>` / `--mcp-session-id=<id>` after the host argument. `vsDebugServer.cjs` reads only `argv[2]` (port) and `argv[3]` (host) and ignores trailing tokens, so the markers are inert at runtime (same trick as the #343 proxy-worker tagging). Tokens are whitespace-free (the win32 scan splits `CommandLine` on whitespace) and never contain `--help` (which would make vsDebugServer print usage instead of serving).
- The startup janitor feeds its existing single process scan through a **third matcher** (`parseJsDebugAdapterArgs`): two-factor — a `vsDebugServer` token AND a valid owner marker — so VS Code's own js-debug instances can never match. Reaping reuses the proxy reaper's kill paths; on win32 that's `taskkill /PID <pid> /T /F`, which also sweeps the debuggee/watchdog children js-debug spawned beneath the stranded server.
- Marker constants moved to `@debugmcp/shared` (`process-markers.ts`) so the adapter package can import them; re-exported from `proxy-orphan-reaper.ts` so existing importers are untouched.

**Prevention — stop creating the orphans in the first place:**
- On win32, `ProxyProcessAdapter.kill()` now fires `taskkill /PID <workerPid> /T /F` *before* the plain kill, while the worker is still alive (taskkill `/T` can only discover children through a live parent). This covers all three ProxyManager hard-kill sites with one seam. Guarded by the adapter's tracked exit state so an already-exited (possibly recycled) PID is never tree-killed. On win32 every `childProcess.kill()` signal was already a hard `TerminateProcess`, so tree semantics is strictly what was intended; POSIX behavior is unchanged.

## Notes / accepted scope

- The tree-kill also applies to the dap-core `killProcess` command path and the IPC-test path — both mean "kill the worker", so this is intended.
- Double-reap race (worker reaper's `/T` killing the vsDebugServer before the adapter reaper gets to it) is benign: `killWindows` treats taskkill exit 128/1 as already-gone.
- POSIX reap of a stranded vsDebugServer is single-PID (`SIGTERM`→`SIGKILL`); a process-group sweep for its children is a possible follow-up, but the observed issue is win32-scoped.
- Dry-run command snapshots now include the marker tokens (display-only).

## Verification

- TDD throughout; new tests: `parseJsDebugAdapterArgs` matcher (5), janitor third-matcher wiring (3 extended), adapter argv markers (3), win32 tree-kill in `kill()` (5).
- Full unit suite: 214 files / 3857 tests green; coverage 93.01% stmts / 83.0% branch (4114 tests across projects).
- **Live repro on the reporting Windows box**: started a JS launch session (markers visible in the process table), force-killed the proxy worker single-PID → vsDebugServer stranded with a dead PPID (bug reproduced); restarted the server → the janitor reaped the marked orphan within seconds, including the debuggee grandchild. No `vsDebugServer` processes remained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)