### PR TITLE
fix(#530): stop reporting every clean proxy shutdown as a pre-init death

### DIFF
--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -138,6 +138,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     timer?: NodeJS.Timeout;
   }>();
   private isInitialized = false;
+  // Never reset by cleanup(): stop() runs cleanup() before the process 'exit'
+  // event arrives, so isInitialized alone cannot distinguish a genuine
+  // pre-init death from the exit that follows every normal stop (issue #530)
+  private everInitialized = false;
   private isStopped = false;
   /** Bounded wait for in-flight DAP requests to settle before stop() cancels them. */
   private stopDrainTimeoutMs = 1000;
@@ -210,6 +214,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
     this.sessionId = config.sessionId;
     this.isStopped = false;
+    // The latch tracks the process this start() launches (issue #530)
+    this.everInitialized = false;
     this.isDryRun = config.dryRunSpawn === true;
     this.dryRunCompleteReceived = false;
     this.dryRunCommandSnapshot = undefined;
@@ -331,6 +337,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
       const handleInitialized = () => {
         this.isInitialized = true;
+        this.everInitialized = true;
         cleanup();
         resolve();
       };
@@ -932,7 +939,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         capturedStderr: [...this.stderrBuffer],
       };
 
-      if (!this.isInitialized) {
+      // everInitialized, not isInitialized: stop() runs cleanup() (which
+      // resets isInitialized) before this event fires, so the reset flag
+      // would report every orderly shutdown as a pre-init death (issue #530)
+      if (!this.everInitialized) {
         this.logger.error(
           `[ProxyManager] Proxy exited before initialization. code=${code} signal=${signal} stderrLines=${this.stderrBuffer.length}`,
           this.stderrBuffer
@@ -1086,6 +1096,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         
         // Sync local state with functional core state
         this.isInitialized = result.newState.initialized;
+        if (result.newState.initialized) {
+          this.everInitialized = true;
+        }
         this.adapterConfigured = result.newState.adapterConfigured;
         // The imperative currentThreadId is authoritative — the fast-path
         // stopped handler in handleDapEvent writes it. Restoring the core's
@@ -1236,6 +1249,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         this.emit('adapter-configured');
         if (!this.isInitialized) {
           this.isInitialized = true;
+          this.everInitialized = true;
           this.emit('initialized');
         }
         break;
@@ -1245,6 +1259,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         this.logger.info(`[ProxyManager] Adapter transport connected. Marking initialized to unblock client handshake.`);
         if (!this.isInitialized) {
           this.isInitialized = true;
+          this.everInitialized = true;
           this.emit('initialized');
         }
         break;

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -1012,6 +1012,45 @@ describe('ProxyManager.start', () => {
       expect(fakeProcess.kill).not.toHaveBeenCalled();
     });
 
+    it('does not log "exited before initialization" for the exit that follows a clean stop (issue #530)', async () => {
+      await proxyManager.start(baseConfig);
+      // Initialize through the real message path so the everInitialized
+      // latch is exercised, not poked
+      fakeProcess.emit('message', {
+        type: 'status',
+        status: 'adapter_connected',
+        sessionId: baseConfig.sessionId
+      });
+
+      fakeProcess.killed = false;
+      fakeProcess.send.mockClear();
+
+      const stopPromise = proxyManager.stop();
+      // Let stop() pass its drain and run cleanup() (which resets
+      // isInitialized) before the process exit lands — the real ordering
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(fakeProcess.send).toHaveBeenCalledWith({ cmd: 'terminate', sessionId: baseConfig.sessionId });
+
+      fakeProcess.emit('exit', 0, null);
+      await stopPromise;
+
+      const preInitErrors = (logger.error as ReturnType<typeof vi.fn>).mock.calls
+        .filter((call: unknown[]) => String(call[0]).includes('exited before initialization'));
+      expect(preInitErrors).toEqual([]);
+    });
+
+    it('still logs "exited before initialization" when the proxy dies uninitialized (issue #530)', async () => {
+      // Dry-run start resolves via dry-run-complete without ever marking the
+      // proxy initialized
+      await proxyManager.start(baseConfig);
+
+      fakeProcess.emit('exit', 1, null);
+
+      const preInitErrors = (logger.error as ReturnType<typeof vi.fn>).mock.calls
+        .filter((call: unknown[]) => String(call[0]).includes('exited before initialization'));
+      expect(preInitErrors.length).toBe(1);
+    });
+
     it('cleanup rejects all pending requests and clears launch barrier', () => {
       const pendingReject = vi.fn();
       (proxyManager as unknown as { pendingDapRequests: Map<string, any> }).pendingDapRequests.set('req-1', {


### PR DESCRIPTION
Fixes #530.

## What happened

Every clean debug-session close logs an error-level

```
[ProxyManager] Proxy exited before initialization. code=0 signal=null stderrLines=12
```

plus a dump of routine captured stderr — for a proxy that was fully initialized, ran a complete session, and exited with code 0 in response to the server's own terminate command. Seven occurrences in one full-suite e2e run; it also reads as a crash to anyone triaging logs (it briefly derailed the #529 investigation).

## Mechanism

`stop()` runs `cleanup()` — which resets `isInitialized` — *before* sending the terminate command. By the time the process `exit` event arrives (~800 ms later), the handler's `!this.isInitialized` check is true for every orderly shutdown, tripping a diagnostic meant for proxies that die during startup.

## The fix

An `everInitialized` latch, set wherever `isInitialized` becomes true and never reset by `cleanup()` (re-armed at the top of `start()` so it always describes the process that start launched). The exit handler gates the pre-init error on the latch. Genuine pre-init deaths still log loudly; clean shutdowns log nothing extra.

## Tests

- `does not log "exited before initialization" for the exit that follows a clean stop (issue #530)` — initializes via the real `adapter_connected` message path, replicates the real ordering (stop → cleanup → terminate → exit), fails without the fix.
- `still logs "exited before initialization" when the proxy dies uninitialized (issue #530)` — the genuine diagnostic is preserved (passes with and without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiTRwc8dshMYgmbp5o5m5t
