### PR TITLE
fix(#478): pin packageManager to pnpm@10.33.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
     
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
-      with:
-        version: 10
+      # version comes from package.json "packageManager" (issue #478)
     
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
@@ -136,8 +135,7 @@ jobs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
-      with:
-        version: 10
+      # version comes from package.json "packageManager" (issue #478)
 
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
@@ -195,8 +193,7 @@ jobs:
     
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
-      with:
-        version: 10
+      # version comes from package.json "packageManager" (issue #478)
     
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
@@ -232,8 +229,7 @@ jobs:
     
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
-      with:
-        version: 10
+      # version comes from package.json "packageManager" (issue #478)
     
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/flake-hunt.yml
+++ b/.github/workflows/flake-hunt.yml
@@ -40,8 +40,7 @@ jobs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
-      with:
-        version: 10
+      # version comes from package.json "packageManager" (issue #478)
 
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/mem-bench.yml
+++ b/.github/workflows/mem-bench.yml
@@ -44,8 +44,7 @@ jobs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
-      with:
-        version: 10
+      # version comes from package.json "packageManager" (issue #478)
 
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,7 @@ jobs:
     
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
-      with:
-        version: 10
+      # version comes from package.json "packageManager" (issue #478)
 
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
@@ -270,8 +269,7 @@ jobs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
-      with:
-        version: 10
+      # version comes from package.json "packageManager" (issue #478)
 
     # No registry-url here: setup-node would write an _authToken=${NODE_AUTH_TOKEN}
     # placeholder into .npmrc, which breaks token-less OIDC publishes when the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,12 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 ### Prerequisites
 
 - Node.js 22+
-- pnpm (required — `workspace:*` protocol needs pnpm, not npm)
+- pnpm 10 (required — `workspace:*` protocol needs pnpm, not npm). The exact
+  version is pinned via the `packageManager` field in `package.json`; run
+  `corepack enable` to pick it up automatically. **Never commit a regenerated
+  `pnpm-lock.yaml`** — a different pnpm version rewrites it destructively
+  (dropping the security `overrides` block); if `pnpm install` modifies it,
+  run `git checkout pnpm-lock.yaml` before committing.
 - Python 3.7+ (for debugging Python code)
 - Go 1.18+ and Delve (for debugging Go code, optional)
 - Rust toolchain (for debugging Rust code, optional — CodeLLDB auto-downloads during install)

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "packageManager": "pnpm@10.33.0",
   "main": "dist/index.js",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Closes #478.

Adds the missing `packageManager` pin that let two first-time contributors regenerate `pnpm-lock.yaml` incompatibly this week (one diff silently dropped the entire security `overrides` block and downgraded esbuild).

- `package.json`: `"packageManager": "pnpm@10.33.0"` — matches the Dockerfile's corepack pin. pnpm's `package-manager-strict` default now fails fast with a clear message on the wrong major; corepack users get auto-switched.
- Workflows (`ci.yml`, `flake-hunt.yml`, `mem-bench.yml`, `release.yml`): removed the `version: 10` input from `pnpm/action-setup` — the action reads `packageManager` when the input is omitted, and errors when both are specified and differ.
- `CONTRIBUTING.md`: documents the pin, `corepack enable`, and never committing a regenerated lockfile.

Verified locally: `pnpm install --frozen-lockfile --ignore-scripts` passes with the pin in place (pnpm 10.33.0). CI on this PR exercises the workflow change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)