### PR TITLE
fix(proxy): eliminate dangling rejections behind the seed-1038859894 flake (#420)

### DIFF
--- a/scripts/flake-hunt.mjs
+++ b/scripts/flake-hunt.mjs
@@ -65,7 +65,9 @@ if (failures.length === 0) {
 } else {
   console.error(`[flake-hunt] ✗ ${failures.length}/${RUNS} run(s) failed. Reproduce with:`);
   for (const seed of failures) {
-    console.error(`    vitest run --project ${PROJECT} --sequence.seed=${seed}`);
+    // Keep --sequence.shuffle.tests: the committed config shuffles files only,
+    // so omitting it would not reproduce a within-file ordering failure.
+    console.error(`    vitest run --project ${PROJECT} --sequence.seed=${seed} --sequence.shuffle.tests`);
   }
   process.exit(1);
 }

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -667,27 +667,34 @@ export class DapProxyWorker {
 
     this.connectionManager.setupEventHandlers(this.dapClient, {
       onInitialized: async () => {
-        // Update adapter state
-        if (this.adapterPolicy.updateStateOnEvent) {
-          this.adapterPolicy.updateStateOnEvent('initialized', {}, this.adapterState);
-        }
-
-        if (this.adapterPolicy.requiresCommandQueueing()) {
-          this.logger!.info(`[Worker] DAP "initialized" (${this.adapterPolicy.name}) received; forwarding event and draining queue.`);
-          this.sendDapEvent('initialized', {});
-          await this.drainCommandQueue();
-        } else {
-          // If we're deferring initialized handling (e.g., to send launch/attach first),
-          // mark the event as pending and resolve the promise to signal it arrived
-          if (this.deferInitializedHandling) {
-            this.logger!.info('[Worker] DAP "initialized" event received but deferred until after launch/attach');
-            this.initializedEventPending = true;
-            if (this.initializedEventResolver) {
-              this.initializedEventResolver();
-            }
-          } else {
-            await this.handleInitializedEvent();
+        // Nothing awaits this listener — a rejection escaping it has no
+        // handler and surfaces as an unhandled rejection (issue #420), so
+        // failures are contained and logged here.
+        try {
+          // Update adapter state
+          if (this.adapterPolicy.updateStateOnEvent) {
+            this.adapterPolicy.updateStateOnEvent('initialized', {}, this.adapterState);
           }
+
+          if (this.adapterPolicy.requiresCommandQueueing()) {
+            this.logger!.info(`[Worker] DAP "initialized" (${this.adapterPolicy.name}) received; forwarding event and draining queue.`);
+            this.sendDapEvent('initialized', {});
+            await this.drainCommandQueue();
+          } else {
+            // If we're deferring initialized handling (e.g., to send launch/attach first),
+            // mark the event as pending and resolve the promise to signal it arrived
+            if (this.deferInitializedHandling) {
+              this.logger!.info('[Worker] DAP "initialized" event received but deferred until after launch/attach');
+              this.initializedEventPending = true;
+              if (this.initializedEventResolver) {
+                this.initializedEventResolver();
+              }
+            } else {
+              await this.handleInitializedEvent();
+            }
+          }
+        } catch (error) {
+          this.logger!.error('[Worker] Error handling DAP "initialized" event:', error);
         }
       },
       onOutput: (body) => {

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -107,6 +107,14 @@ interface ProxyRuntimeEnvironment {
   cwd: () => string;
 }
 
+/** Minimal emitter surface shared by IProxyProcess and its stderr stream. */
+interface RemovableEmitter {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string, listener: (...args: any[]) => void): unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  removeListener(event: string, listener: (...args: any[]) => void): unknown;
+}
+
 const DEFAULT_RUNTIME_ENVIRONMENT: ProxyRuntimeEnvironment = {
   moduleUrl: import.meta.url,
   cwd: () => process.cwd()
@@ -123,6 +131,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     resolve: (response: DebugProtocol.Response) => void;
     reject: (error: Error) => void;
     command: string;
+    /** Parent-side backstop timer; must be cleared wherever the entry settles (issue #420). */
+    timer?: NodeJS.Timeout;
   }>();
   private isInitialized = false;
   private isStopped = false;
@@ -155,6 +165,18 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private activeLaunchBarrierRequestId: string | null = null;
   private proxyMessageCounter = 0;
   private exitEmitted = false;
+  /**
+   * Listeners installed on the proxy process (and its stderr stream) by
+   * setupEventHandlers, tracked so a failed start() can detach them — a stale
+   * process driving handleProxyExit after start() already rejected would fire
+   * rejections with nobody listening (issue #420).
+   */
+  private trackedProxyListeners: Array<{
+    emitter: RemovableEmitter;
+    event: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    listener: (...args: any[]) => void;
+  }> = [];
 
   constructor(
     private adapter: IDebugAdapter | null,  // Optional adapter for language-agnostic support
@@ -212,6 +234,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     }
 
     if (!this.proxyProcess || typeof this.proxyProcess.pid === 'undefined') {
+      // Clear the handle so this manager is not permanently stuck on the
+      // 'Proxy already running' guard above (issue #420).
+      this.proxyProcess = null;
       throw new Error('Proxy process is invalid or PID is missing');
     }
 
@@ -256,12 +281,27 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       } : null
     });
 
+    // From here on, any failure must detach the listeners just installed on
+    // the proxy process: start()'s caller discards this manager on failure,
+    // and a stale process handle still wired to handleProxyExit would reject
+    // pending requests into a void (issue #420).
+    try {
+      await this.startInitializationSequence(initCommand);
+    } catch (error) {
+      this.detachProxyEventHandlers();
+      throw error;
+    }
+  }
+
+  /** Send init (with retry) and await readiness; extracted so start() can detach on any failure. */
+  private async startInitializationSequence(initCommand: object): Promise<void> {
     // Send init command with retry logic
     await this.sendInitWithRetry(initCommand);
 
     // Wait for initialization or dry run completion
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
+        cleanup();
         reject(new Error(ErrorMessages.proxyInitTimeout(30)));
       }, 30000);
 
@@ -365,22 +405,28 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
     // Wait for graceful exit or force kill after timeout
     return new Promise((resolve) => {
+      const onExit = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+
       const timeout = setTimeout(() => {
         this.logger.warn(`[ProxyManager] Timeout waiting for proxy exit. Force killing.`);
         if (!process.killed) {
           process.kill('SIGKILL');
         }
+        // Detach the once-listener: it never fired, and leaving it would
+        // accumulate a dead handler on the process object (issue #420).
+        process.removeListener('exit', onExit);
         resolve();
       }, 5000);
 
-      process.once('exit', () => {
-        clearTimeout(timeout);
-        resolve();
-      });
+      process.once('exit', onExit);
 
       // If already killed/exited, resolve immediately
       if (process.killed || process.exitCode !== null) {
         clearTimeout(timeout);
+        process.removeListener('exit', onExit);
         resolve();
       }
     });
@@ -461,10 +507,33 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     }
 
     return new Promise<T>((resolve, reject) => {
+      // Timeout handler. The worker/socket timeout (timeoutMs, default 30s)
+      // fires first and produces the actionable error; this parent timer is a
+      // backstop that only fires if the worker never responds at all. The
+      // handle is stored on the pending entry and cleared wherever the entry
+      // settles — a fired-but-uncleared backstop would otherwise reject with
+      // nobody listening long after the caller has moved on (issue #420).
+      const effectiveTimeoutMs =
+        (options?.timeoutMs ?? this.defaultDapRequestTimeoutMs) + this.dapParentMarginMs;
+      const timer = setTimeout(() => {
+        if (this.pendingDapRequests.has(requestId)) {
+          this.pendingDapRequests.delete(requestId);
+          if (this.dapState) {
+            this.dapState = removePendingRequest(this.dapState, requestId);
+          }
+          if (this.activeLaunchBarrier && this.activeLaunchBarrierRequestId === requestId) {
+            this.clearActiveLaunchBarrier();
+          }
+          reject(new Error(ErrorMessages.dapRequestTimeout(command, Math.round(effectiveTimeoutMs / 1000))));
+        }
+      }, effectiveTimeoutMs);
+      timer.unref?.();
+
       this.pendingDapRequests.set(requestId, {
         resolve: resolve as (value: DebugProtocol.Response) => void,
         reject,
-        command
+        command,
+        timer
       });
 
       // Mirror into functional core for observability (seq is placeholder; ProxyManager remains authoritative)
@@ -480,30 +549,13 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       try {
         this.sendCommand(commandToSend);
       } catch (error) {
+        clearTimeout(timer);
         this.pendingDapRequests.delete(requestId);
         if (barrier) {
           this.clearActiveLaunchBarrier(barrier);
         }
         reject(error);
       }
-
-      // Timeout handler. The worker/socket timeout (timeoutMs, default 30s)
-      // fires first and produces the actionable error; this parent timer is a
-      // backstop that only fires if the worker never responds at all.
-      const effectiveTimeoutMs =
-        (options?.timeoutMs ?? this.defaultDapRequestTimeoutMs) + this.dapParentMarginMs;
-      setTimeout(() => {
-        if (this.pendingDapRequests.has(requestId)) {
-          this.pendingDapRequests.delete(requestId);
-          if (this.dapState) {
-            this.dapState = removePendingRequest(this.dapState, requestId);
-          }
-          if (this.activeLaunchBarrier && this.activeLaunchBarrierRequestId === requestId) {
-            this.clearActiveLaunchBarrier();
-          }
-          reject(new Error(ErrorMessages.dapRequestTimeout(command, Math.round(effectiveTimeoutMs / 1000))));
-        }
-      }, effectiveTimeoutMs);
     });
   }
 
