### PR TITLE
fix(#465): java attach actually pauses the JVM; get_stack_trace gains threadId

### DIFF
--- a/packages/shared/src/interfaces/adapter-policy-java.ts
+++ b/packages/shared/src/interfaces/adapter-policy-java.ts
@@ -175,6 +175,15 @@ export const JavaAdapterPolicy: AdapterPolicy = {
            argsStr.includes('java-debug');
   },
 
+  // The JDI bridge does NOT suspend the VM on attach (its attach handler
+  // only suspends for stopOnEntry in the DAP args, which the transform does
+  // not send) — so without an explicit pause the session reports PAUSED
+  // while the JVM keeps running, and every thread refuses stackTrace
+  // ("not suspended"), leaving the session uninspectable (issue #465).
+  // pauseAllThreads: the bridge's pause-all suspends the whole VM and
+  // anchors its stopped event to a thread that can actually report frames.
+  getAttachBehavior: () => ({ pauseAfterAttach: true, pauseAllThreads: true }),
+
   // JdiDapServer sends "initialized" during initialize (before launch).
   // sendLaunchBeforeConfig tells the proxy to wait for initialized first,
   // then send launch, then breakpoints + configurationDone.

--- a/packages/shared/src/interfaces/adapter-policy.ts
+++ b/packages/shared/src/interfaces/adapter-policy.ts
@@ -478,11 +478,16 @@ export interface AdapterPolicy {
   /**
    * Attach-mode behavior tweaks.
    * pauseAfterAttach: send an explicit DAP 'pause' after attaching when
-   * stopOnEntry is requested. Needed for debuggers (rdbg) that do NOT
-   * suspend the target on attach when it is already running — without it the
-   * session would report PAUSED while the target keeps executing.
+   * stopOnEntry is requested. Needed for debuggers (rdbg, the Java JDI
+   * bridge) that do NOT suspend the target on attach when it is already
+   * running — without it the session would report PAUSED while the target
+   * keeps executing.
+   * pauseAllThreads: send the pause with threadId 0 (pause-all) instead of
+   * the discovered thread's id. The JDI bridge suspends the whole VM on a
+   * pause-all and re-anchors its stopped event to a thread that can actually
+   * report frames (issue #465).
    */
-  getAttachBehavior?(): { pauseAfterAttach?: boolean };
+  getAttachBehavior?(): { pauseAfterAttach?: boolean; pauseAllThreads?: boolean };
 
   /**
    * Get the configuration for starting the debug adapter connection.

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import {
     Breakpoint,
     FunctionBreakpoint,
     SessionLifecycleState,
+    SessionState,
     IEnvironment,
     ExceptionBreakMode,
     REDACTION_NOTICE
@@ -851,11 +852,30 @@ export class DebugMcpServer {
     return this.sessionManager.getVariablesDetailed(sessionId, variablesReference, names);
   }
 
-  public async getStackTrace(sessionId: string, includeInternals: boolean = false): Promise<StackTraceResult> {
+  public async getStackTrace(
+    sessionId: string,
+    includeInternals: boolean = false,
+    threadId?: number
+  ): Promise<StackTraceResult> {
     this.validateSession(sessionId);
     const session = this.sessionManager.getSession(sessionId);
     if (!session || !session.proxyManager) {
         throw new ProxyNotRunningError(sessionId || 'unknown', 'get stack trace');
+    }
+    // An explicit threadId (issue #465) targets that thread AND adopts it as
+    // current when it reports frames, so follow-up scopes/locals/evaluate
+    // anchor to it — this is the escape hatch when the session anchored to a
+    // frameless thread.
+    if (typeof threadId === 'number') {
+      // No ensureStackReady scan here: the caller asked about THIS thread,
+      // so an empty answer for it is the honest one (no silent re-anchor).
+      const result = await this.sessionManager.getStackTraceDetailed(
+        sessionId, threadId, includeInternals
+      );
+      if (result.frames.length > 0) {
+        session.proxyManager.setCurrentThreadId(threadId);
+      }
+      return result;
     }
     let currentThreadId = session.proxyManager.getCurrentThreadId();
     // If no thread ID is known (e.g. adapter omitted threadId from stopped event),
@@ -1180,7 +1200,7 @@ export class DebugMcpServer {
           { name: 'list_threads', description: 'List all threads in the debugged process', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
           { name: 'get_variables', description: 'Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, scope: { type: 'number', description: "The variablesReference number from a StackFrame or Variable" }, names: namesProp }, required: getVariablesRequired } },
           { name: 'get_local_variables', description: 'Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeSpecial: { type: 'boolean', description: 'Include special/internal variables like this, __proto__, __builtins__, etc. Default: false' }, names: namesProp }, required: getLocalVariablesRequired } },
-          { name: 'get_stack_trace', description: 'Get stack trace. The response includes stopReason — why the session is paused (e.g. "breakpoint" vs "exception"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeInternals: { type: 'boolean', description: 'Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output.' } }, required: ['sessionId'] } },
+          { name: 'get_stack_trace', description: 'Get stack trace. The response includes stopReason — why the session is paused (e.g. "breakpoint" vs "exception"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeInternals: { type: 'boolean', description: 'Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output.' }, threadId: { type: 'number', description: 'Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread' } }, required: ['sessionId'] } },
           { name: 'get_scopes', description: 'Get scopes for a stack frame', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, frameId: { type: 'number', description: "The ID of the stack frame from a stackTrace response" } }, required: ['sessionId', 'frameId'] } },
           { name: 'evaluate_expression', description: 'Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, expression: { type: 'string' }, frameId: { type: 'number', description: 'Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically' }, timeout: { type: 'number', description: 'Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout' } }, required: ['sessionId', 'expression'] } },
           { name: 'get_source_context', description: 'Get source context around a specific line in a file', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: fileDescription }, line: { type: 'number', description: 'Line number to get context for' }, linesContext: { type: 'number', description: 'Number of lines before and after to include (default: 5)' } }, required: ['sessionId', 'file', 'line'] } },
@@ -2079,7 +2099,7 @@ export class DebugMcpServer {
               try {
                 // Default to false for cleaner output
                 const includeInternals = args.includeInternals ?? false;
-                const stackTrace = await this.getStackTrace(args.sessionId, includeInternals);
+                const stackTrace = await this.getStackTrace(args.sessionId, includeInternals, args.threadId);
                 const lastStop = this.sessionManager.getSession(args.sessionId)?.lastStop;
                 const payload: Record<string, unknown> = {
                   success: true,
@@ -2750,7 +2770,15 @@ export class DebugMcpServer {
       // Add helpful messages for edge cases
       if (result.variables.length === 0) {
         if (!result.frame) {
-          response.message = 'No stack frames available. The debugger may not be paused.';
+          // Distinguish "not paused" from "paused but the anchored thread has
+          // no frames" — the latter used to claim the debugger may not be
+          // paused while list_debug_sessions said paused (issue #465).
+          const sessionState = this.sessionManager.getSession(args.sessionId)?.state;
+          response.message = sessionState === SessionState.PAUSED
+            ? 'The session is paused, but the anchored thread reported no stack frames. ' +
+              'Try get_stack_trace with a threadId from list_threads, or continue_execution ' +
+              'followed by pause_execution to re-anchor on a reportable thread.'
+            : 'No stack frames available. The debugger may not be paused.';
         } else if (!result.scopeName) {
           response.message = 'No local scope found in the current frame.';
         } else {

--- a/src/session/session-manager-data.ts
+++ b/src/session/session-manager-data.ts
@@ -325,7 +325,7 @@ export abstract class SessionManagerData extends SessionManagerCore {
     this.logger.warn(`[SM getStackTrace ${sessionId}] Stack stayed empty for ${this.pausedStackReadyTimeoutMs}ms while paused (threadId ${threadId}).`);
     return {
       frames: [],
-      note: `The stopped thread reported no stack frames within ${this.pausedStackReadyTimeoutMs}ms; the target may be paused in native code. Retry get_stack_trace, or use list_threads to inspect other threads.`
+      note: `The stopped thread reported no stack frames within ${this.pausedStackReadyTimeoutMs}ms; the target may be paused in native code. Try get_stack_trace with a threadId from list_threads, or continue_execution followed by pause_execution to re-anchor the session on a reportable thread.`
     };
   }
 

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -2787,8 +2787,13 @@ export abstract class SessionManagerOperations extends SessionManagerData {
             proxyManager.once('stopped', onStopped);
           });
           try {
-            await proxyManager.sendDapRequest('pause', { threadId: discoveredThreadId });
-            this.logger.info(`[SessionManager] Sent post-attach pause (threadId=${discoveredThreadId})`);
+            // pauseAllThreads (issue #465): threadId 0 asks the adapter for a
+            // process-wide suspend — the JDI bridge then re-anchors its
+            // stopped event to a thread that can actually report frames,
+            // instead of single-thread-suspending whichever id we picked.
+            const pauseThreadId = attachBehavior.pauseAllThreads ? 0 : discoveredThreadId;
+            await proxyManager.sendDapRequest('pause', { threadId: pauseThreadId });
+            this.logger.info(`[SessionManager] Sent post-attach pause (threadId=${pauseThreadId})`);
             const stopObserved = await stoppedSeen;
             if (!stopObserved) {
               this.logger.warn(

--- a/tests/adapters/java/unit/java-debug-adapter.test.ts
+++ b/tests/adapters/java/unit/java-debug-adapter.test.ts
@@ -750,3 +750,12 @@ describe('JavaDebugAdapter', () => {
     });
   });
 });
+
+describe('JavaAdapterPolicy attach behavior (issue #465)', () => {
+  it('requests a pause-all after attach so the reported PAUSED state is real', async () => {
+    const { JavaAdapterPolicy } = await import('@debugmcp/shared');
+    const behavior = JavaAdapterPolicy.getAttachBehavior?.();
+    expect(behavior?.pauseAfterAttach).toBe(true);
+    expect(behavior?.pauseAllThreads).toBe(true);
+  });
+});

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -2026,6 +2026,34 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 1 });
     });
 
+    it('sends a pause-all post-attach pause for java (issue #465)', async () => {
+      // The JDI bridge does not suspend the VM on attach; without this pause
+      // the session reports PAUSED while the JVM keeps running and every
+      // thread refuses stackTrace. pauseAllThreads sends threadId 0 so the
+      // bridge suspends the whole VM and re-anchors its stopped event to a
+      // thread that can report frames.
+      mockSession.language = 'java';
+      mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
+        if (command === 'threads') {
+          return { body: { threads: [{ id: 1, name: 'main' }] } };
+        }
+        return {};
+      });
+
+      vi.spyOn(operations as any, 'startProxyManager').mockImplementation(async () => {
+        mockSession.proxyManager = mockProxyManager;
+      });
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 5016,
+        host: '127.0.0.1',
+        stopOnEntry: true
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('pause', { threadId: 0 });
+    });
+
     it('should tolerate a rejected post-attach pause (target already stopped)', async () => {
       mockSession.language = 'ruby';
       mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
@@ -2054,8 +2082,11 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       );
     });
 
-    it('should not send a post-attach pause for policies without the behavior (java)', async () => {
-      mockSession.language = 'java';
+    it('should not send a post-attach pause for policies without the behavior (go)', async () => {
+      // java moved to pauseAfterAttach in issue #465 — go's policy has no
+      // getAttachBehavior (Delve suspends on attach natively), so it keeps
+      // the no-pause default this test pins.
+      mockSession.language = 'go';
       mockProxyManager.sendDapRequest.mockImplementation(async (command: string) => {
         if (command === 'threads') {
           return { body: { threads: [{ id: 2, name: 'main' }] } };


### PR DESCRIPTION
Closes #465.

## Root cause

Not a frameless-thread anchor after all: the JDI bridge **never suspends the VM on attach** (its attach handler only suspends for `stopOnEntry` in the DAP args, which the transform doesn't send), and java's policy lacked `pauseAfterAttach` — the only mainstream policy without it. So the session reported `paused` while the JVM kept running, and *every* thread refused `stackTrace` ("not suspended") — which is why the existing frameless-thread scan found nothing anywhere, and why `continue` → `pause` (a real `vm.suspend()`) fixed it.

## Fix (issue asks 1–4)

1. **`JavaAdapterPolicy.getAttachBehavior`** → `pauseAfterAttach: true, pauseAllThreads: true` (new knob): the post-attach pause is sent with `threadId 0`, so the bridge suspends the whole VM and anchors its stopped event via its own `pickReportableThread` hardening (#352) — a thread that can actually report frames.
2. **`get_stack_trace` accepts `threadId`** (ids from `list_threads`); when that thread reports frames it is adopted as the anchor for follow-up scopes/locals/evaluate. The escape hatch the old note pointed at now exists. (No silent re-anchor scan on explicit requests — an empty answer for the asked-about thread stays honest.)
3. **The note names the real recovery** — `threadId` targeting or `continue_execution` + `pause_execution` — instead of advice that couldn't be followed.
4. **`get_local_variables` no longer contradicts session state**: paused-with-frameless-anchor now says exactly that, with the same recovery pointers.

## Verification

- Live repro (`java -agentlib:jdwp=...,suspend=n`, `attach_to_process`): `get_stack_trace` returns `PauseTest.main` and `get_local_variables` returns `counter` **on the first try** (previously: empty frames, unactionable note, "may not be paused"). `threadId: 1` targeting verified too.
- New unit tests: java sends pause-all (`threadId: 0`) post-attach; policy pin for the attach behavior; the policies-without-behavior pin moved from java to go (java joining was the point).
- Full unit suites: 3207 passed.

Note: the issue's C/C++ observation (pause anchoring to an arbitrary thread, e.g. LLDB's injected `DbgBreakPoint` thread) now has a complete discoverable path: `list_threads` → `get_stack_trace {threadId}` → locals anchored there. Composes with #482's frame walk-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)