### PR TITLE
feat(#425): scheduled canary install-and-debug matrix over published artifacts

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -112,6 +112,20 @@ jobs:
           CLI="$(npm root -g)/@debugmcp/mcp-debugger/dist/cli.mjs"
           test -f "$CLI"
           echo "CLI=$CLI" >> "$GITHUB_ENV"
+          # Era detection: a slim-era CLI (v0.25.0+) declares the
+          # @debugmcp/codelldb-* optionalDependencies; a fat-era CLI
+          # (<= 0.24.x) bundles the engine in dist/ instead (linux-x64 only —
+          # see the rust cycle's era gate).
+          SLIM="$(node -p "Object.keys(require(process.argv[1]).optionalDependencies||{}).some(k=>k.startsWith('@debugmcp/codelldb-'))" "$(npm root -g)/@debugmcp/mcp-debugger/package.json")"
+          echo "SLIM=$SLIM" >> "$GITHUB_ENV"
+          case "${{ matrix.os }}" in
+            ubuntu-latest)    PLAT=linux-x64 ;;
+            ubuntu-24.04-arm) PLAT=linux-arm64 ;;
+            macos-latest)     PLAT=darwin-arm64 ;;
+            windows-latest)   PLAT=win32-x64 ;;
+            *) echo "unmapped runner ${{ matrix.os }}"; exit 1 ;;
+          esac
+          echo "CANARY_PLAT=$PLAT" >> "$GITHUB_ENV"
 
       - name: Provision CODELLDB_PATH fallback
         if: ${{ matrix.leg == 'omit-optional' }}
@@ -120,27 +134,30 @@ jobs:
         # upstream VSIX (same pin and guarantee as the Dockerfile vendor
         # step). vendor-codelldb.js needs workspace deps, so it is not used.
         run: |
-          case "${{ matrix.os }}" in
-            ubuntu-latest)    PLAT=linux-x64;    EXT="" ;;
-            ubuntu-24.04-arm) PLAT=linux-arm64;  EXT="" ;;
-            macos-latest)     PLAT=darwin-arm64; EXT="" ;;
-            windows-latest)   PLAT=win32-x64;    EXT=".exe" ;;
-            *) echo "unmapped runner ${{ matrix.os }}"; exit 1 ;;
-          esac
+          EXT=""
+          [ "${{ runner.os }}" = "Windows" ] && EXT=".exe"
           MANIFEST=packages/codelldb-common/vendor-manifest.json
           VERSION="$(node -p "require('./$MANIFEST').codelldb.version")"
-          EXPECTED_SHA="$(node -p "require('./$MANIFEST').codelldb.assets['codelldb-$PLAT.vsix']")"
+          EXPECTED_SHA="$(node -p "require('./$MANIFEST').codelldb.assets['codelldb-$CANARY_PLAT.vsix']")"
           curl -fsSL --retry 3 -o "$RUNNER_TEMP/codelldb.vsix" \
-            "https://github.com/vadimcn/codelldb/releases/download/v${VERSION}/codelldb-${PLAT}.vsix"
+            "https://github.com/vadimcn/codelldb/releases/download/v${VERSION}/codelldb-${CANARY_PLAT}.vsix"
           ACTUAL_SHA="$(node -e "const{createHash}=require('crypto');const{readFileSync}=require('fs');console.log(createHash('sha256').update(readFileSync(process.argv[1])).digest('hex'))" "$RUNNER_TEMP/codelldb.vsix")"
           if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
-            echo "codelldb-$PLAT.vsix digest mismatch: expected $EXPECTED_SHA got $ACTUAL_SHA"
+            echo "codelldb-$CANARY_PLAT.vsix digest mismatch: expected $EXPECTED_SHA got $ACTUAL_SHA"
             exit 1
           fi
-          python -m zipfile -e "$RUNNER_TEMP/codelldb.vsix" "$RUNNER_TEMP/codelldb"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            # No exec bits to preserve on Windows; python -m zipfile suffices.
+            python -m zipfile -e "$RUNNER_TEMP/codelldb.vsix" "$RUNNER_TEMP/codelldb"
+          else
+            # unzip preserves the zip's unix modes — the engine needs +x on
+            # more than the adapter binary (lldb-server/debugserver under
+            # lldb/bin), which python -m zipfile silently drops.
+            unzip -q "$RUNNER_TEMP/codelldb.vsix" -d "$RUNNER_TEMP/codelldb"
+          fi
           BIN="$RUNNER_TEMP/codelldb/extension/adapter/codelldb$EXT"
-          [ -n "$EXT" ] || chmod 755 "$BIN"
           test -e "$BIN"
+          [ -n "$EXT" ] || test -x "$BIN"
           echo "CODELLDB_PATH=$BIN" >> "$GITHUB_ENV"
 
       - name: Assert CodeLLDB backend source (doctor)
@@ -154,8 +171,6 @@ jobs:
         # This flips automatically when v0.25.0 publishes, and a release that
         # ships neither optional deps nor a vendor payload fails loudly here.
         run: |
-          PKG="$(npm root -g)/@debugmcp/mcp-debugger/package.json"
-          SLIM="$(node -p "Object.keys(require(process.argv[1]).optionalDependencies||{}).some(k=>k.startsWith('@debugmcp/codelldb-'))" "$PKG")"
           if [ "$SLIM" = "true" ]; then
             if [ "$LEG" = "omit-optional" ]; then EXPECT="env:CODELLDB_PATH"; else EXPECT="platform-package"; fi
           else
@@ -197,10 +212,31 @@ jobs:
             -- node "$CLI" stdio
 
       - name: Smoke cycle (rust — CodeLLDB engine proof)
+        env:
+          LEG: ${{ matrix.leg }}
         run: |
+          # Era gate: a fat-era CLI bundles CodeLLDB only for linux-x64, so a
+          # default install genuinely has no engine elsewhere — a known 0.24.x
+          # gap that the @debugmcp/codelldb-* platform packages close in
+          # v0.25.0 (the slim era, where this cycle runs everywhere). The
+          # omit-optional leg still proves the engine on every platform via
+          # the CODELLDB_PATH fallback.
+          if [ "$SLIM" != "true" ] && [ "$LEG" = "default" ] && [ "$CANARY_PLAT" != "linux-x64" ]; then
+            echo "::notice::fat-era CLI ships CodeLLDB only for linux-x64 — rust cycle skipped on $CANARY_PLAT (closed by v0.25.0 platform packages)"
+            exit 0
+          fi
           EXT=""