@@ -627,7 +679,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           const handler = () => {
             if (resolved) return;
             resolved = true;
-            if (timer) clearTimeout(timer);
+            // Detach on success too — this listener is registered with on(),
+            // and each un-removed acknowledgment handler would otherwise stay
+            // on the manager for its lifetime (issue #420).
+            cleanup();
             resolve(true);
           };
 
@@ -748,30 +803,40 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private setupEventHandlers(): void {
     if (!this.proxyProcess) return;
 
+    // Track every listener installed here so a failed start() can detach the
+    // lot (issue #420); see trackedProxyListeners.
+    this.trackedProxyListeners = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const track = (emitter: RemovableEmitter, event: string, listener: (...args: any[]) => void) => {
+      emitter.on(event, listener);
+      this.trackedProxyListeners.push({ emitter, event, listener });
+    };
+    const proc = this.proxyProcess as unknown as RemovableEmitter;
+
     // Handle IPC messages
-    this.proxyProcess.on('message', (rawMessage: unknown) => {
+    track(proc, 'message', (rawMessage: unknown) => {
       this.handleProxyMessage(rawMessage);
     });
 
-    this.proxyProcess.on('ipc-send-start', (data: { pid?: number; connectedBefore?: boolean; summary?: string; timestamp?: number }) => {
+    track(proc, 'ipc-send-start', (data: { pid?: number; connectedBefore?: boolean; summary?: string; timestamp?: number }) => {
       this.logger.debug(
         `[ProxyManager] IPC send start pid=${data?.pid ?? 'unknown'} connected=${data?.connectedBefore} summary=${data?.summary ?? 'n/a'}`
       );
     });
 
-    this.proxyProcess.on('ipc-send-complete', (data: { pid?: number; connectedAfter?: boolean; summary?: string; timestamp?: number; queueSizeBefore?: number; queueSizeAfter?: number }) => {
+    track(proc, 'ipc-send-complete', (data: { pid?: number; connectedAfter?: boolean; summary?: string; timestamp?: number; queueSizeBefore?: number; queueSizeAfter?: number }) => {
       this.logger.debug(
         `[ProxyManager] IPC send complete pid=${data?.pid ?? 'unknown'} connected=${data?.connectedAfter} summary=${data?.summary ?? 'n/a'} queueBefore=${data?.queueSizeBefore ?? 'n/a'} queueAfter=${data?.queueSizeAfter ?? 'n/a'}`
       );
     });
 
-    this.proxyProcess.on('ipc-send-failed', (data: { pid?: number; killed?: boolean; childProcessKilled?: boolean | string; summary?: string; timestamp?: number }) => {
+    track(proc, 'ipc-send-failed', (data: { pid?: number; killed?: boolean; childProcessKilled?: boolean | string; summary?: string; timestamp?: number }) => {
       this.logger.warn(
         `[ProxyManager] IPC send returned false pid=${data?.pid ?? 'unknown'} killed=${data?.killed} childKilled=${data?.childProcessKilled} summary=${data?.summary ?? 'n/a'}`
       );
     });
 
-    this.proxyProcess.on('ipc-send-error', (data: { pid?: number; error?: string; summary?: string; timestamp?: number }) => {
+    track(proc, 'ipc-send-error', (data: { pid?: number; error?: string; summary?: string; timestamp?: number }) => {
       this.logger.error(
         `[ProxyManager] IPC send error pid=${data?.pid ?? 'unknown'} error=${data?.error ?? 'unknown'} summary=${data?.summary ?? 'n/a'}`
       );
@@ -783,19 +848,22 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // patterns (issue #151). Scoped to this process's handlers so a pending
     // partial line survives until this stream's own 'end'/'close', and never
     // bleeds into a later process's stderr.
-    const stderrLineBuffer = new LineBuffer();
-    this.proxyProcess.stderr?.on('data', (data: Buffer | string) => {
-      this.recordStderrLines(stderrLineBuffer.append(data.toString()));
-    });
-    // Flush the trailing partial line only once the stream itself is done.
-    // Flushing on process 'exit' would be wrong: the pipe can still deliver
-    // the rest of a split line afterwards, re-creating the straddle leak.
-    const flushStderr = () => this.recordStderrLines(stderrLineBuffer.flush());
-    this.proxyProcess.stderr?.on('end', flushStderr);
-    this.proxyProcess.stderr?.on('close', flushStderr);
+    const stderr = this.proxyProcess.stderr as unknown as RemovableEmitter | null;
+    if (stderr) {
+      const stderrLineBuffer = new LineBuffer();
+      track(stderr, 'data', (data: Buffer | string) => {
+        this.recordStderrLines(stderrLineBuffer.append(data.toString()));
+      });
+      // Flush the trailing partial line only once the stream itself is done.
+      // Flushing on process 'exit' would be wrong: the pipe can still deliver
+      // the rest of a split line afterwards, re-creating the straddle leak.
+      const flushStderr = () => this.recordStderrLines(stderrLineBuffer.flush());
+      track(stderr, 'end', flushStderr);
+      track(stderr, 'close', flushStderr);
+    }
 
     // Handle exit
-    this.proxyProcess.on('exit', (code: number | null, signal: string | null) => {
+    track(proc, 'exit', (code: number | null, signal: string | null) => {
       this.logger.info(`[ProxyManager] Proxy exited. Code: ${code}, Signal: ${signal}`);
 
       this.lastExitDetails = {
@@ -816,11 +884,30 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     });
 
     // Handle errors
-    this.proxyProcess.on('error', (err: Error) => {
+    track(proc, 'error', (err: Error) => {
       this.logger.error(`[ProxyManager] Proxy error:`, err);
       this.emit('error', err);
       this.cleanup();
     });
+  }
+
+  /**
+   * Remove the listeners setupEventHandlers installed on the proxy process.
+   * Called when start() fails: the manager is about to be discarded, and a
+   * stale process handle must not keep driving handleProxyExit/cleanup —
+   * those reject pending requests with nobody left to listen (issue #420).
+   * The caller (SessionManager) still runs stop(), which operates on the
+   * process handle directly and needs none of these listeners.
+   */
+  private detachProxyEventHandlers(): void {
+    for (const { emitter, event, listener } of this.trackedProxyListeners) {
+      try {
+        emitter.removeListener(event, listener);
+      } catch {
+        // Best-effort: a torn-down stream may throw on removeListener.
+      }
+    }
+    this.trackedProxyListeners = [];
   }
 
   /**
@@ -972,6 +1059,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     }
 
     this.pendingDapRequests.delete(message.requestId);
+    if (pending.timer) clearTimeout(pending.timer);
     // Mirror completion into functional core
     if (this.dapState) {
       this.dapState = removePendingRequest(this.dapState, message.requestId);
@@ -1148,6 +1236,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
     // Clean up pending requests
     this.pendingDapRequests.forEach(pending => {
+      if (pending.timer) clearTimeout(pending.timer);
       pending.reject(new Error('Proxy exited'));
     });
     this.pendingDapRequests.clear();
@@ -1167,6 +1256,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     if (this.pendingDapRequests.size > 0) {
       this.logger.debug(`[ProxyManager] Clearing ${this.pendingDapRequests.size} pending DAP requests during cleanup`);
       for (const pending of this.pendingDapRequests.values()) {
+        if (pending.timer) clearTimeout(pending.timer);
         pending.reject(new Error(`Request cancelled during proxy shutdown: ${pending.command}`));
       }
       this.pendingDapRequests.clear();

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -588,6 +588,36 @@ describe('DapProxyWorker', () => {
       }
     });
     
+    it('resolves (not rejects) the onInitialized event handler when worker state is missing (issue #420)', async () => {
+      // Event listeners are fire-and-forget: nothing awaits the async
+      // onInitialized handler, so a rejection escaping it surfaces as an
+      // unhandled rejection — in production and as cross-test noise under
+      // shuffled unit runs.
+      const connectionStub = {
+        setupEventHandlers: vi.fn()
+      };
+
+      (worker as any).logger = mockLogger;
+      (worker as any).dapClient = mockDapClient;
+      (worker as any).connectionManager = connectionStub;
+      (worker as any).adapterPolicy = DefaultAdapterPolicy;
+      (worker as any).adapterState = DefaultAdapterPolicy.createInitialState();
+      (worker as any).setupDapEventHandlers();
+
+      const handlers = connectionStub.setupEventHandlers.mock.calls[0][1] as {
+        onInitialized: () => Promise<void>;
+      };
+
+      // Tear down the state handleInitializedEvent requires
+      (worker as any).currentInitPayload = null;
+
+      await expect(handlers.onInitialized()).resolves.toBeUndefined();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('initialized'),
+        expect.anything()
+      );
+    });
+
     it('forwards logMessage and suspendPolicy on initial breakpoints (issue #235)', async () => {
       const connectionStub = {
         setBreakpoints: vi.fn().mockResolvedValue({ body: { breakpoints: [] } }),

--- a/tests/proxy/go-initialized-fallback.test.ts
+++ b/tests/proxy/go-initialized-fallback.test.ts
@@ -336,15 +336,21 @@ describe('Go initialized event fallback', () => {
 
     // Start the connection — it will wait for initialized
     const connectPromise = (worker as any).startAdapterAndConnect(GO_PAYLOAD);
-
-    // Advance past Phase 1 (2s) and Phase 2 (10s)
-    await vi.advanceTimersByTimeAsync(13000);
-
-    await expect(connectPromise).rejects.toThrow(
+    // Attach the rejection expectation BEFORE the timer advance: the async
+    // fake-timer loop yields through real ticks, where a handler-less
+    // rejection surfaces as unhandled (issue #420).
+    const rejection = expect(connectPromise).rejects.toThrow(
       /Timeout waiting for initialized event \(after launch fallback\)/
     );
 
-    vi.useRealTimers();
+    try {
+      // Advance past Phase 1 (2s) and Phase 2 (10s)
+      await vi.advanceTimersByTimeAsync(13000);
+
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   /**

--- a/tests/unit/proxy/proxy-manager-message-handling.test.ts
+++ b/tests/unit/proxy/proxy-manager-message-handling.test.ts
@@ -703,10 +703,14 @@ describe('ProxyManager Message Handling', () => {
       vi.useFakeTimers();
 
       const request = proxyManager.sendDapRequest('threads');
+      // Attach the rejection expectation BEFORE the timer advance — the async
+      // fake-timer loop yields through real ticks, where a handler-less
+      // rejection surfaces as unhandled (issue #420).
+      const rejection = expect(request).rejects.toThrow(/Debug adapter did not respond/i);
 
       await vi.advanceTimersByTimeAsync(35_000);
 
-      await expect(request).rejects.toThrow(/Debug adapter did not respond/i);
+      await rejection;
 
       const pending = (proxyManager as unknown as { pendingDapRequests: Map<string, unknown> }).pendingDapRequests;
       expect(pending.size).toBe(0);
@@ -1091,11 +1095,14 @@ describe('ProxyManager Message Handling', () => {
         createInitialState('timeout-session');
 
       const requestPromise = proxyManager.sendDapRequest('launch', {});
+      // Attach before advancing so the rejection is never handler-less at a
+      // real tick boundary (issue #420).
+      const rejection = expect(requestPromise).rejects.toThrow(/Debug adapter did not respond to 'launch'/);
 
       await vi.advanceTimersByTimeAsync(35000);
 
       try {
-        await expect(requestPromise).rejects.toThrow(/Debug adapter did not respond to 'launch'/);
+        await rejection;
         expect(barrier.dispose).toHaveBeenCalled();
       } finally {
         vi.useRealTimers();

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import path from 'path';
 import { pathToFileURL } from 'url';
@@ -86,6 +86,20 @@ describe('ProxyManager.start', () => {
       fileSystem,
       logger
     );
+  });
+
+  // Under shuffled ordering (issue #420, seed 1038859894) anything this file
+  // leaves behind — fake timers, live listeners between the manager and its
+  // fake process, stray setImmediate emits — fires into whichever test runs
+  // next and surfaces there as unhandled-rejection noise. Tear it all down.
+  afterEach(async () => {
+    vi.useRealTimers();
+    // Detach the fake first so any straggling emit finds no manager handlers.
+    fakeProcess.removeAllListeners();
+    (fakeProcess.stderr as unknown as EventEmitter | null)?.removeAllListeners();
+    proxyManager.removeAllListeners();
+    // Flush this test's stray macrotasks inside its own attribution window.
+    await new Promise((resolve) => setImmediate(resolve));
   });
 
   const baseConfig: ProxyConfig = {
@@ -499,9 +513,13 @@ describe('ProxyManager.start', () => {
 
       const startPromise = proxyManager.start(baseConfig);
 
+      // Attach the rejection expectation BEFORE driving the rejection: the
+      // async fake-timer loop yields through real ticks, where an unhandled
+      // rejection would otherwise be flagged (issue #420).
+      const rejection = expect(startPromise).rejects.toThrow(/Failed to initialize proxy after 6 attempts\. Last error: ipc failure/);
       await vi.advanceTimersByTimeAsync(16500);
 
-      await expect(startPromise).rejects.toThrow(/Failed to initialize proxy after 6 attempts\. Last error: ipc failure/);
+      await rejection;
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Error sending init on attempt 6'));
     });
   });
@@ -526,10 +544,11 @@ describe('ProxyManager.start', () => {
     });
 
     try {
+      const rejection = expect(startPromise).rejects.toThrow(/Debug proxy initialization did not complete within 30s/);
       await vi.advanceTimersByTimeAsync(30000);
       await vi.runOnlyPendingTimersAsync();
       await Promise.resolve();
-      await expect(startPromise).rejects.toThrow(/Debug proxy initialization did not complete within 30s/);
+      await rejection;
     } finally {
       vi.useRealTimers();
     }
@@ -568,12 +587,13 @@ describe('ProxyManager.start', () => {
       });
 
       const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+      const rejection = expect(startPromise).rejects.toThrow(
+        /Proxy exit details -> code=2 signal=SIGTERM stderr:\nboot failure/
+      );
       // Drive the init-retry backoff via fake timers: 35s covers the ~15.5s
       // backoff schedule plus timeout margins.
       await vi.advanceTimersByTimeAsync(35000);
-      await expect(startPromise).rejects.toThrow(
-        /Proxy exit details -> code=2 signal=SIGTERM stderr:\nboot failure/
-      );
+      await rejection;
     } finally {
       vi.useRealTimers();
     }
@@ -791,12 +811,13 @@ describe('ProxyManager.start', () => {
       });
 
       const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+      const rejection = expect(startPromise).rejects.toThrow(
+        /Proxy exit details -> code=2 signal=SIGTERM stderr:\nlate boot failure/
+      );
       // Drive the init-retry backoff via fake timers: 35s covers the ~15.5s
       // backoff schedule plus timeout margins.
       await vi.advanceTimersByTimeAsync(35000);
-      await expect(startPromise).rejects.toThrow(
-        /Proxy exit details -> code=2 signal=SIGTERM stderr:\nlate boot failure/
-      );
+      await rejection;
     } finally {
       vi.useRealTimers();
     }
@@ -886,26 +907,29 @@ describe('ProxyManager.start', () => {
   describe('stop and cleanup behavior', () => {
     it('sends terminate and force kills when proxy does not exit in time', async () => {
       vi.useFakeTimers();
+      try {
+        (proxyManager as unknown as { proxyProcess: IProxyProcess | null }).proxyProcess = fakeProcess;
+        (proxyManager as unknown as { sessionId: string | null }).sessionId = baseConfig.sessionId;
 
-      (proxyManager as unknown as { proxyProcess: IProxyProcess | null }).proxyProcess = fakeProcess;
-      (proxyManager as unknown as { sessionId: string | null }).sessionId = baseConfig.sessionId;
+        fakeProcess.killed = false;
+        fakeProcess.exitCode = null;
+        fakeProcess.send.mockClear();
+        fakeProcess.kill.mockClear();
 
-      fakeProcess.killed = false;
-      fakeProcess.exitCode = null;
-      fakeProcess.send.mockClear();
-      fakeProcess.kill.mockClear();
+        const stopPromise = proxyManager.stop();
 
-      const stopPromise = proxyManager.stop();
+        await vi.advanceTimersByTimeAsync(5000);
+        await vi.runOnlyPendingTimersAsync();
+        await stopPromise;
 
-      await vi.advanceTimersByTimeAsync(5000);
-      await vi.runOnlyPendingTimersAsync();
-      await stopPromise;
-
-      expect(fakeProcess.send).toHaveBeenCalledWith({ cmd: 'terminate', sessionId: baseConfig.sessionId });
-      expect(fakeProcess.kill).toHaveBeenCalledWith('SIGKILL');
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Timeout waiting for proxy exit'));
-
-      vi.useRealTimers();
+        expect(fakeProcess.send).toHaveBeenCalledWith({ cmd: 'terminate', sessionId: baseConfig.sessionId });
+        expect(fakeProcess.kill).toHaveBeenCalledWith('SIGKILL');
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Timeout waiting for proxy exit'));
+      } finally {
+        // Without the finally, a failed assertion above would leak fake
+        // timers into the next shuffled test (issue #420).
+        vi.useRealTimers();
+      }
     });
 
     it('resolves immediately when proxy already exited', async () => {
@@ -1354,10 +1378,11 @@ describe('ProxyManager.start', () => {
       });
 
       const request = proxyManager.sendDapRequest('continue');
+      const rejection = expect(request).rejects.toThrow(/Debug adapter did not respond to 'continue'/);
 
       await vi.advanceTimersByTimeAsync(35000);
 
-      await expect(request).rejects.toThrow(/Debug adapter did not respond to 'continue'/);
+      await rejection;
       const pending = (proxyManager as unknown as { pendingDapRequests: Map<string, unknown> }).pendingDapRequests;
       expect(pending.size).toBe(0);
     } finally {
@@ -1413,13 +1438,14 @@ describe('ProxyManager.start', () => {
       });
 
       const startPromise = proxyManager.start(config);
+      // With retry logic, error message is different
+      const rejection = expect(startPromise).rejects.toThrow(/Failed to initialize proxy after \d+ attempts/);
 
       // Drive the init-retry backoff via fake timers: 35s covers the ~15.5s
       // backoff schedule plus timeout margins.
       await vi.advanceTimersByTimeAsync(35000);
 
-      // With retry logic, error message is different
-      await expect(startPromise).rejects.toThrow(/Failed to initialize proxy after \d+ attempts/);
+      await rejection;
     } finally {
       vi.useRealTimers();
     }
@@ -1441,13 +1467,14 @@ describe('ProxyManager.start', () => {
       });
 
       const startPromise = proxyManager.start(config);
+      // With retry logic, error message is different
+      const rejection = expect(startPromise).rejects.toThrow(/Failed to initialize proxy after \d+ attempts/);
 
       // Drive the init-retry backoff via fake timers: 35s covers the ~15.5s
       // backoff schedule plus timeout margins.
       await vi.advanceTimersByTimeAsync(35000);
 
-      // With retry logic, error message is different
-      await expect(startPromise).rejects.toThrow(/Failed to initialize proxy after \d+ attempts/);
+      await rejection;
     } finally {
       vi.useRealTimers();
     }
@@ -1490,6 +1517,11 @@ describe('ProxyManager.start', () => {
       const startPromise = proxyManager.start(config);
       const stopPromise = proxyManager.stop();
 
+      // Attach the rejection expectation BEFORE the timer advance: this was
+      // the worst offender of the seed-1038859894 flake — startPromise sat
+      // handler-less across the whole 35s advance (issue #420).
+      const startRejection = expect(startPromise).rejects.toThrow(/Proxy/);
+
       setImmediate(() => {
         fakeProcess.emit('exit', 0, null);
       });
@@ -1499,7 +1531,7 @@ describe('ProxyManager.start', () => {
       await vi.advanceTimersByTimeAsync(35000);
 
       await expect(stopPromise).resolves.toBeUndefined();
-      await expect(startPromise).rejects.toThrow(/Proxy/);
+      await startRejection;
     } finally {
       vi.useRealTimers();
     }
@@ -1513,6 +1545,126 @@ describe('ProxyManager.start', () => {
     });
 
     await expect(proxyManager.stop()).resolves.toBeUndefined();
+  });
+
+  // Leaked timers and listeners from settled operations were the enablers of
+  // the seed-1038859894 shuffle flake: rejections fired into later tests
+  // after this file's tests had finished (issue #420).
+  describe('listener and timer hygiene (issue #420)', () => {
+    it('clears the DAP parent backstop timer when the response arrives', async () => {
+      (proxyManager as unknown as { proxyProcess: IProxyProcess | null }).proxyProcess = fakeProcess;
+      (proxyManager as unknown as { isInitialized: boolean }).isInitialized = true;
+      (proxyManager as unknown as { sessionId: string | null }).sessionId = baseConfig.sessionId;
+      (proxyManager as unknown as { dapState: ReturnType<typeof createInitialState> | null }).dapState =
+        createInitialState(baseConfig.sessionId);
+
+      vi.useFakeTimers();
+      try {
+        fakeProcess.sendCommand.mockImplementation((payload) => {
+          if (payload.cmd === 'dap') {
+            (proxyManager as unknown as {
+              handleProxyMessage: (message: object) => void;
+            }).handleProxyMessage({
+              type: 'dapResponse',
+              sessionId: baseConfig.sessionId,
+              requestId: payload.requestId,
+              success: true,
+              response: { type: 'response', seq: 1, request_seq: 1, command: payload.dapCommand, success: true }
+            });
+          }
+        });
+
+        const before = vi.getTimerCount();
+        await proxyManager.sendDapRequest('threads');
+
+        // The ~35s backstop must not survive a settled request.
+        expect(vi.getTimerCount()).toBe(before);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('removes the init-received listener after a successful start', async () => {
+      await proxyManager.start(baseConfig);
+
+      expect(proxyManager.listenerCount('init-received')).toBe(0);
+    });
+
+    it('detaches proxy process listeners when start fails via init exhaustion', async () => {
+      vi.useFakeTimers();
+      try {
+        fakeProcess.sendCommand.mockReset();
+        fakeProcess.sendCommand.mockImplementation(() => {
+          throw new Error('ipc failure');
+        });
+
+        const startPromise = proxyManager.start(baseConfig);
+        const rejection = expect(startPromise).rejects.toThrow(/Failed to initialize proxy/);
+        await vi.advanceTimersByTimeAsync(16500);
+        await rejection;
+
+        // A stale process emitting after the failed start must not reach the
+        // manager (it would fire handleProxyExit into a later test).
+        const exitSpy = vi.fn();
+        proxyManager.on('exit', exitSpy);
+        fakeProcess.emit('exit', 1, null);
+        fakeProcess.emit('message', { type: 'status', status: 'terminated', sessionId: baseConfig.sessionId });
+        expect(exitSpy).not.toHaveBeenCalled();
+
+        expect(fakeProcess.listenerCount('exit')).toBe(0);
+        expect(fakeProcess.listenerCount('message')).toBe(0);
+        expect((fakeProcess.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('detaches proxy process listeners when start times out awaiting readiness', async () => {
+      vi.useFakeTimers();
+      try {
+        fakeProcess.sendCommand.mockImplementation((cmd: { cmd?: string; sessionId?: string }) => {
+          if (cmd.cmd === 'init') {
+            setTimeout(() => {
+              fakeProcess.emit('message', {
+                type: 'status',
+                status: 'init_received',
+                sessionId: cmd.sessionId
+              });
+            }, 0);
+          }
+        });
+
+        const startPromise = proxyManager.start({ ...baseConfig, dryRunSpawn: false });
+        const rejection = expect(startPromise).rejects.toThrow(/did not complete within 30s/);
+        await vi.advanceTimersByTimeAsync(30100);
+        await rejection;
+
+        expect(fakeProcess.listenerCount('exit')).toBe(0);
+        expect(fakeProcess.listenerCount('message')).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('removes the stop() exit listener when the force-kill timeout wins', async () => {
+      vi.useFakeTimers();
+      try {
+        (proxyManager as unknown as { proxyProcess: IProxyProcess | null }).proxyProcess = fakeProcess;
+        (proxyManager as unknown as { sessionId: string | null }).sessionId = baseConfig.sessionId;
+        fakeProcess.killed = false;
+        fakeProcess.exitCode = null;
+
+        const baseline = fakeProcess.listenerCount('exit');
+        const stopPromise = proxyManager.stop();
+        await vi.advanceTimersByTimeAsync(5000);
+        await stopPromise;
+
+        expect(fakeProcess.kill).toHaveBeenCalledWith('SIGKILL');
+        expect(fakeProcess.listenerCount('exit')).toBe(baseline);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

Fixes #420. The 2026-08-14 nightly Flake Hunt failed 1 of 10 randomized Windows unit sweeps (seed `1038859894`) with unhandled-rejection warnings around `tests/unit/proxy/proxy-manager.start.test.ts`. Investigation confirmed the issue's hypothesis and found two reinforcing causes:

- **Test-side**: several tests created a promise, drove its rejection via `vi.advanceTimersByTimeAsync`, and attached the `.rejects` expectation only afterwards. Sinon's async fake-timer loop yields through *real* tick boundaries between fake-timer callbacks — exactly where Node's unhandled-rejection check runs — so whether the rejection was momentarily handler-less was scheduling-dependent. The file also had no top-level `afterEach`, leaving each `ProxyManager` wired to its `FakeProxyProcess` with real `setImmediate` emits able to fire post-test.
- **Source-side**: real leaks in `ProxyManager` let settled operations keep live rejectors — the ~35s DAP parent backstop timer was never cleared on response; `start()` failure paths never detached the listeners `setupEventHandlers` installed (and the `sendInitWithRetry` throw bypassed the wait-promise's local cleanup entirely), so a stale process could drive `handleProxyExit` → `pendingDapRequests` rejections into a later test; each successful init leaked its persistent `init-received` listener; `stop()`'s force-kill path leaked its `once('exit')` handler. `DapProxyWorker`'s async `onInitialized` event listener is fire-and-forget, so its failures surfaced as unhandled rejections (in production too).

Replaying the seed on this Windows box reproduced the exact warnings from the issue in 2 of 5 baseline runs (`Failed to initialize proxy after 6 attempts`, `Debug adapter did not respond to 'launch' request within 35s`).

## Fix

**Source (behavior-preserving)** — `src/proxy/proxy-manager.ts`:
- `sendDapRequest`: the parent backstop timer is stored on the pending entry, cleared at every settle point (`handleDapResponse`, `handleProxyExit`, `cleanup()`, the send-failure catch — which also no longer falls through to create the timer), and `unref()`d.
- `start()`: listeners installed on the proxy process/stderr are tracked and detached on **any** start failure (covers the `sendInitWithRetry` throw path uniformly); the 30s init timeout runs its local cleanup before rejecting; the missing-pid throw clears `proxyProcess` so the manager isn't permanently stuck on the `Proxy already running` guard. Safe because `SessionManager` calls `stop()` after a failed start and `stop()` uses the process handle directly.
- `sendInitWithRetry` removes its `init-received` listener on success, not only on timeout.
- `stop()` removes its `once('exit')` listener in the force-kill-timeout and already-exited branches.
- `src/proxy/dap-proxy-worker.ts`: the `onInitialized` listener contains and logs failures (consistent with the runner's existing log-don't-crash rejection policy).

**Tests**: top-level `afterEach` in `proxy-manager.start.test.ts` (real timers, `removeAllListeners` on both sides, macrotask flush); all create→advance→expect orderings now attach the `.rejects` expectation before driving the rejection (worst case: `startPromise` at the stop-during-start test sat handler-less across a 35s advance); same ordering fix in `proxy-manager-message-handling.test.ts` and `go-initialized-fallback.test.ts`; try/finally around the force-kill test's fake timers. Five new hygiene tests pin the source fixes (timer count after settle, listener counts after success/failure/stop, no manager events from a stale process after failed start).

**Drive-by**: `scripts/flake-hunt.mjs`'s end-of-run summary now includes `--sequence.shuffle.tests` — without it the printed reproduce line couldn't reproduce within-file ordering failures (the committed config shuffles files only).

## Verification (Windows box, `LEAK_GUARD_STRICT=1 CI=true`)

- Baseline (pre-fix): 2 of 5 seed replays surfaced the issue's exact unhandled-rejection warnings; post-fix: **8/8 replays with zero `UnhandledRejection` lines**, all 214 files passing (previously every run had 4 residual lines from the ProxyManager backstop timers and the worker's `onInitialized`).
- Fresh-seed flake hunt (`FLAKE_RUNS=5`): 5/5 passed.
- Full unit suite green in default order; lint clean; coverage 93.01% stmts / 83.0% branch (one unrelated Docker e2e — `docker-entrypoint` `sse --help` — flaked under parallel load during the coverage run and passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)