### PR TITLE
fix(#469): ruby logpoints fail fast; deferred logpoint verdicts surface on the launch response

### DIFF
--- a/packages/shared/src/interfaces/adapter-policy-ruby.ts
+++ b/packages/shared/src/interfaces/adapter-policy-ruby.ts
@@ -6,6 +6,10 @@ import type { DapClientBehavior, DapClientContext, ReverseRequestResult } from '
 
 export const RubyAdapterPolicy: AdapterPolicy = {
   name: 'ruby',
+  // rdbg does not advertise supportsLogPoints and its setBreakpoints ignores
+  // logMessage, silently downgrading a logpoint into a pausing breakpoint —
+  // the inverse of what a logpoint promises. Reject up front (issue #469).
+  supportsLogPoints: false,
   supportsReverseStartDebugging: false,
   childSessionStrategy: 'none',
   buildChildStartArgs: () => {

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -885,12 +885,16 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       // unverified-at-launch is the designed deferral path.
       const fnBpWarning = this.buildFunctionBreakpointLaunchWarning(finalSession);
 
+      // Logpoint-downgrade verdict (issue #469): the deferred set_breakpoint
+      // warning promised a launch-time answer — deliver it on this response.
+      const logpointWarning = this.buildLogpointDowngradeLaunchWarning(finalSession);
+
       // Adapter degradation notes (issue #441) accumulate on the session as
       // annotated output events arrive; joining here is best-effort — a note
       // arriving after this return still lands in the output buffer as an
       // attributed [mcp-debugger] Warning entry.
       const launchWarning =
-        [fnBpWarning, ...(finalSession.adapterNotices ?? [])]
+        [fnBpWarning, logpointWarning, ...(finalSession.adapterNotices ?? [])]
           .filter(Boolean)
           .join('; ') || undefined;
 
@@ -1507,6 +1511,36 @@ export abstract class SessionManagerOperations extends SessionManagerData {
    * undefined for bind-late policies (js/java) — unverified-at-launch is
    * their designed deferral, not a failure.
    */
+  /**
+   * Launch-time logpoint-downgrade warning (issue #469). A logpoint accepted
+   * pre-launch under unknown policy support ("it will be validated against
+   * the adapter's capabilities at launch") gets its promised verdict here:
+   * when the live adapter does not advertise supportsLogPoints, the logpoint
+   * has been silently downgraded to a pausing breakpoint — say so in the
+   * start_debugging response instead of only in the server log.
+   */
+  protected buildLogpointDowngradeLaunchWarning(session: ManagedSession): string | undefined {
+    const caps = session.adapterCapabilities;
+    if (!caps || caps.supportsLogPoints === true) {
+      return undefined;
+    }
+    const downgraded: string[] = [];
+    for (const bp of session.breakpoints.values()) {
+      if (bp.logMessage !== undefined) {
+        downgraded.push(`${path.basename(bp.file)}:${bp.line}`);
+      }
+    }
+    if (downgraded.length === 0) {
+      return undefined;
+    }
+    return (
+      `Logpoint(s) at ${downgraded.join(', ')} were downgraded to pausing breakpoints: ` +
+      `the ${session.language} adapter does not advertise supportsLogPoints, so the ` +
+      `logMessage will not be logged and the program will PAUSE at those lines instead ` +
+      `of running through them`
+    );
+  }
+
   protected buildFunctionBreakpointLaunchWarning(session: ManagedSession): string | undefined {
     if ((session.functionBreakpoints?.size ?? 0) === 0) {
       return undefined;

--- a/tests/adapters/ruby/unit/adapter-policy-ruby.test.ts
+++ b/tests/adapters/ruby/unit/adapter-policy-ruby.test.ts
@@ -335,3 +335,13 @@ describe('buildRdbgInvocation', () => {
       .toThrow(/Set RDBG_PATH to the rdbg Ruby script/);
   });
 });
+
+describe('RubyAdapterPolicy logpoint verdict (issue #469)', () => {
+  it('declares supportsLogPoints false so logMessage is rejected up front', () => {
+    // rdbg does not advertise supportsLogPoints and silently downgrades a
+    // logpoint into a pausing breakpoint. An undefined verdict here defers
+    // to a launch-time validation whose answer the caller never used to
+    // receive — the policy must say false so set_breakpoint fails fast.
+    expect(RubyAdapterPolicy.supportsLogPoints).toBe(false);
+  });
+});

--- a/tests/core/unit/session/session-manager-logpoint-warning.test.ts
+++ b/tests/core/unit/session/session-manager-logpoint-warning.test.ts
@@ -1,0 +1,76 @@
+/**
+ * buildLogpointDowngradeLaunchWarning (issue #469): the deferred
+ * set_breakpoint warning ("validated against the adapter's capabilities at
+ * launch") must actually deliver its verdict on the start_debugging
+ * response when the live adapter cannot do logpoints.
+ */
+import { describe, it, expect } from 'vitest';
+import { SessionManager } from '../../../../src/session/session-manager.js';
+
+type BuilderSession = {
+  language: string;
+  adapterCapabilities?: Record<string, unknown>;
+  breakpoints: Map<string, { file: string; line: number; logMessage?: string }>;
+};
+
+function build(session: BuilderSession): string | undefined {
+  // The builder reads only session state, so invoking it off the prototype
+  // with a bare receiver keeps this a pure unit test.
+  return (SessionManager.prototype as unknown as {
+    buildLogpointDowngradeLaunchWarning(s: BuilderSession): string | undefined;
+  }).buildLogpointDowngradeLaunchWarning.call({}, session);
+}
+
+const logpoint = { file: '/proj/examples/ruby/fizzbuzz.rb', line: 16, logMessage: 'value={value}' };
+
+describe('buildLogpointDowngradeLaunchWarning', () => {
+  it('warns when the live adapter does not advertise supportsLogPoints', () => {
+    const warning = build({
+      language: 'ruby',
+      adapterCapabilities: { supportsFunctionBreakpoints: true },
+      breakpoints: new Map([['a', logpoint]])
+    });
+    expect(warning).toMatch(/fizzbuzz\.rb:16/);
+    expect(warning).toMatch(/downgraded to pausing breakpoint/);
+    expect(warning).toMatch(/PAUSE/);
+  });
+
+  it('stays silent when the adapter advertises logpoint support', () => {
+    expect(
+      build({
+        language: 'python',
+        adapterCapabilities: { supportsLogPoints: true },
+        breakpoints: new Map([['a', logpoint]])
+      })
+    ).toBeUndefined();
+  });
+
+  it('stays silent when no logpoints exist', () => {
+    expect(
+      build({
+        language: 'ruby',
+        adapterCapabilities: {},
+        breakpoints: new Map([['a', { file: '/proj/x.rb', line: 3 }]])
+      })
+    ).toBeUndefined();
+  });
+
+  it('stays silent before capabilities are known', () => {
+    expect(
+      build({ language: 'ruby', breakpoints: new Map([['a', logpoint]]) })
+    ).toBeUndefined();
+  });
+
+  it('names every downgraded logpoint', () => {
+    const warning = build({
+      language: 'ruby',
+      adapterCapabilities: {},
+      breakpoints: new Map([
+        ['a', logpoint],
+        ['b', { file: '/proj/lib/other.rb', line: 42, logMessage: 'hi' }]
+      ])
+    });
+    expect(warning).toMatch(/fizzbuzz\.rb:16/);
+    expect(warning).toMatch(/other\.rb:42/);
+  });
+});

--- a/tests/e2e/mcp-server-logpoints.test.ts
+++ b/tests/e2e/mcp-server-logpoints.test.ts
@@ -5,11 +5,14 @@
  * hot line does NOT pause execution; the interpolated message arrives as
  * output readable via get_output.
  *
- * Known-unsupported adapters (java, dotnet): set_breakpoint with logMessage
- * fails fast with a clear error.
+ * Known-unsupported adapters (java, dotnet, ruby): set_breakpoint with
+ * logMessage fails fast with a clear error. (Ruby joined this group in
+ * issue #469 — rdbg does not advertise supportsLogPoints and silently
+ * downgrades logpoints into pausing breakpoints.)
  *
- * Unknown support (ruby): accepted with a warning; runtime behavior is
- * adapter-dependent and not asserted.
+ * Unknown support ('warning' expectation): accepted with a warning; runtime
+ * behavior is adapter-dependent and not asserted. No in-tree adapter is in
+ * this group any more, but the path remains for dynamically loaded adapters.
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import path from 'path';
@@ -30,7 +33,7 @@ const EXPECTATION: Record<string, 'logs' | 'error' | 'warning'> = {
   mock: 'logs',
   java: 'error',
   dotnet: 'error',
-  ruby: 'warning',
+  ruby: 'error',
 };
 
 // Python's bpLine has a=1, b=2 in scope — assert real interpolation there.


### PR DESCRIPTION
Closes #469.

## What was wrong

A ruby logpoint was accepted with "support is unknown; it will be validated against the adapter's capabilities at launch" — and that verdict never arrived on any caller-visible channel. rdbg ignored the `logMessage`, the program froze at a pausing breakpoint, and `list_breakpoints` asserted a verified logpoint.

## Fix (issue options 3 + 1)

1. **Up-front rejection for ruby.** `RubyAdapterPolicy` now declares `supportsLogPoints: false` — verified against rdbg's live initialize response, which does not advertise the capability. `set_breakpoint` with `logMessage` on ruby now returns the same clear error java/dotnet produce: `Logpoints (logMessage) not supported by the ruby adapter`. (Java/.NET were checked per the issue's note — they already had `false` and already fail fast.)
2. **The deferred verdict now actually arrives** for adapters whose support is genuinely unknown (none in-tree any more, but dynamically loaded adapters remain): `buildLogpointDowngradeLaunchWarning` mirrors the #308 unbound-function-breakpoint pattern — when live capabilities lack `supportsLogPoints` and logpoints exist, the `start_debugging` response `warning` names each downgraded logpoint (`file:line`) and says the program will **PAUSE** there instead of logging.

## Verification

- Live repro: `set_breakpoint` + `logMessage` on a ruby session → immediate clear error (previously: silent downgrade, frozen debuggee).
- New unit tests: policy verdict pin; 5 cases for the launch-warning builder.
- Logpoints e2e updated (ruby: `warning` group → `error` group) — 9 tests passing against the real adapters.
- Full unit suites: 3208 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)