-          [ "${{ runner.os }}" = "Windows" ] && EXT=".exe"
-          rustc -g -o "$RUNNER_TEMP/canary-hello$EXT" examples/rust/hello_world/src/main.rs
+          RUSTC=(rustc)
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            EXT=".exe"
+            # The runner's default rustc is MSVC-host (PDB); the rust adapter
+            # refuses PDB binaries (MSVC_TOOLCHAIN_DETECTED) and the repo's
+            # supported Windows path is DWARF via the GNU toolchain
+            # (tests/e2e/rust-example-utils.ts).
+            rustup toolchain install stable-x86_64-pc-windows-gnu --profile minimal
+            RUSTC=(rustc +stable-x86_64-pc-windows-gnu)
+          fi
+          "${RUSTC[@]}" -g -o "$RUNNER_TEMP/canary-hello$EXT" examples/rust/hello_world/src/main.rs
           node scripts/canary-smoke.mjs --lang rust \
             --program "$RUNNER_TEMP/canary-hello$EXT" \
             --break-file "$GITHUB_WORKSPACE/examples/rust/hello_world/src/main.rs" --line 26 \

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -19,6 +19,11 @@ name: Canary (published artifacts)
 # the installed artifact, not the repo build.
 
 on:
+  # TEMPORARY (remove before merge): branch push trigger so the canary can be
+  # exercised pre-merge — workflow_dispatch only resolves workflows that
+  # exist on the default branch.
+  push:
+    branches: [feat/425-canary-workflow]
   schedule:
     - cron: '0 9 * * 2'  # Tue 09:00 UTC (Mon 06/08/18 + daily 07:00 are taken by other workflows)
   workflow_dispatch:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -19,11 +19,6 @@ name: Canary (published artifacts)
 # the installed artifact, not the repo build.
 
 on:
-  # TEMPORARY (remove before merge): branch push trigger so the canary can be
-  # exercised pre-merge — workflow_dispatch only resolves workflows that
-  # exist on the default branch.
-  push:
-    branches: [feat/425-canary-workflow]
   schedule:
     - cron: '0 9 * * 2'  # Tue 09:00 UTC (Mon 06/08/18 + daily 07:00 are taken by other workflows)
   workflow_dispatch:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,407 @@
