### PR TITLE
fix(#470): DAP decoder resyncs past a malformed header block instead of dropping the frames behind it

### DIFF
--- a/src/proxy/dap-framing.ts
+++ b/src/proxy/dap-framing.ts
@@ -36,11 +36,13 @@ const MAX_HEADER_BYTES = 16 * 1024;
 export interface DapFrameDecoderOptions {
   /**
    * Invoked on malformed input. 'header' means an invalid/absent
-   * Content-Length header was seen and the buffered payload was discarded;
-   * 'json' means a complete frame failed to parse and was skipped;
-   * 'overflow' means the peer advertised a frame above maxContentLength (or
-   * streamed header bytes past the header allowance) and the buffer was
-   * discarded — same recovery contract as 'header'.
+   * Content-Length header was seen — the malformed block was discarded and
+   * decoding resynced at the next `Content-Length` occurrence in the
+   * buffered remainder if one exists (issue #470), else the remainder was
+   * discarded too; 'json' means a complete frame failed to parse and was
+   * skipped; 'overflow' means the peer advertised a frame above
+   * maxContentLength (or streamed header bytes past the header allowance)
+   * and the buffer was discarded.
    */
   onError?: (error: Error, context: DapFrameDecoderErrorContext) => void;
   /** Upper bound for a single frame body (issue #402); default 64 MB or DAP_MAX_FRAME_BYTES. */
@@ -150,11 +152,26 @@ export class DapFrameDecoder {
       this.headerData = Buffer.alloc(0);
 
       if (parsedLength === null || parsedLength <= 0 || !Number.isFinite(parsedLength)) {
+        // A malformed header block must not take the frames after it down
+        // too: a dropped *response* is unrecoverable at the DAP layer — the
+        // pending request never settles and the init deadline converts a
+        // transient framing hiccup into a hard launch failure (issue #470).
+        // Resync at the next plausible header start inside the remainder;
+        // when none exists, discard it as before so stray junk cannot
+        // poison the frames of a later push.
+        const resyncAt = remainder.indexOf('Content-Length');
         this.onError?.(
-          new Error('Invalid Content-Length header encountered; discarding payload'),
+          new Error(
+            resyncAt === -1
+              ? 'Invalid Content-Length header encountered; discarding payload'
+              : 'Invalid Content-Length header encountered; discarded malformed block and resynced at next header'
+          ),
           'header'
         );
         this.reset();
+        if (resyncAt !== -1) {
+          input = remainder.subarray(resyncAt);
+        }
         continue;
       }
 

--- a/src/proxy/minimal-dap.ts
+++ b/src/proxy/minimal-dap.ts
@@ -41,8 +41,18 @@ export class MinimalDapClient extends EventEmitter {
   private decoder = new DapFrameDecoder({
     onError: (error, context) => {
       if (context === 'header' || context === 'overflow') {
-        // Same recovery contract: the decoder discarded the buffer (issue #402)
-        logger.warn(`[MinimalDapClient] ${error.message}`);
+        // A discarded frame that was a pending *response* is unrecoverable —
+        // DAP has no resend, so the request promise only settles at its
+        // timeout. Name the seq(s) at error level so this fails loudly
+        // instead of as a generic init/request timeout (issue #470).
+        const pendingSeqs = Array.from(this.pendingRequests.keys());
+        if (pendingSeqs.length > 0) {
+          logger.error(
+            `[MinimalDapClient] ${error.message} (request seq(s) awaiting a response: ${pendingSeqs.join(', ')} — if the discarded frame was one of them, that request will time out)`
+          );
+        } else {
+          logger.warn(`[MinimalDapClient] ${error.message}`);
+        }
       } else {
         logger.error('[MinimalDapClient] Error parsing message:', error);
       }

--- a/tests/unit/proxy/dap-framing.property.test.ts
+++ b/tests/unit/proxy/dap-framing.property.test.ts
@@ -135,6 +135,64 @@ describe('DapFrameDecoder malformed-input recovery', () => {
     expect(decoder.push(frame(msg))).toEqual([msg]);
   });
 
+  it('recovers a well-formed frame that follows a junk block in the same chunk (issue #470)', () => {
+    // The rdbg direct-socket path intermittently delivers a non-DAP block
+    // ahead of the initialize response. A dropped *response* is
+    // unrecoverable at the DAP layer, so the decoder must resync at the
+    // next header instead of discarding the response with the junk.
+    const errors: Array<{ message: string; context: string }> = [];
+    const decoder = new DapFrameDecoder({
+      onError: (err, context) => errors.push({ message: err.message, context })
+    });
+
+    const response = { seq: 2, type: 'response', command: 'initialize', request_seq: 1, success: true };
+    const junk = Buffer.from('DEBUGGER: unexpected preamble\r\n\r\n', 'utf8');
+    const received = decoder.push(Buffer.concat([junk, frame(response)]));
+
+    expect(received).toEqual([JSON.parse(JSON.stringify(response))]);
+    expect(errors).toEqual([expect.objectContaining({ context: 'header' })]);
+
+    // Later frames decode normally.
+    const event = { seq: 3, type: 'event', event: 'initialized' };
+    expect(decoder.push(frame(event))).toEqual([event]);
+  });
+
+  it('resyncs when the frame after the junk block is itself split across pushes', () => {
+    const errors: string[] = [];
+    const decoder = new DapFrameDecoder({
+      onError: (_err, context) => errors.push(context)
+    });
+
+    const response = { seq: 2, type: 'response', command: 'initialize', request_seq: 1, success: true };
+    const encoded = frame(response);
+    const junk = Buffer.from('garbage line\r\n\r\n', 'utf8');
+    const firstPush = Buffer.concat([junk, encoded.subarray(0, encoded.length - 10)]);
+
+    expect(decoder.push(firstPush)).toEqual([]);
+    expect(decoder.push(encoded.subarray(encoded.length - 10))).toEqual([
+      JSON.parse(JSON.stringify(response))
+    ]);
+    expect(errors).toEqual(['header']);
+  });
+
+  it('junk preamble delivered in a single push never costs the frames behind it', () => {
+    fc.assert(
+      fc.property(
+        messagesArb,
+        fc.string({ unit: fc.constantFrom(...ALNUM.split('')), minLength: 1, maxLength: 64 }),
+        (messages, junkText) => {
+          const decoder = new DapFrameDecoder({ onError: () => { /* expected */ } });
+          const stream = Buffer.concat([
+            Buffer.from(`${junkText}\r\n\r\n`, 'utf8'),
+            ...messages.map(m => encodeDapMessage(m as unknown as DebugProtocol.ProtocolMessage))
+          ]);
+          const received = decoder.push(stream);
+          expect(received).toEqual(messages.map(m => JSON.parse(JSON.stringify(m))));
+        }
+      )
+    );
+  });
+
   it('skips a frame whose body is not valid JSON and continues with the next frame', () => {
     const errors: string[] = [];
     const decoder = new DapFrameDecoder({


### PR DESCRIPTION
Closes #470.

## Root-cause handling

The `Invalid Content-Length header` path in `DapFrameDecoder` discarded the **entire buffered remainder**, not just the malformed block — so when rdbg's direct socket intermittently delivers non-DAP bytes ahead of the `initialize` response, the response is thrown away with the junk, the request promise never settles, and the launch dies at the 30 s init deadline blaming adapter startup.

The decoder now resyncs: it searches the remainder for the next `Content-Length` occurrence and resumes decoding there. When no header start exists in the remainder it falls back to discarding it, preserving the existing protection (pinned by tests) against stray junk poisoning frames in later pushes. Recovery is strictly better than before, never worse.

## Fail-loudly hardening (the issue's independent ask)

`MinimalDapClient` now logs header/overflow decode errors at **error** level naming the pending request seq(s) whenever a request is in flight — a genuinely lost response now points at itself instead of surfacing as a generic init timeout.

## On the trigger

I probed `rdbg --open` raw socket bytes 8× on this machine (spawn → connect → initialize → hex-dump): all clean, no preamble — the junk emission is environment/timing dependent and was only ever observed under full-sweep load (2-of-3 ruby launches in the sweep, per the issue). Rather than chase an intermittent emitter inside the debug gem, this makes the decoder indifferent to it: junk costs one warning, not the session.

## Tests

- New: junk block + response in one chunk → response survives, one `header` error (the literal #470 signature).
- New: junk block + response split across pushes → response survives.
- New property: junk preamble in a single push never costs any following frames.
- Existing invalid-header/JSON-skip/property suites unchanged and passing (92 tests in the three framing/minimal-dap files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)