+name: Canary (published artifacts)
+
+# Weekly install-and-debug matrix over what users actually run (issue #425):
+# the published npm package (default install and the --omit=optional +
+# CODELLDB_PATH fallback), npx, and the published Docker image — across
+# x64/arm64 Linux, arm64 macOS, and Windows. PR CI builds from source on two
+# OSes and never exercises the published artifacts; the v0.24.0 image shipping
+# without CodeLLDB (#387) is the class of regression this fences.
+#
+# Failures never block PRs: the notify job files (or comments on) an issue
+# labeled `canary-failure` instead. Dispatch with a version input to use the
+# matrix as the post-release verification gate (docs/release-checklist.md).
+#
+# x64 macOS is intentionally not covered — the macos-13 (x64) hosted runners
+# are retired; macos-latest is arm64.
+#
+# The smoke driver (scripts/canary-smoke.mjs) is dependency-free on purpose:
+# no pnpm/workspace install happens in the npm/docker jobs, so every leg tests
+# the installed artifact, not the repo build.
+
+on:
+  schedule:
+    - cron: '0 9 * * 2'  # Tue 09:00 UTC (Mon 06/08/18 + daily 07:00 are taken by other workflows)
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'npm version / Docker tag to test (default: latest)'
+        required: false
+        default: 'latest'
+      channels:
+        description: 'Which install channels to run'
+        type: choice
+        options: [all, npm, docker]
+        default: 'all'
+
+permissions: {}
+
+concurrency:
+  group: canary-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CANARY_VERSION: ${{ github.event.inputs.version || 'latest' }}
+
+jobs:
+  npm-smoke:
+    name: npm ${{ matrix.leg }} (${{ matrix.os }})
+    if: ${{ (github.event.inputs.channels || 'all') != 'docker' }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        leg: [default, omit-optional]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: 22.x
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies (hash-pinned)
+        run: |
+          python -m pip install --require-hashes -r requirements/pip.txt
+          python -m pip install --require-hashes -r requirements/debugpy.txt
+
+      - name: Ensure rustc
+        # rustc is preinstalled on the x64/macos images; the arm images have
+        # drifted before. Minimal profile — only the smoke fixture needs it.
+        run: |
+          if ! command -v rustc >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --profile minimal --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Install published CLI (${{ matrix.leg }})
+        env:
+          LEG: ${{ matrix.leg }}
+        # The scratch prefix keeps `npm install -g` honest without polluting
+        # the runner; docs/release-checklist.md documents this as the
+        # reliable smoke path when the npx cache misbehaves.
+        run: |
+          export NPM_CONFIG_PREFIX="$RUNNER_TEMP/canary-prefix"
+          TRANSCRIPTS="$RUNNER_TEMP/canary-transcripts"
+          mkdir -p "$TRANSCRIPTS"
+          echo "NPM_CONFIG_PREFIX=$NPM_CONFIG_PREFIX" >> "$GITHUB_ENV"
+          echo "TRANSCRIPTS=$TRANSCRIPTS" >> "$GITHUB_ENV"
+          OMIT=""
+          [ "$LEG" = "omit-optional" ] && OMIT="--omit=optional"
+          npm install -g $OMIT "@debugmcp/mcp-debugger@${CANARY_VERSION}"
+          CLI="$(npm root -g)/@debugmcp/mcp-debugger/dist/cli.mjs"
+          test -f "$CLI"
+          echo "CLI=$CLI" >> "$GITHUB_ENV"
+
+      - name: Provision CODELLDB_PATH fallback
+        if: ${{ matrix.leg == 'omit-optional' }}
+        # The documented fallback for installs without the optional
+        # @debugmcp/codelldb-* packages: a digest-pinned download of the
+        # upstream VSIX (same pin and guarantee as the Dockerfile vendor
+        # step). vendor-codelldb.js needs workspace deps, so it is not used.
+        run: |
+          case "${{ matrix.os }}" in
+            ubuntu-latest)    PLAT=linux-x64;    EXT="" ;;
+            ubuntu-24.04-arm) PLAT=linux-arm64;  EXT="" ;;
+            macos-latest)     PLAT=darwin-arm64; EXT="" ;;
+            windows-latest)   PLAT=win32-x64;    EXT=".exe" ;;
+            *) echo "unmapped runner ${{ matrix.os }}"; exit 1 ;;
+          esac
+          MANIFEST=packages/codelldb-common/vendor-manifest.json
+          VERSION="$(node -p "require('./$MANIFEST').codelldb.version")"
+          EXPECTED_SHA="$(node -p "require('./$MANIFEST').codelldb.assets['codelldb-$PLAT.vsix']")"
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/codelldb.vsix" \
+            "https://github.com/vadimcn/codelldb/releases/download/v${VERSION}/codelldb-${PLAT}.vsix"
+          ACTUAL_SHA="$(node -e "const{createHash}=require('crypto');const{readFileSync}=require('fs');console.log(createHash('sha256').update(readFileSync(process.argv[1])).digest('hex'))" "$RUNNER_TEMP/codelldb.vsix")"
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "codelldb-$PLAT.vsix digest mismatch: expected $EXPECTED_SHA got $ACTUAL_SHA"
+            exit 1
+          fi
+          python -m zipfile -e "$RUNNER_TEMP/codelldb.vsix" "$RUNNER_TEMP/codelldb"
+          BIN="$RUNNER_TEMP/codelldb/extension/adapter/codelldb$EXT"
+          [ -n "$EXT" ] || chmod 755 "$BIN"
+          test -e "$BIN"
+          echo "CODELLDB_PATH=$BIN" >> "$GITHUB_ENV"
+
+      - name: Assert CodeLLDB backend source (doctor)
+        env:
+          LEG: ${{ matrix.leg }}
+        # Era auto-detection: a slim-era CLI (v0.25.0+) declares the
+        # @debugmcp/codelldb-* optionalDependencies and must resolve the
+        # engine from them (or from CODELLDB_PATH on the omit-optional leg);
+        # a fat-era CLI (<= 0.24.x) bundles the engine in dist/ and reports
+        # 'vendored' on both legs (the vendored tree wins over the env var).
+        # This flips automatically when v0.25.0 publishes, and a release that
+        # ships neither optional deps nor a vendor payload fails loudly here.
+        run: |
+          PKG="$(npm root -g)/@debugmcp/mcp-debugger/package.json"
+          SLIM="$(node -p "Object.keys(require(process.argv[1]).optionalDependencies||{}).some(k=>k.startsWith('@debugmcp/codelldb-'))" "$PKG")"
+          if [ "$SLIM" = "true" ]; then
+            if [ "$LEG" = "omit-optional" ]; then EXPECT="env:CODELLDB_PATH"; else EXPECT="platform-package"; fi
+          else
+            EXPECT="vendored"
+          fi
+          set +e
+          node "$CLI" doctor rust --json --timeout 30000 \
+            > "$TRANSCRIPTS/doctor.json" 2> "$TRANSCRIPTS/doctor.err"
+          DOCTOR_EXIT=$?
+          set -e
+          if grep -qE "unknown (option|command)" "$TRANSCRIPTS/doctor.err"; then
+            # Pre-doctor release (<= 0.24.x): the rust debug cycle below is
+            # still the proof that the engine loads.
+            echo "::notice::doctor not available in this release — backend-source assertion skipped"
+            exit 0
+          fi
+          if [ "$DOCTOR_EXIT" -ne 0 ]; then
+            echo "doctor exited $DOCTOR_EXIT"
+            cat "$TRANSCRIPTS/doctor.err" "$TRANSCRIPTS/doctor.json" || true
+            exit 1
+          fi
+          SOURCE="$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).languages.find(l=>l.language==='rust').backend.source" "$TRANSCRIPTS/doctor.json")"
+          echo "backend.source=$SOURCE (expected $EXPECT)"
+          [ "$SOURCE" = "$EXPECT" ]
+
+      - name: Smoke cycle (mock)
+        run: |
+          node scripts/canary-smoke.mjs --lang mock \
+            --program "$GITHUB_WORKSPACE/examples/python/simple_test.py" --line 11 \
+            --transcript "$TRANSCRIPTS/mock.jsonl" \
+            -- node "$CLI" stdio
+
+      - name: Smoke cycle (python)
+        run: |
+          node scripts/canary-smoke.mjs --lang python \
+            --program "$GITHUB_WORKSPACE/examples/python/simple_test.py" --line 11 \
+            --expect-line --expect-var a --expect-var b \
+            --transcript "$TRANSCRIPTS/python.jsonl" \
+            -- node "$CLI" stdio
+
+      - name: Smoke cycle (rust — CodeLLDB engine proof)
+        run: |
+          EXT=""
+          [ "${{ runner.os }}" = "Windows" ] && EXT=".exe"
+          rustc -g -o "$RUNNER_TEMP/canary-hello$EXT" examples/rust/hello_world/src/main.rs
+          node scripts/canary-smoke.mjs --lang rust \
+            --program "$RUNNER_TEMP/canary-hello$EXT" \
+            --break-file "$GITHUB_WORKSPACE/examples/rust/hello_world/src/main.rs" --line 26 \
+            --adapter-config '{"sourceLanguages":["rust"]}' \
+            --expect-line --expect-var name \
+            --transcript "$TRANSCRIPTS/rust.jsonl" \
+            -- node "$CLI" stdio
+
+      - name: Smoke cycle (npx channel)
+        # Channel fidelity for the npx one-liner from the README. Skipped on
+        # Windows: spawning npx.cmd without a shell is a known ENOENT
+        # (tests/e2e/npx/npx-test-utils.ts); the scratch-prefix install above
+        # is the documented reliable path there (docs/release-checklist.md).
+        if: ${{ matrix.leg == 'default' && runner.os != 'Windows' }}
+        run: |
+          node scripts/canary-smoke.mjs --lang mock \
+            --program "$GITHUB_WORKSPACE/examples/python/simple_test.py" --line 11 \
+            --transcript "$TRANSCRIPTS/npx-mock.jsonl" \
+            -- npx -y "@debugmcp/mcp-debugger@${CANARY_VERSION}" stdio
+
+      - name: Upload transcripts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: canary-npm-${{ matrix.os }}-${{ matrix.leg }}
+          path: ${{ runner.temp }}/canary-transcripts/
+          retention-days: 14
+
+  docker-smoke:
+    name: docker (${{ matrix.os }})
+    if: ${{ (github.event.inputs.channels || 'all') != 'npm' }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        # Only for the smoke driver itself — python/debugpy live in the image.
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: 22.x
+
+      - name: Pull published image
+        run: |
+          TRANSCRIPTS="$RUNNER_TEMP/canary-transcripts"
+          mkdir -p "$TRANSCRIPTS"
+          echo "TRANSCRIPTS=$TRANSCRIPTS" >> "$GITHUB_ENV"
+          IMAGE="debugmcp/mcp-debugger:${CANARY_VERSION}"
+          docker pull "$IMAGE"
+          docker image inspect --format 'digest: {{index .RepoDigests 0}}' "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Assert CodeLLDB backend source (doctor, in-container)
+        run: |
+          set +e
+          docker run --rm "$IMAGE" doctor rust cpp --json --timeout 30000 \
+            > "$TRANSCRIPTS/doctor.json" 2> "$TRANSCRIPTS/doctor.err"
+          DOCTOR_EXIT=$?
+          set -e
+          if grep -qE "unknown (option|command)" "$TRANSCRIPTS/doctor.err"; then
+            echo "::notice::doctor not available in this image — backend-source assertion skipped"
+            exit 0
+          fi
+          if [ "$DOCTOR_EXIT" -ne 0 ]; then
+            echo "doctor exited $DOCTOR_EXIT"
+            cat "$TRANSCRIPTS/doctor.err" "$TRANSCRIPTS/doctor.json" || true
+            exit 1
+          fi
+          # The image vendors the engine into the codelldb-common package
+          # root, which outranks the CODELLDB_PATH the image also sets — a
+          # different source here means the vendor tree moved (#387/#394).
+          SOURCE="$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).languages.find(l=>l.language==='rust').backend.source" "$TRANSCRIPTS/doctor.json")"
+          echo "backend.source=$SOURCE (expected vendored)"
+          [ "$SOURCE" = "vendored" ]
+
+      - name: Smoke cycle (mock)
+        # Paths are workspace-relative: the server resolves them under the
+        # /workspace mount (MCP_CONTAINER=true).
+        run: |
+          node scripts/canary-smoke.mjs --lang mock \
+            --program examples/python/simple_test.py --line 11 \
+            --transcript "$TRANSCRIPTS/mock.jsonl" \
+            -- docker run -i --rm -v "$GITHUB_WORKSPACE:/workspace" "$IMAGE" stdio
+
+      - name: Smoke cycle (python)
+        run: |
+          node scripts/canary-smoke.mjs --lang python \
+            --program examples/python/simple_test.py --line 11 \
+            --expect-line --expect-var a --expect-var b \
+            --transcript "$TRANSCRIPTS/python.jsonl" \
+            -- docker run -i --rm -v "$GITHUB_WORKSPACE:/workspace" "$IMAGE" stdio
+
+      - name: Smoke cycle (rust — CodeLLDB engine proof)
+        # The image ships no compiler; build the fixture in a rust container
+        # against the same /workspace mount so the DWARF paths match what the
+        # debug container sees (tests/e2e/rust-example-utils.ts pattern).
+        run: |
+          docker run --rm -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace/examples/rust/hello_world \
+            rust:1.83-slim cargo build --target-dir target-canary
+          node scripts/canary-smoke.mjs --lang rust \
+            --program examples/rust/hello_world/target-canary/debug/hello_world \
+            --break-file examples/rust/hello_world/src/main.rs --line 26 \
+            --adapter-config '{"sourceLanguages":["rust"]}' \
+            --expect-line --expect-var name \
+            --transcript "$TRANSCRIPTS/rust.jsonl" \
+            -- docker run -i --rm -v "$GITHUB_WORKSPACE:/workspace" "$IMAGE" stdio
+
+      - name: Upload transcripts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: canary-docker-${{ matrix.os }}
+          path: ${{ runner.temp }}/canary-transcripts/
+          retention-days: 14
+
+  docker-build-guard:
+    name: docker build guard (${{ matrix.os }})
+    if: ${{ (github.event.inputs.channels || 'all') != 'npm' }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build builder stage and assert single-platform vendoring
+        # Fence for #394: a CI checkout has no vendored payloads, so the
+        # Dockerfile's digest-verified fetch always runs; before the fix the
+        # node prebuild re-vendored all five platforms. Asserting state (not
+        # network) keeps the guard meaningful even with layer caching.
+        run: |
+          case "$(uname -m)" in
+            aarch64) ARCH=linux-arm64 ;;
+            *)       ARCH=linux-x64 ;;
+          esac
+          echo "ARCH=$ARCH" >> "$GITHUB_ENV"
+          docker build --target builder -t canary-builder .
+          docker run --rm canary-builder sh -c '
+            set -e
+            cd /app/packages/codelldb-common/vendor/codelldb
+            ls -l
+            PLATS="$(ls -1 | grep -E "^(linux|darwin|win32)-" | sort | tr "\n" " " | sed "s/ *$//")"
+            [ "$PLATS" = "'"$ARCH"'" ] || { echo "expected only '"$ARCH"' in vendor tree, got: $PLATS"; exit 1; }
+            [ "$(readlink current)" = "'"$ARCH"'" ] || { echo "current symlink broken: $(readlink current)"; exit 1; }
+            test -x "current/adapter/codelldb"'
+
+      - name: Build runtime image and assert engine state
+        run: |
+          docker build -t canary-image .
+          docker run --rm --entrypoint sh canary-image -c '
+            set -e
+            cd /app/node_modules/@debugmcp/codelldb-common/vendor/codelldb
+            ls -l
+            COUNT="$(find . -type f -name codelldb | wc -l)"
+            [ "$COUNT" -eq 1 ] || { echo "expected exactly 1 codelldb binary, found $COUNT (2 means the current symlink was copied as a real dir)"; exit 1; }
+            PLATS="$(ls -1 | grep -E "^(linux|darwin|win32)-" | tr "\n" " " | sed "s/ *$//")"
+            [ "$PLATS" = "'"$ARCH"'" ] || { echo "expected only '"$ARCH"' in image vendor tree, got: $PLATS"; exit 1; }
+            [ "$(readlink current)" = "'"$ARCH"'" ] || { echo "current symlink broken: $(readlink current)"; exit 1; }
+            test -x "$CODELLDB_PATH"'
+
+  notify:
+    name: File canary-failure issue
+    needs: [npm-smoke, docker-smoke, docker-build-guard]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 10
+    steps:
+      - name: File or update canary-failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          FAILED="$(printf '%s' "$NEEDS_JSON" | jq -r '[to_entries[] | select(.value.result=="failure") | .key] | join(", ")')"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          BODY="Canary run failed for version \`${CANARY_VERSION}\` (trigger: ${GITHUB_EVENT_NAME}).
+
+          Failed jobs: ${FAILED}
+          Run: ${RUN_URL}
+
+          Per-leg transcripts are attached as artifacts on the run. A leg that
+          fails here but passes locally against the same version is a
+          release/packaging finding — triage before the next release."
+          EXISTING="$(gh issue list --repo "$GITHUB_REPOSITORY" --label canary-failure --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --label canary-failure \
+              --title "Canary failure: published-artifact smoke ($(date -u +%F))" \
+              --body "$BODY"
+          fi

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ mcp-debugger gives AI agents step-through debugging over the Model Context Proto
 
 - **Environment self-check** — ✅ shipped: the [`mcp-debugger doctor` command](docs/diagnostics.md) checks every adapter's runtime prerequisites in one pass, and the [diagnostics guide](docs/diagnostics.md) consolidates prerequisites and failure signatures ([#423](https://github.com/debugmcp/mcp-debugger/issues/423)).
 - **Turnkey Kubernetes debugging** — a copy-paste recipe (docs + example manifests + attach presets) for debugging pods via ephemeral sidecar containers and port-forwarded attach ([#424](https://github.com/debugmcp/mcp-debugger/issues/424)).
-- **Published-artifact canary** — a scheduled install-and-debug matrix that exercises what users actually install (npx, global npm, Docker) across platforms, catching packaging regressions before users do ([#425](https://github.com/debugmcp/mcp-debugger/issues/425)).
+- **Published-artifact canary** — ✅ shipped: the [Canary workflow](.github/workflows/canary.yml) runs a weekly (and on-demand, as the release gate) install-and-debug matrix over what users actually install (npx, global npm, Docker) across x64/arm64 Linux, arm64 macOS, and Windows, catching packaging regressions before users do ([#425](https://github.com/debugmcp/mcp-debugger/issues/425)).
 
 ## Non-goals
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -48,8 +48,8 @@ Pre-release validation for mcp-debugger. Run `npm run release:dry-run` to automa
 - [ ] GitHub Release body has the correct changelog content
 - [ ] Verify provenance: `gh attestation verify debugmcp-mcp-debugger-x.y.z.tgz --repo debugmcp/mcp-debugger` (download the asset first)
 - [ ] Verify npm: each published package shows the new version with `latest` dist-tag and a provenance badge on npmjs.com; `npm audit signatures` passes in a scratch project that installs them
-- [ ] Verify: `npx @debugmcp/mcp-debugger@x.y.z stdio` works (if the npx cache misbehaves, `npm install --prefix <tmp-dir>` is the reliable smoke path)
-- [ ] Verify: `docker pull debugmcp/mcp-debugger:x.y.z` works
+- [ ] **Run the canary as the release gate**: `gh workflow run canary.yml -f version=x.y.z` and confirm every leg is green (Actions → "Canary (published artifacts)"). It installs the published npm package (default and `--omit=optional` + `CODELLDB_PATH` legs), runs npx, pulls the Docker image, and drives a breakpoint→variables→continue cycle in mock/python/rust on x64/arm64 Linux, arm64 macOS, and Windows — superseding the manual npx/docker spot checks below
+- [ ] Fallback manual checks (when the canary can't run): `npx @debugmcp/mcp-debugger@x.y.z stdio` works (if the npx cache misbehaves, `npm install --prefix <tmp-dir>` is the reliable smoke path); `docker pull debugmcp/mcp-debugger:x.y.z` works
 - [ ] Verify: PyPI has `debug-mcp-server-launcher==x.y.z`
 - [ ] **Website content review** — audit https://debugmcp.io against what this release shipped (language matrix, tool count, feature claims, comparison table) and update `debugmcp/website`
 - [ ] Update `SECURITY.md` supported-versions table if a new minor line started (should have happened pre-tag)

--- a/scripts/canary-smoke.mjs
+++ b/scripts/canary-smoke.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+/**
+ * canary-smoke.mjs — dependency-free MCP debug smoke cycle for the canary
+ * workflow (issue #425).
+ *
+ * Speaks raw newline-delimited JSON-RPC over stdio to an arbitrary MCP server
+ * command (a published npm install, an npx invocation, or a `docker run -i`),
+ * so it deliberately needs NO workspace install: it tests the artifact the
+ * user runs, not the repo build.
+ *
+ * Cycle (mirrors tests/e2e/docker/docker-smoke-rust.test.ts sequencing):
+ *   list_supported_languages  -> assert --lang is installed
+ *   create_debug_session
+ *   set_breakpoint            -> --break-file (default: --program) at --line
+ *   start_debugging           -> stopOnEntry: true; response state is 'paused'
+ *   continue_execution        -> returns on dispatch; stop lands async
+ *   poll list_debug_sessions  -> until state === 'paused'
+ *   poll get_stack_trace      -> frame at --line (only with --expect-line)
+ *   get_local_variables       -> assert each --expect-var present
+ *   continue_execution        -> poll until the session completes
+ *   close_debug_session
+ *
+ * Exit codes: 0 pass, 1 cycle/assertion failure, 2 usage or spawn error.
+ *
+ * The server command comes after `--` (so its own flags pass through), e.g.:
+ *   node scripts/canary-smoke.mjs \
+ *     --lang python --program examples/python/simple_test.py --line 11 \
+ *     --expect-line --expect-var a --expect-var b --transcript /tmp/python.jsonl \
+ *     -- node /prefix/node_modules/@debugmcp/mcp-debugger/dist/cli.mjs stdio
+ *
+ * Docker channel (paths are workspace-relative inside the container):
+ *   node scripts/canary-smoke.mjs --lang mock --program examples/python/simple_test.py --line 11 \
+ *     -- docker run -i --rm -v "$PWD:/workspace" debugmcp/mcp-debugger:latest stdio
+ */
+
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { parseArgs } from 'util';
+
+const POLL_INTERVAL_MS = 250;
+const REQUEST_TIMEOUT_MS = 30000;
+const KILL_GRACE_MS = 5000;
+const FAILURE_TAIL_LINES = 40;
+// A breakpoint on a line whose code spans multiple address ranges (e.g. a
+// rust format! line on win32) stops once per location, so one continue does
+// not guarantee completion. Bound the re-continue loop instead.
+const MAX_CONTINUES = 5;
+
+function usage(message) {
+  if (message) console.error(`[canary] ${message}`);
+  console.error(
+    'Usage: canary-smoke.mjs --lang <language>\n' +
+    '  [--program <path>] [--break-file <path>] [--line <n>]\n' +
+    '  [--adapter-config <json>] [--expect-var <name>]... [--expect-line]\n' +
+    '  [--list-only] [--timeout <ms>] [--transcript <file>]\n' +
+    '  -- <server command> [server args...]'
+  );
+  process.exit(2);
+}
+
+let options;
+let serverCommand;
+try {
+  const parsed = parseArgs({
+    allowPositionals: true,
+    options: {
+      lang: { type: 'string' },
+      program: { type: 'string' },
+      'break-file': { type: 'string' },
+      line: { type: 'string' },
+      'adapter-config': { type: 'string' },
+      'expect-var': { type: 'string', multiple: true },
+      'expect-line': { type: 'boolean' },
+      'list-only': { type: 'boolean' },
+      timeout: { type: 'string' },
+      transcript: { type: 'string' }
+    }
+  });
+  options = parsed.values;
+  serverCommand = parsed.positionals;
+} catch (err) {
+  usage(err.message);
+}
+
+if (!serverCommand || serverCommand.length === 0) usage('server command after -- is required');
+if (!options.lang) usage('--lang is required');
+if (!options['list-only']) {
+  if (!options.program) usage('--program is required (unless --list-only)');
+  if (!options.line) usage('--line is required (unless --list-only)');
+}
+const overallTimeoutMs = options.timeout ? Number(options.timeout) : 120000;
+if (!Number.isFinite(overallTimeoutMs) || overallTimeoutMs <= 0) usage('--timeout must be a positive number');
+const bpLine = options.line ? Number(options.line) : undefined;
+if (options.line && !Number.isInteger(bpLine)) usage('--line must be an integer');
+let adapterLaunchConfig;
+if (options['adapter-config']) {
+  try {
+    adapterLaunchConfig = JSON.parse(options['adapter-config']);
+  } catch (err) {
+    usage(`--adapter-config is not valid JSON: ${err.message}`);
+  }
+}
+
+/* ---------- transcript ---------- */
+
+const transcriptTail = [];
+let transcriptStream = null;
+if (options.transcript) {
+  fs.mkdirSync(path.dirname(path.resolve(options.transcript)), { recursive: true });
+  transcriptStream = fs.createWriteStream(options.transcript, { flags: 'w' });
+}
+
+function transcribe(dir, data) {
+  const line = JSON.stringify({ t: new Date().toISOString(), dir, data });
+  transcriptTail.push(line);
+  if (transcriptTail.length > FAILURE_TAIL_LINES) transcriptTail.shift();
+  if (transcriptStream) transcriptStream.write(line + '\n');
+}
+
+/* ---------- raw stdio MCP client ---------- */
+
+class McpStdioClient {
+  constructor(command, args) {
+    this.nextId = 1;
+    this.pending = new Map(); // id -> { resolve, reject, timer }
+    this.exited = false;
+    this.disposed = false;
+    this.spawnFailed = false;
+    this.child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    this.spawnError = new Promise((resolve) => {
+      this.child.once('error', (err) => {
+        this.spawnFailed = true;
+        resolve(err);
+      });
+      this.child.once('spawn', () => resolve(null));
+    });
+
+    // stdin can hit EPIPE/write-after-end when the server dies or the
+    // watchdog disposes mid-request — surface it via the transcript, not an
+    // unhandled 'error' event.
+    this.child.stdin.on('error', (err) => transcribe('note', `stdin error: ${err.message}`));
+
+    let stdoutBuffer = '';
+    this.child.stdout.setEncoding('utf8');
+    this.child.stdout.on('data', (chunk) => {
+      stdoutBuffer += chunk;
+      let newline;
+      while ((newline = stdoutBuffer.indexOf('\n')) !== -1) {
+        const line = stdoutBuffer.slice(0, newline).trim();
+        stdoutBuffer = stdoutBuffer.slice(newline + 1);
+        if (line) this.handleLine(line);
+      }
+    });
+    this.child.stderr.setEncoding('utf8');
+    this.child.stderr.on('data', (chunk) => transcribe('stderr', chunk.trimEnd()));
+    this.child.on('exit', (code, signal) => {
+      this.exited = true;
+      transcribe('note', `server exited (code=${code} signal=${signal})`);
+      for (const { reject, timer } of this.pending.values()) {
+        clearTimeout(timer);
+        reject(new Error(`server exited (code=${code} signal=${signal}) before responding`));
+      }
+      this.pending.clear();
+    });
+  }
+
+  handleLine(line) {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      transcribe('recv-unparseable', line);
+      return;
+    }
+    transcribe('recv', message);
+    if (message.id !== undefined && this.pending.has(message.id)) {
+      const { resolve, reject, timer } = this.pending.get(message.id);
+      this.pending.delete(message.id);
+      clearTimeout(timer);
+      if (message.error) {
+        reject(new Error(`JSON-RPC error ${message.error.code}: ${message.error.message}`));
+      } else {
+        resolve(message.result);
+      }
+    }
+    // Notifications and unsolicited messages are transcribed above and ignored.
+  }
+
+  send(message) {
+    if (this.disposed || !this.child.stdin.writable) {
+      throw new Error('cannot send: server stdin is closed');
+    }
+    transcribe('send', message);
+    this.child.stdin.write(JSON.stringify(message) + '\n');
+  }
+
+  request(method, params, timeoutMs = REQUEST_TIMEOUT_MS) {
+    if (this.exited || this.disposed) return Promise.reject(new Error('server already exited'));
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`request '${method}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      this.send({ jsonrpc: '2.0', id, method, params });
+    });
+  }
+
+  notify(method, params) {
+    this.send({ jsonrpc: '2.0', method, ...(params ? { params } : {}) });
+  }
+
+  async initialize() {
+    const spawnErr = await this.spawnError;
+    if (spawnErr) throw Object.assign(new Error(`failed to spawn server: ${spawnErr.message}`), { usageError: true });
+    const result = await this.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'canary-smoke', version: '1.0.0' }
+    });
+    this.notify('notifications/initialized');
+    return result;
+  }
+
+  /**
+   * Call an MCP tool and parse the conventional JSON payload out of
+   * content[0].text. Throws on isError or an explicit success:false unless
+   * { tolerateFailure } — polling steps probe states that are legal to reject
+   * (e.g. get_stack_trace while running).
+   */
+  async callTool(name, args, { tolerateFailure = false } = {}) {
+    const result = await this.request('tools/call', { name, arguments: args });
+    const text = Array.isArray(result?.content) && result.content[0]?.type === 'text'
+      ? result.content[0].text
+      : undefined;
+    let payload = {};
+    if (text !== undefined) {
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        payload = { rawText: text };
+      }
+    }
+    const failed = result?.isError === true || payload.success === false;
+    if (failed && !tolerateFailure) {
+      throw new Error(`tool '${name}' failed: ${payload.message ?? payload.error ?? text ?? 'unknown error'}`);
+    }
+    payload.__failed = failed;
+    return payload;
+  }
+
+  async dispose() {
+    this.disposed = true;
+    try { this.child.stdin.end(); } catch { /* already closed */ }
+    // A child that never spawned emits no 'exit' — don't wait for one.
+    if (this.exited || this.spawnFailed) return;
+    const exited = new Promise((resolve) => this.child.once('exit', resolve));
+    this.child.kill('SIGTERM');
+    const timer = setTimeout(() => this.child.kill('SIGKILL'), KILL_GRACE_MS);
+    await exited;
+    clearTimeout(timer);
+  }
+}
+
+/* ---------- cycle steps ---------- */
+
+const startedAt = Date.now();
+function remainingBudgetMs() {
+  return overallTimeoutMs - (Date.now() - startedAt);
+}
+
+function step(name, detail = '') {
+  console.log(`[canary] ${name}${detail ? `: ${detail}` : ''}`);
+}
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function pollUntil(description, probe) {
+  for (;;) {
+    if (remainingBudgetMs() <= 0) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    const value = await probe();
+    if (value !== undefined) return value;
+    await wait(POLL_INTERVAL_MS);
+  }
+}
+
+async function findSession(client, sessionId) {
+  const payload = await client.callTool('list_debug_sessions', {}, { tolerateFailure: true });
+  return (payload.sessions ?? []).find((s) => s.id === sessionId);
+}
+
+async function runCycle(client) {
+  const lang = options.lang;
+
+  const languages = await client.callTool('list_supported_languages', {});
+  const installed = languages.installed ?? [];
+  if (!installed.includes(lang)) {
+    throw new Error(`language '${lang}' not in installed list: ${JSON.stringify(installed)}`);
+  }
+  step('list_supported_languages ok', `${installed.length} installed, '${lang}' present`);
+  if (options['list-only']) return;
+
+  const created = await client.callTool('create_debug_session', { language: lang, name: 'canary' });
+  const sessionId = created.sessionId;
+  if (!sessionId) throw new Error('create_debug_session returned no sessionId');
+  step('create_debug_session ok', sessionId);
+
+  try {
+    const breakFile = options['break-file'] ?? options.program;
+    await client.callTool('set_breakpoint', { sessionId, file: breakFile, line: bpLine });
+    step('set_breakpoint ok', `${breakFile}:${bpLine}`);
+
+    const started = await client.callTool('start_debugging', {
+      sessionId,
+      scriptPath: options.program,
+      args: [],
+      dapLaunchArgs: { stopOnEntry: true },
+      ...(adapterLaunchConfig ? { adapterLaunchConfig } : {})
+    });
+    if (!String(started.state ?? '').includes('paused')) {
+      throw new Error(`start_debugging (stopOnEntry) did not pause: state=${started.state}`);
+    }
+    step('start_debugging ok', 'paused on entry');
+
+    await client.callTool('continue_execution', { sessionId });
+    await pollUntil('breakpoint pause', async () => {
+      const session = await findSession(client, sessionId);
+      return session?.state === 'paused' ? true : undefined;
+    });
+    step('continue_execution ok', 'paused at breakpoint');
+
+    if (options['expect-line']) {
+      await pollUntil(`stack frame at line ${bpLine}`, async () => {
+        const stack = await client.callTool('get_stack_trace', { sessionId }, { tolerateFailure: true });
+        if (stack.__failed) return undefined;
+        const frames = stack.stackFrames ?? [];
+        return frames.some((f) => f.line === bpLine) ? true : undefined;
+      });
+      step('get_stack_trace ok', `frame at line ${bpLine}`);
+    }
+
+    const locals = await client.callTool('get_local_variables', { sessionId });
+    const variables = locals.variables ?? [];
+    for (const name of options['expect-var'] ?? []) {
+      const found = variables.find((v) => v.name === name);
+      if (!found) {
+        throw new Error(`expected local '${name}' not found; got: ${variables.map((v) => v.name).join(', ') || '(none)'}`);
+      }
+      transcribe('note', `local ${name} = ${found.value}`);
+    }
+    step('get_local_variables ok', `${variables.length} variables${(options['expect-var'] ?? []).length ? `, expected present: ${options['expect-var'].join(', ')}` : ''}`);
+
+    // Continue to completion. A multi-location breakpoint (verified: the
+    // rust format! line on win32) re-stops on the same line, so allow a
+    // bounded number of re-continues before calling it a hang.
+    let completed = false;
+    for (let attempt = 1; attempt <= MAX_CONTINUES && !completed; attempt++) {
+      // Snapshot the current stop so a stale 'paused' (poll racing the
+      // resume) is not mistaken for a re-stop.
+      const before = await findSession(client, sessionId);
+      const prevStopTs = before?.lastStop?.timestamp;
+      await client.callTool('continue_execution', { sessionId });
+      const outcome = await pollUntil(`completion or re-pause (continue #${attempt})`, async () => {
+        const session = await findSession(client, sessionId);
+        if (!session || session.state === 'stopped') return 'completed';
+        if (session.state === 'error') throw new Error('session entered error state after continue');
+        if (session.state === 'paused' && session.lastStop?.timestamp !== prevStopTs) return 'paused';
+        return undefined;
+      });
+      if (outcome === 'completed') {
+        completed = true;
+      } else {
+        transcribe('note', `re-paused after continue #${attempt} (multi-location breakpoint?)`);
+      }
+    }
+    if (!completed) {
+      throw new Error(`program did not complete after ${MAX_CONTINUES} continues`);
+    }
+    step('continue_execution ok', 'program completed');
+  } finally {
+    // Best-effort close even after a failed step so the server tears down.
+    await client.callTool('close_debug_session', { sessionId }, { tolerateFailure: true }).catch(() => {});
+  }
+  step('close_debug_session ok');
+}
+
+/* ---------- main ---------- */
+
+async function main() {
+  const client = new McpStdioClient(serverCommand[0], serverCommand.slice(1));
+  const watchdog = setTimeout(() => {
+    console.error(`[canary] FAIL: overall timeout of ${overallTimeoutMs}ms exceeded`);
+    printFailureTail();
+    client.dispose().finally(() => process.exit(1));
+  }, overallTimeoutMs);
+
+  try {
+    await client.initialize();
+    step('initialize ok');
+    await runCycle(client);
+    console.log(`[canary] PASS (${options.lang}, ${Date.now() - startedAt}ms)`);
+  } catch (err) {
+    console.error(`[canary] FAIL: ${err.message}`);
+    printFailureTail();
+    process.exitCode = err.usageError ? 2 : 1;
+  } finally {
+    clearTimeout(watchdog);
+    await client.dispose();
+    if (transcriptStream) await new Promise((resolve) => transcriptStream.end(resolve));
+  }
+}
+
+function printFailureTail() {
+  console.error(`[canary] last ${transcriptTail.length} transcript entries:`);
+  for (const line of transcriptTail) console.error(`  ${line}`);
+}
+
+main().catch((err) => {
+  console.error(`[canary] unexpected error: ${err.stack ?? err}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Implements the published-artifact canary from #425: a weekly (Tue 09:00 UTC) + manually dispatchable workflow that installs what users actually run — `npm i -g` (default and `--omit=optional` + `CODELLDB_PATH` legs), npx, and the published Docker image — and drives a real breakpoint → stop → variables → continue cycle against each, across ubuntu x64/arm64, macOS arm64, and Windows. Dispatching with `-f version=x.y.z` makes it the post-release verification gate (release checklist updated).

## What's in it

- **`scripts/canary-smoke.mjs`** — dependency-free newline-JSON-RPC MCP client (no workspace install in any leg, so the canary tests the artifact, not the repo build). Cycle mirrors the proven docker-rust e2e sequencing; the final continue runs a bounded continue-to-completion loop because a multi-location breakpoint (the rust `format!` line on win32, verified via DAP trace) legitimately re-stops on the same line.
- **`.github/workflows/canary.yml`** —
  - `npm-smoke` (4 OS × 2 legs): scratch-prefix global install, hash-pinned debugpy, mock + python + rust cycles, npx fidelity leg on non-Windows, digest-pinned CODELLDB_PATH fallback provisioning, and a doctor-based `backend.source` assertion with fat/slim era auto-detection (flips to `platform-package` / `env:CODELLDB_PATH` expectations automatically when v0.25.0 publishes; skips cleanly on pre-doctor releases).
  - `docker-smoke` (both arches): pulls the published image, in-container doctor, workspace-relative cycles, rust fixture cross-compiled against the same `/workspace` mount.
  - `docker-build-guard` (both arches): state-based fence for #394 single-platform vendoring (builder tree has exactly one platform dir + `current` symlink) and #387 engine presence in the runtime image.
  - `notify`: files or comments on a deduped `canary-failure`-labeled issue instead of blocking PRs.
- Docs: release checklist gains the dispatch-as-release-gate step; ROADMAP marks the canary theme shipped.

## Validation

Two full runs on this branch (via a since-removed temporary push trigger):
- Run 1 surfaced a **real 0.24.x packaging finding** — the fat-era npm CLI bundles CodeLLDB only for linux-x64, so default installs can't debug rust/cpp on win/mac/arm (closed by the v0.25.0 platform packages; the canary era-gates that leg until then) — plus two workflow bugs (exec bits dropped by `python -m zipfile`; MSVC-host rustc on Windows runners). The notify job auto-filed #448 (triaged and closed).
- Run 2: **all 12 legs green** — including the first-ever CI exercise of the darwin-arm64 and linux-arm64 CodeLLDB payloads (via the `CODELLDB_PATH` legs).

Local validation on win32 covered all three cycles against published 0.24.2 (npm + docker channels) and the guard assertions against the published image.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)