### PR TITLE
fix(#502): make proxy-worker teardown deterministic — latch terminate onto in-flight shutdown, escalate on real exit evidence, verify the kill

### DIFF
--- a/docs/case-studies/the-zombie-worker-and-the-frozen-force-kill.md
+++ b/docs/case-studies/the-zombie-worker-and-the-frozen-force-kill.md
@@ -65,7 +65,7 @@ A 54-second-old zombie (its debuggee died at t≈4s), argv-tagged as exactly the
 
 6. `continue_execution` on session 1 released the frozen timer; SIGKILL delivered; the zombie died within a second. Both attach sessions closed cleanly.
 
-## The fix ([PR #533](https://github.com/debugmcp/mcp-debugger/pull/533))
+## The fix ([PR #535](https://github.com/debugmcp/mcp-debugger/pull/535))
 
 Root cause plus every hole the audit found on the escalation path:
 

--- a/docs/case-studies/the-zombie-worker-and-the-frozen-force-kill.md
+++ b/docs/case-studies/the-zombie-worker-and-the-frozen-force-kill.md
@@ -1,0 +1,94 @@
+# Case study: the zombie worker and the frozen force-kill
+
+*How the stale-session reaper's leaked proxy worker ([#502](https://github.com/debugmcp/mcp-debugger/issues/502)) turned out to be a shutdown race the worker loses against itself — reproduced on the first try, then held open live by attaching mcp-debugger to **both sides of its own bug at once**: one debug session frozen inside the parent's force-kill timer, a second attached to the zombie worker it was about to kill.*
+
+## The incident
+
+Issue #502 (single Windows observation, low confidence): after the Streamable HTTP stale-session reaper tore down an abandoned session, that session's proxy worker process stayed alive for minutes, holding its DAP sockets, until killed by hand. A follow-up audit on the issue confirmed the teardown chain had real holes — fire-and-forget `stop()` calls behind cleared references, a `.killed`-gated SIGKILL escalation, no retained worker pid — but could not reproduce the leak on Linux: the reaper's own path tore down cleanly every time.
+
+The audit was looking one layer too high. The live mechanism is in the worker.
+
+## The race, precisely
+
+On natural debuggee termination the worker's DAP event callback ends with a bare `this.shutdown()` — a floating promise (`dap-proxy-worker.ts`). `shutdown()` sets state `SHUTTING_DOWN`, then spends ≥1s in teardown (two 500ms grace waits plus an adapter tree-kill) before reaching `TERMINATED`.
+
+Meanwhile the parent reacts to the same DAP `terminated` event by calling `ProxyManager.stop()`, which sends the worker an IPC `terminate` command. That command lands **inside** the shutdown window essentially every time — the parent's reaction takes ~7ms, the window is ~800ms. And then:
+
+- `handleTerminate` sees `SHUTTING_DOWN` and **early-returns** ("Already shutting down or terminated.");
+- the runner's sole exit scheduler runs after `handleCommand` returns and fires only when state is exactly `TERMINATED` — it sees `SHUTTING_DOWN` and schedules **nothing**;
+- the in-flight shutdown later reaches `TERMINATED`, but it wasn't command-driven, so the check never runs again.
+
+The worker completes its own shutdown perfectly and then sits alive forever in state `TERMINATED`, an idle event loop holding an IPC pipe. Nothing is coming to save it except the parent's 5-second force-kill timer — and the audit had already shown how that escalation can be skipped (`.killed` latches on any *delivered* signal, not on death; a second `stop()` no-ops because `cleanup()` already dropped the handle; the status-driven `'exit'` handler never stops at all). On Linux the SIGKILL usually lands, which is why the reaper path "worked". The leak is what happens when it doesn't.
+
+First repro attempt, unfixed main, mock adapter, natural termination — the worker's own log:
+
+```
+21:44:15.058  [Worker] DAP event: terminated             ← floating shutdown() begins
+21:44:15.065  [Worker] handleCommand cmd=terminate       ← parent's command, 7ms later
+21:44:15.065  [Worker] Already shutting down or terminated.
+21:44:15.065  [Worker] Completed command terminate … state=shutting_down   ← no exit scheduled
+21:44:15.866  [Worker] Shutdown sequence completed.      ← TERMINATED; nobody re-checks
+21:44:20.064  [ProxyManager] Timeout waiting for proxy exit. Force killing.  ← parent server log
+```
+
+The worker survived its own completed shutdown by exactly five seconds, and died only by SIGKILL. Deterministic, first try.
+
+## Holding the bug open: two debuggers on one leak
+
+A 5-second zombie is hard to inspect. So the window was held open with mcp-debugger itself:
+
+1. **Target**: a standalone unfixed server, `node --inspect=9250 dist/index.js http -p 3987`.
+2. **Debugger session 1** attached to the *server* (`attach_to_process`, port 9250) and set a breakpoint on the force-kill line — `set_breakpoint` echoed the exact line content back for verification:
+   `` this.logger.warn(`[ProxyManager] Timeout waiting for proxy exit. Force killing.`) ``
+3. A scratch MCP client drove a mock session to natural termination and abandoned it.
+4. Five seconds later the server froze at the breakpoint — **inside the force-kill timer callback, SIGKILL not yet delivered**. Pausing the parent freezes its timer, so the window the race opened now stays open indefinitely.
+
+The paused frame's async stack drew the whole indictment in one screen: the timeout callback → `stop()` → `handleExited` (`session-manager-core.ts` — the fire-and-forget site from the audit) → `handleDapEvent` → the IPC message handler. `evaluate_expression` in the frozen frame:
+
+```json
+{"handleKilled": false, "handleExitCode": null, "handleSignalCode": null,
+ "workerPid": 672121, "managerProxyProcess": "nulled-by-cleanup", "isStopped": true}
+```
+
+The worker got its terminate command five seconds ago and has not exited (`exitCode`/`signalCode` null); the manager already nulled its own handle (`cleanup()` runs *before* the escalation) — only this closure can still kill it.
+
+5. **Debugger session 2**, while session 1 held the parent frozen: `kill -USR1 672121` opened the zombie's inspector, and a second mcp-debugger javascript session attached straight to the leaked worker:
+
+```json
+{"pid": 672121,
+ "argv": ["--mcp-owner-pid=671384", "--mcp-session-id=f0d62c51-…"],
+ "uptimeSec": 54, "activeHandles": ["Pipe", "Socket", "Socket"],
+ "connectedToParent": true}
+```
+
+A 54-second-old zombie (its debuggee died at t≈4s), argv-tagged as exactly the reaped session's worker, event loop empty but for the IPC pipe and stdio — alive until someone external kills it. That is #502's Windows observation, recreated and inspected from the inside on Linux.
+
+6. `continue_execution` on session 1 released the frozen timer; SIGKILL delivered; the zombie died within a second. Both attach sessions closed cleanly.
+
+## The fix ([PR #533](https://github.com/debugmcp/mcp-debugger/pull/533))
+
+Root cause plus every hole the audit found on the escalation path:
+
+- **Worker** (`dap-proxy-worker.ts`): `shutdown()` is now re-entrant via a latched promise; a `terminate` command arriving mid-shutdown **awaits the in-flight shutdown** instead of early-returning, so `handleCommand` completes only once state is `TERMINATED` and the runner schedules the exit. (A subtlety: the init-failure path shuts down *before* rethrowing, then used to roll state back and re-run the entire teardown to land on `TERMINATED` — the rollback is now skipped when a shutdown already ran.)
+- **ProxyManager / process adapter**: the IPC-send, SIGKILL, and early-resolve guards in `stop()` now key on actual exit evidence (`exitCode`/`signalCode`), not `.killed`; `ProxyProcessAdapter.kill()` likewise refuses only after real exit, so escalation signals always deliver; the worker pid is retained across `cleanup()` and exposed as `IProxyManager.getProxyPid()`.
+- **SessionManager**: terminal handlers record the pid and retain their `stop()` promise on the session (`pendingProxyStop`); `closeSession` awaits it even when `proxyManager` is already cleared; the status-driven `'exit'` (worker *claims* dead — the OS process may not be) now stops the proxy like every other terminal event; and 1.5s after every close a `process.kill(pid, 0)` liveness probe logs `leaked worker (issue #502)` with the pid if the worker survived — a recurrence can never again be invisible.
+- **HTTP layer**: `MCP_HTTP_STALE_SWEEP_INTERVAL_MS` makes the 60s sweep testable in seconds; and `--log-file` now applies to the CLI logger too (see below).
+
+After the fix, the same scenario:
+
+```
+22:05:10.748  [Worker] handleCommand cmd=terminate
+22:05:10.750  [Worker] Terminate received during in-flight shutdown; awaiting completion.
+22:05:11.549  [Worker] Shutdown sequence completed.
+22:05:11.549  [Worker] Completed command terminate … state=terminated   ← exit scheduled
+22:05:11.550  (node:687009) WARNING: Exited the environment with code 0
+```
+
+Clean exit ~800ms after termination; no force-kill anywhere; the abandoned session reaped three seconds later. The new e2e (`tests/e2e/mcp-server-smoke-http-stale-reap.test.ts`) pins the whole chain against the real server: worker pid captured via argv tags, client dropped without DELETE, pid polled to death, and the log asserted to contain the reap line but **not** the force-kill line — red on unfixed main, green in 7s after the fix.
+
+## What dogfooding surfaced along the way
+
+- **`--log-file` never reached the CLI logger.** The `http` command silences the console to protect stdio transports, and the CLI logger is created before option parsing — so the stale-session reaper's warn line (added by #337 precisely to make reaping visible) went to a per-pid default log nobody watches, and the operator's `--log-file` showed a session being closed with no explanation. Found because the e2e's reap assertion failed against a server that had demonstrably reaped. Fixed for `http` in this PR (`attachSharedFileTransport`); the deprecated `sse` path has the same defect ([#533](https://github.com/debugmcp/mcp-debugger/issues/533)).
+- **Freezing a timer with a breakpoint is a general technique** for turning a transient process state into an inspectable one: the parent's 5s force-kill only fires from its event loop, so pausing the parent at the timer callback holds the child's zombie state open indefinitely — long enough to SIGUSR1 the child and attach a second debugger to it.
+- **`set_breakpoint`'s content echo and the attach-mode refusal of `statement` addressing** both did their jobs: the echo confirmed the force-kill line before the run, and the refusal ("the debuggee's loaded source may not match the file on the mcp-debugger host") pushed toward line addressing with a clear reason rather than a silent mis-bind.
+- **Worker stderr is logged at `error` level.** The parent forwards every worker stderr line as `[ProxyManager STDERR]` at error level — including the worker's own `[DEBUG]` diagnostics, which makes error-grepping a debug-level server log noisy ([#534](https://github.com/debugmcp/mcp-debugger/issues/534)).

--- a/src/cli/http-command.ts
+++ b/src/cli/http-command.ts
@@ -7,6 +7,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { DebugMcpServer } from '../server.js';
+import { attachSharedFileTransport } from '../utils/logger.js';
 import { SSEOptions } from './setup.js';
 import { watchStdinForParentExit } from './stdin-watchdog.js';
 import type { ProcessLike } from '../interfaces/process-interfaces.js';
@@ -37,7 +38,7 @@ interface SessionData {
 
 /** Idle window before a streamless HTTP session is reaped (issue #337). */
 const DEFAULT_STALE_SESSION_MS = 30 * 60 * 1000;
-const STALE_SWEEP_INTERVAL_MS = 60 * 1000;
+const DEFAULT_STALE_SWEEP_INTERVAL_MS = 60 * 1000;
 
 function parseStaleSessionMs(raw: string | undefined, logger: WinstonLoggerType): number {
   if (raw === undefined || raw === '') {
@@ -47,6 +48,23 @@ function parseStaleSessionMs(raw: string | undefined, logger: WinstonLoggerType)
   if (!Number.isFinite(parsed) || parsed < 0) {
     logger.warn(`Ignoring invalid MCP_HTTP_STALE_SESSION_MS value "${raw}"; using default ${DEFAULT_STALE_SESSION_MS}ms.`);
     return DEFAULT_STALE_SESSION_MS;
+  }
+  return parsed;
+}
+
+/**
+ * Sweep cadence override (issue #502): lets tests exercise the reap path in
+ * seconds instead of the 60s production default. Disabling the reaper stays
+ * the job of MCP_HTTP_STALE_SESSION_MS=0, so only positive values are valid.
+ */
+function parseSweepIntervalMs(raw: string | undefined, logger: WinstonLoggerType): number {
+  if (raw === undefined || raw === '') {
+    return DEFAULT_STALE_SWEEP_INTERVAL_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger.warn(`Ignoring invalid MCP_HTTP_STALE_SWEEP_INTERVAL_MS value "${raw}"; using default ${DEFAULT_STALE_SWEEP_INTERVAL_MS}ms.`);
+    return DEFAULT_STALE_SWEEP_INTERVAL_MS;
   }
   return parsed;
 }
@@ -72,6 +90,7 @@ export function createHttpApp(
   // MCP_HTTP_STALE_SESSION_MS (default 30 min; 0 disables) is closed through
   // the normal onclose path, which stops its server and debug sessions.
   const staleSessionMs = parseStaleSessionMs(proc.env.MCP_HTTP_STALE_SESSION_MS, logger);
+  const staleSweepIntervalMs = parseSweepIntervalMs(proc.env.MCP_HTTP_STALE_SWEEP_INTERVAL_MS, logger);
   let staleSweepTimer: NodeJS.Timeout | undefined;
   if (staleSessionMs > 0) {
     staleSweepTimer = setInterval(() => {
@@ -86,7 +105,7 @@ export function createHttpApp(
           }
         }
       }
-    }, STALE_SWEEP_INTERVAL_MS);
+    }, staleSweepIntervalMs);
     staleSweepTimer.unref?.();
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -244,6 +263,13 @@ export async function handleHttpCommand(
 
   if (options.logLevel) {
     logger.level = options.logLevel;
+  }
+  if (options.logFile) {
+    // The CLI logger predates option parsing, so --log-file never reached it;
+    // with console silenced in http mode that made this module's lines (the
+    // stale-session reaper's especially) invisible in the operator's log
+    // (issue #502).
+    attachSharedFileTransport(logger, options.logFile);
   }
 
   const port = parseInt(options.port, 10);

--- a/src/implementations/process-launcher-impl.ts
+++ b/src/implementations/process-launcher-impl.ts
@@ -376,8 +376,13 @@ class ProxyProcessAdapter extends EventEmitter implements IProxyProcess {
   }
   
   kill(signal?: string): boolean {
-    if (this.killed || this.disposed) {
-      return false; // Already killed or disposed
+    // Refuse only once the child has actually exited (or this adapter was
+    // disposed, which itself follows the child's exit). Gating on .killed
+    // blocked escalation: a delivered signal latches .killed while the
+    // process may still be alive, so a follow-up SIGKILL was silently
+    // swallowed (issue #502).
+    if (this.disposed || this._exitCode !== null || this._signalCode !== null) {
+      return false; // Already exited or disposed
     }
 
     // If waiting for initialization, fail it

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -86,6 +86,12 @@ export class DapProxyWorker {
   private currentInitPayload: ProxyInitPayload | null = null;
   private state: ProxyState = ProxyState.UNINITIALIZED;
   private isAttachMode: boolean = false;
+  // In-flight shutdown latch (issue #502): natural termination starts
+  // shutdown() as a floating promise off a DAP event, so a terminate command
+  // arriving mid-shutdown must await the same promise — otherwise
+  // handleCommand returns while state is still SHUTTING_DOWN and the runner's
+  // post-command exit check never fires, stranding the worker alive forever.
+  private shutdownPromise: Promise<void> | null = null;
   /** Once-per-session guard for the adapter_capabilities status message (issue #243). */
   private adapterCapabilitiesSent: boolean = false;
   // Exit-code synthesis bookkeeping (issue #247): a real DAP exited event
@@ -363,7 +369,13 @@ export class DapProxyWorker {
       // Start adapter and connect
       await this.startAdapterAndConnect(payload);
     } catch (error) {
-      this.state = ProxyState.UNINITIALIZED;
+      // Roll back for a possible re-init — unless a shutdown already ran
+      // (startAdapterAndConnect shuts down before rethrowing): the latched
+      // shutdown() below is then a completed no-op, and clobbering its
+      // TERMINATED would let a retry re-init a torn-down worker (issue #502).
+      if (!this.shutdownPromise) {
+        this.state = ProxyState.UNINITIALIZED;
+      }
       const message = error instanceof Error ? error.message : String(error);
 
       // Include adapter spawn config (command + args only, NOT env) for diagnostics
@@ -1410,9 +1422,29 @@ export class DapProxyWorker {
    * Handle terminate command
    */
   async handleTerminate(): Promise<void> {
-    // Check if already shutting down or terminated for idempotent behavior
-    if (this.state === ProxyState.SHUTTING_DOWN || this.state === ProxyState.TERMINATED) {
+    // Already fully terminated: return immediately — the runner's post-command
+    // check sees TERMINATED and schedules the process exit.
+    if (this.state === ProxyState.TERMINATED) {
       this.logger?.info('[Worker] Already shutting down or terminated.');
+      return;
+    }
+
+    // Shutdown in flight (issue #502): natural termination runs shutdown() as
+    // a floating promise off a DAP event, and the parent's terminate command
+    // routinely lands inside that ≥1s window. Returning early here left
+    // handleCommand finishing while state was still SHUTTING_DOWN, so the
+    // runner's exit check never fired and the worker sat alive forever in
+    // TERMINATED. Latch onto the in-flight shutdown instead, so this command
+    // completes only once state is TERMINATED and the exit gets scheduled.
+    if (this.state === ProxyState.SHUTTING_DOWN) {
+      if (this.shutdownPromise) {
+        this.logger?.info('[Worker] Terminate received during in-flight shutdown; awaiting completion.');
+        await this.shutdownPromise;
+        this.sendStatus('terminated', { expected: true });
+      } else {
+        // State poked without an in-flight shutdown (tests only).
+        this.logger?.info('[Worker] Already shutting down or terminated.');
+      }
       return;
     }
 
@@ -1439,14 +1471,27 @@ export class DapProxyWorker {
   }
 
   /**
-   * Shutdown the worker
+   * Shutdown the worker. Re-entrant: a second caller gets the same in-flight
+   * promise, so awaiting shutdown() always means "shutdown has completed"
+   * (issue #502). The worker is single-shot — the promise is never cleared.
    */
-  async shutdown(): Promise<void> {
+  shutdown(): Promise<void> {
+    if (this.shutdownPromise) {
+      this.logger?.info('[Worker] Shutdown already in progress.');
+      return this.shutdownPromise;
+    }
+    // State poked without a promise (only happens in tests): keep the old
+    // early-return contract.
     if (this.state === ProxyState.SHUTTING_DOWN || this.state === ProxyState.TERMINATED) {
       this.logger?.info('[Worker] Shutdown already in progress.');
-      return;
+      return Promise.resolve();
     }
 
+    this.shutdownPromise = this.performShutdown();
+    return this.shutdownPromise;
+  }
+
+  private async performShutdown(): Promise<void> {
     this.state = ProxyState.SHUTTING_DOWN;
     this.logger?.info('[Worker] Initiating shutdown sequence...');
 

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -88,6 +88,12 @@ export interface IProxyManager extends EventEmitter {
     options?: { timeoutMs?: number }
   ): Promise<T>;
   isRunning(): boolean;
+  /**
+   * OS pid of the proxy worker this manager spawned (null before the first
+   * successful spawn). Survives stop()/cleanup(), so callers can verify after
+   * teardown that the worker actually died (issue #502).
+   */
+  getProxyPid(): number | null;
   getCurrentThreadId(): number | null;
   setCurrentThreadId(threadId: number): void;
 
@@ -128,6 +134,10 @@ const DEFAULT_RUNTIME_ENVIRONMENT: ProxyRuntimeEnvironment = {
  */
 export class ProxyManager extends EventEmitter implements IProxyManager {
   private proxyProcess: IProxyProcess | null = null;
+  // Worker OS pid, retained across cleanup() (which nulls proxyProcess) so
+  // callers can verify after teardown that the worker actually died — the
+  // leaked-worker case had no post-hoc handle at any layer (issue #502).
+  private lastProxyPid: number | null = null;
   private sessionId: string | null = null;
   private currentThreadId: number | null = null;
   private pendingDapRequests = new Map<string, {
@@ -214,6 +224,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
     this.sessionId = config.sessionId;
     this.isStopped = false;
+    this.lastProxyPid = null;
     // The latch tracks the process this start() launches (issue #530)
     this.everInitialized = false;
     this.isDryRun = config.dryRunSpawn === true;
@@ -256,6 +267,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       throw new Error('Proxy process is invalid or PID is missing');
     }
 
+    this.lastProxyPid = this.proxyProcess.pid ?? null;
     this.logger.info(`[ProxyManager] Proxy spawned with PID: ${this.proxyProcess.pid}`);
 
     // Set up event handlers
@@ -417,9 +429,15 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // Cleanup (cancels whatever is still pending after the drain)
     this.cleanup();
 
+    // Gate on actual exit evidence, not ChildProcess.killed — Node latches
+    // .killed when any signal is *delivered*, not when the process dies, so a
+    // prior kill() made both the terminate send and the SIGKILL escalation
+    // silent no-ops against a still-live worker (issue #502).
+    const hasExited = () => process.exitCode != null || process.signalCode != null;
+
     // Send terminate command if process is still running
     try {
-      if (!process.killed) {
+      if (!hasExited()) {
         process.send({ cmd: 'terminate', sessionId: sessionIdSnapshot });
       }
     } catch (error) {
@@ -434,8 +452,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       };
 
       const timeout = setTimeout(() => {
-        this.logger.warn(`[ProxyManager] Timeout waiting for proxy exit. Force killing.`);
-        if (!process.killed) {
+        this.logger.warn(
+          `[ProxyManager] Timeout waiting for proxy exit. Force killing pid ${this.lastProxyPid ?? 'unknown'}.`
+        );
+        if (!hasExited()) {
           process.kill('SIGKILL');
         }
         // Detach the once-listener: it never fired, and leaving it would
@@ -446,8 +466,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
       process.once('exit', onExit);
 
-      // If already killed/exited, resolve immediately
-      if (process.killed || process.exitCode !== null) {
+      // If already exited, resolve immediately
+      if (hasExited()) {
         clearTimeout(timeout);
         process.removeListener('exit', onExit);
         resolve();
@@ -583,7 +603,18 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   }
 
   isRunning(): boolean {
-    return this.proxyProcess !== null && !this.proxyProcess.killed;
+    // Actual-exit evidence, not .killed: a delivered signal latches .killed
+    // while the process may still be alive (issue #502). Loose null checks:
+    // test doubles may leave signalCode undefined.
+    return (
+      this.proxyProcess !== null &&
+      this.proxyProcess.exitCode == null &&
+      this.proxyProcess.signalCode == null
+    );
+  }
+
+  getProxyPid(): number | null {
+    return this.lastProxyPid;
   }
 
   getCurrentThreadId(): number | null {

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -26,6 +26,7 @@ import { IProxyManagerFactory } from '../factories/proxy-manager-factory.js';
 import type { BreakpointSyncResult, FunctionBreakpointSyncResult } from '../proxy/dap-proxy-interfaces.js';
 import { normalizeBreakpointMessage } from '../utils/breakpoint-message.js';
 import { consumeChildOrigin } from '../utils/child-origin-events.js';
+import { isPidAlive } from '../utils/jvm-orphan-reaper.js';
 import { IAdapterRegistry } from '@debugmcp/shared';
 
 // Custom launch arguments interface extending DebugProtocol.LaunchRequestArguments
@@ -194,6 +195,7 @@ export abstract class SessionManagerCore extends EventEmitter {
     this.logger.info(`Closing debug session: ${sessionId}. Active proxy: ${session.proxyManager ? 'yes' : 'no'}`);
     
     if (session.proxyManager) {
+      session.lastProxyPid = session.proxyManager.getProxyPid?.() ?? session.lastProxyPid;
       // Always cleanup listeners first
       try {
         this.cleanupProxyEventHandlers(session, session.proxyManager);
@@ -201,28 +203,64 @@ export abstract class SessionManagerCore extends EventEmitter {
         this.logger.error(`[SessionManager] Critical error during listener cleanup for session ${sessionId}:`, cleanupError);
         // Continue with session closure despite cleanup errors
       }
-      
+
       // Then stop the proxy
       try {
         await session.proxyManager.stop();
-      } catch (error: unknown) { 
+      } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         this.logger.error(`[SessionManager] Error stopping proxy for session ${sessionId}:`, message);
       } finally {
         session.proxyManager = undefined;
       }
     }
-    
+
+    // A terminal event handler may have cleared proxyManager and left its
+    // stop() in flight; await it so close cannot outrun the teardown and
+    // report success while the worker is still dying (issue #502).
+    if (session.pendingProxyStop) {
+      await session.pendingProxyStop;
+      session.pendingProxyStop = undefined;
+    }
+
     this._updateSessionState(session, SessionState.STOPPED);
-    
+
     // Also update session lifecycle to TERMINATED
     this.sessionStore.update(sessionId, {
       sessionLifecycle: SessionLifecycleState.TERMINATED
     });
-    
+
     this.logger.info(`Session ${sessionId} marked as STOPPED/TERMINATED.`);
     this.sessionStore.remove(sessionId);
+    this.verifyProxyReaped(sessionId, session.lastProxyPid);
     return true;
+  }
+
+  /**
+   * Post-close verification (issue #502): a short while after a session is
+   * closed, confirm its proxy worker OS process is actually gone and log an
+   * error naming the pid if not. The historical leak was invisible — every
+   * layer had dropped its handle — so a recurrence must at least log itself.
+   * The timer is unref'd and best-effort; overridable seam for tests.
+   */
+  protected pidLivenessCheck: (pid: number) => boolean = isPidAlive;
+
+  private verifyProxyReaped(sessionId: string, pid: number | undefined): void {
+    if (!pid) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        if (this.pidLivenessCheck(pid)) {
+          this.logger.error(
+            `[SessionManager] Proxy worker pid=${pid} for session ${sessionId} is still alive after session close — leaked worker (issue #502)`
+          );
+        }
+      } catch {
+        // Liveness probe is diagnostics only; never let it throw.
+      }
+    }, 1500);
+    timer.unref?.();
   }
 
   /**
@@ -235,26 +273,32 @@ export abstract class SessionManagerCore extends EventEmitter {
    */
   protected async stopProxyPreservingSession(session: ManagedSession): Promise<void> {
     const proxyManager = session.proxyManager;
-    if (!proxyManager) {
-      return;
+    if (proxyManager) {
+      session.lastProxyPid = proxyManager.getProxyPid?.() ?? session.lastProxyPid;
+      try {
+        this.cleanupProxyEventHandlers(session, proxyManager);
+      } catch (cleanupError) {
+        this.logger.error(
+          `[SessionManager] Error during listener cleanup for session ${session.id}:`,
+          cleanupError
+        );
+      }
+      try {
+        await proxyManager.stop();
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.error(`[SessionManager] Error stopping proxy for session ${session.id}:`, message);
+      } finally {
+        session.proxyManager = undefined;
+        // The mirror listener lived in the stopped worker (issue #217).
+        session.exposure = undefined;
+      }
     }
-    try {
-      this.cleanupProxyEventHandlers(session, proxyManager);
-    } catch (cleanupError) {
-      this.logger.error(
-        `[SessionManager] Error during listener cleanup for session ${session.id}:`,
-        cleanupError
-      );
-    }
-    try {
-      await proxyManager.stop();
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(`[SessionManager] Error stopping proxy for session ${session.id}:`, message);
-    } finally {
-      session.proxyManager = undefined;
-      // The mirror listener lived in the stopped worker (issue #217).
-      session.exposure = undefined;
+    // Await a teardown started by a terminal event handler (issue #502) so a
+    // relaunch cannot race the previous worker's exit.
+    if (session.pendingProxyStop) {
+      await session.pendingProxyStop;
+      session.pendingProxyStop = undefined;
     }
   }
 
@@ -673,6 +717,7 @@ export abstract class SessionManagerCore extends EventEmitter {
 
       // Clean up listeners since proxy is gone
       this.cleanupProxyEventHandlers(session, proxyManager);
+      session.lastProxyPid = proxyManager.getProxyPid?.() ?? session.lastProxyPid;
       session.proxyManager = undefined;
 
       // Reap the proxy process instead of just dropping the reference. The
@@ -680,7 +725,8 @@ export abstract class SessionManagerCore extends EventEmitter {
       // stalls (e.g. a hung adapter process) nothing else reaps it — on
       // Windows especially, orphans accumulate (issue #122). stop() is
       // idempotent against an already-exiting worker and force-kills after 5s.
-      proxyManager.stop().catch((err) => {
+      // The promise is retained so closeSession can await it (issue #502).
+      session.pendingProxyStop = proxyManager.stop().catch((err) => {
         this.logger.warn(
           `[SessionManager] Error stopping proxy after 'terminated' for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -703,10 +749,12 @@ export abstract class SessionManagerCore extends EventEmitter {
 
       // Clean up listeners since proxy is gone
       this.cleanupProxyEventHandlers(session, proxyManager);
+      session.lastProxyPid = proxyManager.getProxyPid?.() ?? session.lastProxyPid;
       session.proxyManager = undefined;
 
-      // Reap the proxy process (see handleTerminated for rationale, issue #122)
-      proxyManager.stop().catch((err) => {
+      // Reap the proxy process (see handleTerminated for rationale, issue
+      // #122); promise retained for closeSession (issue #502).
+      session.pendingProxyStop = proxyManager.stop().catch((err) => {
         this.logger.warn(
           `[SessionManager] Error stopping proxy after 'exited' for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -918,10 +966,12 @@ export abstract class SessionManagerCore extends EventEmitter {
 
       // Clean up listeners since proxy is in error state
       this.cleanupProxyEventHandlers(session, proxyManager);
+      session.lastProxyPid = proxyManager.getProxyPid?.() ?? session.lastProxyPid;
       session.proxyManager = undefined;
 
-      // Reap the proxy process (see handleTerminated for rationale, issue #122)
-      proxyManager.stop().catch((err) => {
+      // Reap the proxy process (see handleTerminated for rationale, issue
+      // #122); promise retained for closeSession (issue #502).
+      session.pendingProxyStop = proxyManager.stop().catch((err) => {
         this.logger.warn(
           `[SessionManager] Error stopping proxy after 'error' for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -964,7 +1014,22 @@ export abstract class SessionManagerCore extends EventEmitter {
 
       // Clean up listeners since proxy is gone
       this.cleanupProxyEventHandlers(session, proxyManager);
+      session.lastProxyPid = proxyManager.getProxyPid?.() ?? session.lastProxyPid;
       session.proxyManager = undefined;
+
+      // A defined 'expected' marks the status-driven emission (the worker
+      // REPORTED termination over IPC — the OS process may still be alive,
+      // e.g. stranded mid-shutdown). Reap it like the other terminal
+      // handlers; stop() is idempotent and cheap once the worker is truly
+      // gone. The undefined case is the real child-process exit, where the
+      // process is already dead and handleProxyExit cleaned up (issue #502).
+      if (expected !== undefined) {
+        session.pendingProxyStop = proxyManager.stop().catch((err) => {
+          this.logger.warn(
+            `[SessionManager] Error stopping proxy after 'exit' for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
+      }
     };
     proxyManager.on('exit', handleExit);
     handlers.set('exit', handleExit);

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -77,6 +77,14 @@ export interface SessionExposure {
 export interface ManagedSession extends DebugSessionInfo {
   executablePath?: string;  // Language-agnostic executable path
   proxyManager?: IProxyManager;
+  // In-flight proxy teardown started by a terminal event handler (which
+  // clears proxyManager before its fire-and-forget stop()); closeSession
+  // awaits this so it cannot report success while the worker may still be
+  // dying — or failing to die (issue #502).
+  pendingProxyStop?: Promise<void>;
+  // Worker OS pid retained across teardown so closeSession can verify the
+  // worker actually died and log a leak otherwise (issue #502).
+  lastProxyPid?: number;
   breakpoints: Map<string, Breakpoint>;
   // Function breakpoints (issue #271 phase 3): session-global, name-addressed,
   // synced via DAP setFunctionBreakpoints (replace-all per request).

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -331,6 +331,26 @@ export function redirectProxyLoggers(options: { file: string; level?: string }):
  * and restored in finally. logger.close() remains forbidden as documented on
  * the transport cache above.
  */
+/**
+ * Attach the shared file transport for `file` to an existing logger
+ * (add-only, idempotent, best-effort). Used by the HTTP CLI action (issue
+ * #502): the CLI logger is created before options are parsed, so `--log-file`
+ * never reached it — and with console silenced in http mode, operationally
+ * important lines (e.g. the stale-session reaper's) were invisible in the
+ * very file the operator asked for. Reuses the per-path transport cache, so
+ * the CLI lines interleave with the DebugMcpServer's in one file.
+ */
+export function attachSharedFileTransport(logger: WinstonLoggerType, file: string): void {
+  try {
+    const transport = getOrCreateSharedFileTransport(file);
+    if (!logger.transports.includes(transport)) {
+      logger.add(transport);
+    }
+  } catch {
+    // Best-effort: the default per-pid log still applies.
+  }
+}
+
 export function detachSharedFileTransport(logger: WinstonLoggerType): void {
   const transport = loggerFileTransports.get(logger);
   if (!transport) {

--- a/tests/core/unit/session/session-manager-worker-reap.test.ts
+++ b/tests/core/unit/session/session-manager-worker-reap.test.ts
@@ -1,0 +1,141 @@
+/**
+ * SessionManager worker-reap tests (issue #502)
+ *
+ * The HTTP stale-session reaper leak: terminal event handlers cleared
+ * session.proxyManager before a fire-and-forget stop(), so closeSession could
+ * report success while the worker was still dying — or failing to die — and
+ * nothing retained the worker pid to verify the kill after the fact.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SessionManager, SessionManagerConfig } from '../../../../src/session/session-manager.js';
+import { DebugLanguage } from '@debugmcp/shared';
+import { createMockDependencies } from './session-manager-test-utils.js';
+
+describe('SessionManager - worker reap guarantees (issue #502)', () => {
+  let sessionManager: SessionManager;
+  let dependencies: ReturnType<typeof createMockDependencies>;
+  let config: SessionManagerConfig;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    dependencies = createMockDependencies();
+    config = {
+      logDirBase: '/tmp/test-sessions',
+      defaultDapLaunchArgs: {
+        stopOnEntry: true,
+        justMyCode: true
+      }
+    };
+    sessionManager = new SessionManager(config, dependencies);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    dependencies.mockProxyManager.reset();
+  });
+
+  async function startSession(): Promise<string> {
+    const session = await sessionManager.createSession({
+      language: DebugLanguage.MOCK,
+      pythonPath: 'python'
+    });
+    await sessionManager.startDebugging(session.id, 'test.py');
+    await vi.runAllTimersAsync();
+    return session.id;
+  }
+
+  it('reaps the worker on a status-driven exit (worker claims dead; OS process may be alive)', async () => {
+    await startSession();
+    const mockProxy = dependencies.mockProxyManager;
+
+    // The 3-arg 'exit' (expected defined) is emitted from a worker STATUS
+    // message — the worker reported termination over IPC, but its OS process
+    // may still be alive (e.g. stranded mid-shutdown). It must be stopped
+    // like the other terminal events, not just dereferenced.
+    mockProxy.simulateEvent('exit', 0, undefined, true);
+    await vi.runAllTimersAsync();
+
+    expect(mockProxy.stopCalls).toBe(1);
+  });
+
+  it('does not stop() on a real child-process exit (2-arg form; process already gone)', async () => {
+    await startSession();
+    const mockProxy = dependencies.mockProxyManager;
+
+    mockProxy.simulateExit(0);
+    await vi.runAllTimersAsync();
+
+    expect(mockProxy.stopCalls).toBe(0);
+  });
+
+  it('closeSession awaits the in-flight stop started by a terminal handler', async () => {
+    const sessionId = await startSession();
+    const mockProxy = dependencies.mockProxyManager;
+
+    let resolveStop!: () => void;
+    const stopMock = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolveStop = resolve; })
+    );
+    mockProxy.stop = stopMock;
+
+    // Terminal handler clears session.proxyManager and fires stop() —
+    // which we hold open.
+    mockProxy.simulateEvent('terminated');
+    expect(stopMock).toHaveBeenCalledTimes(1);
+
+    let closed = false;
+    const closePromise = sessionManager.closeSession(sessionId).then((result) => {
+      closed = true;
+      return result;
+    });
+
+    // Give closeSession every chance to (incorrectly) finish early.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(closed).toBe(false);
+
+    resolveStop();
+    await expect(closePromise).resolves.toBe(true);
+    // No second stop: the pending one was awaited, not re-issued.
+    expect(stopMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs an error naming the worker pid when it is still alive after close', async () => {
+    const sessionId = await startSession();
+    const mockProxy = dependencies.mockProxyManager;
+    mockProxy.proxyPid = 31337;
+
+    // Liveness seam: pretend the worker survived the teardown.
+    (sessionManager as unknown as { pidLivenessCheck: (pid: number) => boolean })
+      .pidLivenessCheck = () => true;
+
+    await sessionManager.closeSession(sessionId);
+    await vi.advanceTimersByTimeAsync(1500);
+
+    const errorCalls = (dependencies.mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
+    const leakLine = errorCalls.find((call) =>
+      typeof call[0] === 'string' && call[0].includes('31337') && call[0].includes('leaked worker')
+    );
+    expect(leakLine).toBeDefined();
+  });
+
+  it('stays silent when the worker is confirmed dead after close', async () => {
+    const sessionId = await startSession();
+    const mockProxy = dependencies.mockProxyManager;
+    mockProxy.proxyPid = 31337;
+
+    (sessionManager as unknown as { pidLivenessCheck: (pid: number) => boolean })
+      .pidLivenessCheck = () => false;
+
+    await sessionManager.closeSession(sessionId);
+    await vi.advanceTimersByTimeAsync(1500);
+
+    const errorCalls = (dependencies.mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
+    const leakLine = errorCalls.find((call) =>
+      typeof call[0] === 'string' && call[0].includes('leaked worker')
+    );
+    expect(leakLine).toBeUndefined();
+  });
+});

--- a/tests/core/unit/session/session-manager-worker-reap.test.ts
+++ b/tests/core/unit/session/session-manager-worker-reap.test.ts
@@ -121,6 +121,49 @@ describe('SessionManager - worker reap guarantees (issue #502)', () => {
     expect(leakLine).toBeDefined();
   });
 
+  it('warns when the status-driven exit reap itself fails', async () => {
+    await startSession();
+    const mockProxy = dependencies.mockProxyManager;
+    mockProxy.stop = vi.fn().mockRejectedValue(new Error('stop exploded'));
+
+    mockProxy.simulateEvent('exit', 0, undefined, true);
+    await vi.runAllTimersAsync();
+
+    const warnCalls = (dependencies.mockLogger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    expect(warnCalls.some((call) =>
+      typeof call[0] === 'string' && call[0].includes("Error stopping proxy after 'exit'")
+    )).toBe(true);
+  });
+
+  it('stopProxyPreservingSession awaits a pending stop and survives cleanup/stop failures', async () => {
+    const sessionId = await startSession();
+    const mockProxy = dependencies.mockProxyManager;
+    const managed = sessionManager.getSession(sessionId)!;
+
+    // Both failure paths at once: listener cleanup throws, stop() rejects,
+    // and a terminal handler left a pending stop behind.
+    (sessionManager as unknown as { cleanupProxyEventHandlers: () => void })
+      .cleanupProxyEventHandlers = () => { throw new Error('cleanup boom'); };
+    mockProxy.stop = vi.fn().mockRejectedValue(new Error('stop boom'));
+    let pendingResolved = false;
+    managed.pendingProxyStop = Promise.resolve().then(() => { pendingResolved = true; });
+
+    await (sessionManager as unknown as {
+      stopProxyPreservingSession: (s: typeof managed) => Promise<void>;
+    }).stopProxyPreservingSession(managed);
+
+    expect(managed.proxyManager).toBeUndefined();
+    expect(managed.pendingProxyStop).toBeUndefined();
+    expect(pendingResolved).toBe(true);
+    const errorCalls = (dependencies.mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
+    expect(errorCalls.some((call) =>
+      typeof call[0] === 'string' && call[0].includes('Error during listener cleanup')
+    )).toBe(true);
+    expect(errorCalls.some((call) =>
+      typeof call[0] === 'string' && call[0].includes('Error stopping proxy for session')
+    )).toBe(true);
+  });
+
   it('stays silent when the worker is confirmed dead after close', async () => {
     const sessionId = await startSession();
     const mockProxy = dependencies.mockProxyManager;

--- a/tests/e2e/mcp-server-smoke-http-stale-reap.test.ts
+++ b/tests/e2e/mcp-server-smoke-http-stale-reap.test.ts
@@ -1,0 +1,204 @@
+/**
+ * E2E regression test for issue #502: the Streamable HTTP stale-session
+ * reaper must actually reap the session's proxy worker OS process.
+ *
+ * Drives the exact leak scenario against a real server:
+ *  1. HTTP client creates a mock-language session and runs the debuggee to
+ *     natural termination (the worker starts shutdown() as a floating
+ *     promise, and the parent's terminate command lands mid-shutdown — the
+ *     #502 race window).
+ *  2. The client is abandoned WITHOUT a DELETE (socket-level close only).
+ *  3. The stale-session sweep reaps the session.
+ *  4. The worker pid must be gone, with no force-kill escalation: on unfixed
+ *     code the worker either survives forever or dies only via the 5s
+ *     "Timeout waiting for proxy exit" SIGKILL.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'path';
+import * as os from 'os';
+import * as net from 'net';
+import { existsSync, readFileSync, rmSync, mkdtempSync } from 'fs';
+import { spawn, ChildProcess } from 'child_process';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { parseSdkToolResult, waitForHealthEndpoint, pollUntil } from './smoke-test-utils.js';
+import { listTaggedProxies } from '../../src/utils/proxy-orphan-reaper.js';
+
+const TEST_TIMEOUT = 90000;
+
+const projectRoot = process.cwd();
+const MOCK_SCRIPT = path.join(projectRoot, 'examples', 'python', 'simple_test.py');
+
+let serverProcess: ChildProcess | null = null;
+let mcpClient: Client | null = null;
+let tmpDir: string | null = null;
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close(() => {
+        if (port) {
+          setTimeout(() => resolve(port), 100);
+        } else {
+          reject(new Error('Could not determine an ephemeral port'));
+        }
+      });
+    });
+  });
+}
+
+describe('MCP Server E2E HTTP stale-session reap (issue #502)', () => {
+  afterEach(async () => {
+    if (mcpClient) {
+      try {
+        await mcpClient.close();
+      } catch {
+        // Already abandoned/closed — expected in this test.
+      }
+      mcpClient = null;
+    }
+
+    if (serverProcess && serverProcess.exitCode === null) {
+      const proc = serverProcess;
+      proc.kill('SIGTERM');
+      const exited = await pollUntil(
+        async () => (proc.exitCode !== null ? true : undefined),
+        3000,
+        100
+      );
+      if (!exited) {
+        proc.kill('SIGKILL');
+      }
+    }
+    serverProcess = null;
+
+    if (tmpDir) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup.
+      }
+      tmpDir = null;
+    }
+  });
+
+  it('reaps the proxy worker of an abandoned HTTP session, without force-kill escalation', async () => {
+    const distEntry = path.join(projectRoot, 'dist', 'index.js');
+    if (!existsSync(distEntry)) {
+      throw new Error('dist/index.js not found. Run "npm run build" first.');
+    }
+
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mcp-502-'));
+    const logFile = path.join(tmpDir, 'server.log');
+    const port = await findAvailablePort();
+
+    serverProcess = spawn(process.execPath, [
+      distEntry,
+      'http',
+      '-p', String(port),
+      '--log-file', logFile,
+      '--log-level', 'debug'
+    ], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        MCP_HTTP_STALE_SESSION_MS: '2000',
+        MCP_HTTP_STALE_SWEEP_INTERVAL_MS: '1000'
+      }
+    });
+    const serverPid = serverProcess.pid!;
+
+    await waitForHealthEndpoint(port, 15000);
+
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`)
+    );
+    mcpClient = new Client({ name: 'stale-reap-502', version: '1.0.0' });
+    await mcpClient.connect(transport);
+
+    const created = parseSdkToolResult(await mcpClient.callTool({
+      name: 'create_debug_session',
+      arguments: { language: 'mock', name: 'stale-reap-502' }
+    }));
+    expect(created.sessionId).toBeDefined();
+    const sessionId = created.sessionId as string;
+
+    parseSdkToolResult(await mcpClient.callTool({
+      name: 'set_breakpoint',
+      arguments: { sessionId, file: MOCK_SCRIPT, line: 32 }
+    }));
+
+    const started = parseSdkToolResult(await mcpClient.callTool({
+      name: 'start_debugging',
+      arguments: { sessionId, scriptPath: MOCK_SCRIPT, dapLaunchArgs: { stopOnEntry: true } }
+    }));
+    expect(started.success).toBe(true);
+
+    // Capture the worker pid via its argv tags while it is alive.
+    const workerPid = await pollUntil(async () => {
+      const workers = (await listTaggedProxies()).filter(w => w.ownerPid === serverPid);
+      return workers.length > 0 ? workers[0].pid : undefined;
+    }, 10000, 200);
+    expect(workerPid).toBeDefined();
+    expect(pidAlive(workerPid!)).toBe(true);
+
+    // Run the debuggee to natural termination: continue to the breakpoint,
+    // then past it (the mock adapter terminates after the last breakpoint).
+    // This opens the #502 race window inside the worker.
+    parseSdkToolResult(await mcpClient.callTool({
+      name: 'continue_execution',
+      arguments: { sessionId }
+    }));
+    await new Promise(resolve => setTimeout(resolve, 800));
+    parseSdkToolResult(await mcpClient.callTool({
+      name: 'continue_execution',
+      arguments: { sessionId }
+    }));
+
+    // Abandon the session: close the client's sockets WITHOUT sending the
+    // MCP DELETE (transport.close() aborts streams; terminateSession() is
+    // the DELETE — deliberately not called).
+    await mcpClient.close();
+    mcpClient = null;
+
+    // The stale sweep (idle > 2s, ticked every 1s) must reap the session…
+    const reaped = await pollUntil(async () => {
+      try {
+        return readFileSync(logFile, 'utf8').includes('Reaping stale HTTP session')
+          ? true
+          : undefined;
+      } catch {
+        return undefined;
+      }
+    }, 20000, 250);
+    expect(reaped).toBe(true);
+
+    // …and the worker OS process must actually die.
+    const workerGone = await pollUntil(
+      async () => (pidAlive(workerPid!) ? undefined : true),
+      20000,
+      250
+    );
+    expect(workerGone).toBe(true);
+
+    // The teardown must have been graceful: no 5s force-kill escalation
+    // (the only thing that reaped the stranded worker on unfixed code), and
+    // no post-close leak detection firing.
+    const log = readFileSync(logFile, 'utf8');
+    expect(log).not.toContain('Timeout waiting for proxy exit');
+    expect(log).not.toContain('leaked worker');
+  }, TEST_TIMEOUT);
+});

--- a/tests/proxy/dap-proxy-worker.test.ts
+++ b/tests/proxy/dap-proxy-worker.test.ts
@@ -3628,6 +3628,52 @@ describe('DapProxyWorker', () => {
       expect(mockLogger.info).toHaveBeenCalledWith('[Worker] Shutdown already in progress.');
       expect(worker.getState()).toBe(ProxyState.SHUTTING_DOWN);
     });
+
+    it('terminate during in-flight shutdown latches onto it and completes in TERMINATED (issue #502)', async () => {
+      // Natural termination runs shutdown() as a floating promise off a DAP
+      // event; the parent's terminate command routinely lands inside that
+      // window. It must complete only once state is TERMINATED, or the
+      // runner's post-command exit check never fires and the worker is
+      // stranded alive.
+      vi.useFakeTimers();
+      try {
+        const processStub = { shutdown: vi.fn().mockResolvedValue(undefined) };
+        const connectionStub = { disconnect: vi.fn().mockResolvedValue(undefined) };
+        const adapterProc = { pid: 4242 };
+        (worker as any).dapClient = mockDapClient;
+        (worker as any).processManager = processStub;
+        (worker as any).connectionManager = connectionStub;
+        (worker as any).adapterProcess = adapterProc;
+        (worker as any).state = ProxyState.CONNECTED;
+
+        // Floating shutdown, as onTerminated/onClose start it (no await).
+        const floating = (worker as any).shutdown() as Promise<void>;
+        expect(worker.getState()).toBe(ProxyState.SHUTTING_DOWN);
+
+        // The terminate command arrives mid-shutdown.
+        const terminatePromise = worker.handleTerminate();
+
+        // Let the shutdown's internal 500ms grace wait elapse.
+        await vi.advanceTimersByTimeAsync(500);
+        await floating;
+        await terminatePromise;
+
+        // The property the runner's exit scheduler depends on: when the
+        // terminate command completes, state is TERMINATED.
+        expect(worker.getState()).toBe(ProxyState.TERMINATED);
+        // No double teardown: the latched terminate reuses the in-flight
+        // shutdown rather than running its own.
+        expect(processStub.shutdown).toHaveBeenCalledTimes(1);
+        // The parent still gets its terminated status (expected: true).
+        const terminatedCalls = mockMessageSender.send.mock.calls.filter(
+          call => call[0].type === 'status' && call[0].status === 'terminated'
+        );
+        expect(terminatedCalls.length).toBe(1);
+        expect(terminatedCalls[0][0].expected).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('Attach Mode Flow', () => {

--- a/tests/test-utils/mocks/mock-proxy-manager.ts
+++ b/tests/test-utils/mocks/mock-proxy-manager.ts
@@ -31,6 +31,8 @@ export class MockProxyManager extends EventEmitter implements IProxyManager {
   public startDelay = 0;
   public shouldFailDapRequests = false;
   public dapRequestDelay = 0;
+  /** Reported by getProxyPid() (issue #502); settable per-test. */
+  public proxyPid: number | null = 4242;
 
   constructor() {
     super();
@@ -200,6 +202,10 @@ export class MockProxyManager extends EventEmitter implements IProxyManager {
     return this._isRunning;
   }
 
+  getProxyPid(): number | null {
+    return this.proxyPid;
+  }
+
   getCurrentThreadId(): number | null {
     return this._currentThreadId;
   }
@@ -273,6 +279,7 @@ export class MockProxyManager extends EventEmitter implements IProxyManager {
     this._dryRunCompleted = false;
     this._dryRunCommand = undefined;
     this._dryRunScript = undefined;
+    this.proxyPid = 4242;
     this.removeAllListeners();
   }
 }

--- a/tests/unit/cli/http-command.test.ts
+++ b/tests/unit/cli/http-command.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { EventEmitter } from 'events';
+import os from 'os';
+import path from 'path';
 import { createHttpApp, handleHttpCommand } from '../../../src/cli/http-command.js';
 import { FakeCurrentProcess } from '../../test-utils/mocks/fake-current-process.js';
 import type { Logger as WinstonLoggerType } from 'winston';
@@ -563,6 +565,24 @@ describe('HTTP Command Handler', () => {
       expect(mockExitProcess).not.toHaveBeenCalled();
       expect(fakeProc.listenerCount('SIGINT')).toBe(1);
       expect(fakeProc.listenerCount('SIGTERM')).toBe(1);
+    });
+
+    it('wires --log-file into the CLI logger without failing on non-winston loggers (issue #502)', async () => {
+      const listen = vi.fn((_port: number, cb: Function) => {
+        cb();
+        return mockHttpServer;
+      });
+      mockApp.listen = listen;
+
+      // The mock logger has no winston transports — attachSharedFileTransport
+      // must swallow that (best-effort) and startup must proceed normally.
+      await handleHttpCommand(
+        { port: '4001', logLevel: 'debug', logFile: path.join(os.tmpdir(), 'http-cmd-502-test.log') },
+        { logger: mockLogger, serverFactory: mockServerFactory, exitProcess: mockExitProcess, proc: fakeProc }
+      );
+
+      expect(listen).toHaveBeenCalledWith(4001, expect.any(Function));
+      expect(mockExitProcess).not.toHaveBeenCalled();
     });
 
     it('exits with code 1 when the app cannot be created', async () => {

--- a/tests/unit/cli/http-command.test.ts
+++ b/tests/unit/cli/http-command.test.ts
@@ -499,6 +499,38 @@ describe('HTTP Command Handler', () => {
       await vi.advanceTimersByTimeAsync(3 * 60_000);
       expect(transport.close).toHaveBeenCalled();
     });
+
+    it('MCP_HTTP_STALE_SWEEP_INTERVAL_MS shortens the sweep cadence (issue #502)', async () => {
+      vi.useFakeTimers();
+      fakeProc.env.MCP_HTTP_STALE_SWEEP_INTERVAL_MS = '1000';
+      const { handler } = createAppAndHandler('500');
+      const transport = await initSession(handler);
+
+      // Idle 500ms window, 1s sweep: the second tick must reap — no 60s wait.
+      await vi.advanceTimersByTimeAsync(2_100);
+
+      expect(transport.close).toHaveBeenCalled();
+    });
+
+    it('invalid MCP_HTTP_STALE_SWEEP_INTERVAL_MS values warn and keep the 60s default', async () => {
+      vi.useFakeTimers();
+      for (const bad of ['0', '-5', 'abc']) {
+        vi.clearAllMocks();
+        fakeProc.env.MCP_HTTP_STALE_SWEEP_INTERVAL_MS = bad;
+        const { handler } = createAppAndHandler('500');
+        const transport = await initSession(handler);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Ignoring invalid MCP_HTTP_STALE_SWEEP_INTERVAL_MS')
+        );
+
+        // Sweep still ticks at the 60s default, not at the invalid value.
+        await vi.advanceTimersByTimeAsync(59_000);
+        expect(transport.close).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(transport.close).toHaveBeenCalled();
+      }
+    });
   });
 
   describe('handleHttpCommand', () => {

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -1043,6 +1043,19 @@ describe('ProxyManager.start', () => {
       }
     });
 
+    it('isRunning() reflects actual exit evidence, not delivered signals (issue #502)', async () => {
+      await completeStart();
+      expect(proxyManager.isRunning()).toBe(true);
+
+      // A delivered signal alone (killed latched) is NOT death.
+      fakeProcess.killed = true;
+      expect(proxyManager.isRunning()).toBe(true);
+
+      // Actual exit evidence is.
+      fakeProcess.exitCode = 0;
+      expect(proxyManager.isRunning()).toBe(false);
+    });
+
     it('getProxyPid() reports the worker pid and survives stop()/cleanup (issue #502)', async () => {
       await completeStart();
       expect(proxyManager.getProxyPid()).toBe(4242);

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -1003,13 +1003,58 @@ describe('ProxyManager.start', () => {
     it('resolves immediately when proxy already exited', async () => {
       (proxyManager as unknown as { proxyProcess: IProxyProcess | null }).proxyProcess = fakeProcess;
       (proxyManager as unknown as { sessionId: string | null }).sessionId = baseConfig.sessionId;
+      // Actual death evidence: exitCode set. (killed alone no longer counts —
+      // Node latches it on any delivered signal, issue #502.)
       fakeProcess.killed = true;
+      fakeProcess.exitCode = 0;
 
       const stopPromise = proxyManager.stop();
       await stopPromise;
 
       expect(fakeProcess.send).not.toHaveBeenCalled();
       expect(fakeProcess.kill).not.toHaveBeenCalled();
+    });
+
+    it('still terminates and escalates when killed is latched but the process never exited (issue #502)', async () => {
+      // ChildProcess.killed flips on any *delivered* signal, not on death: a
+      // prior kill() must not neuter the terminate send, the SIGKILL, or turn
+      // stop() into an instant no-op against a live worker.
+      vi.useFakeTimers();
+      try {
+        (proxyManager as unknown as { proxyProcess: IProxyProcess | null }).proxyProcess = fakeProcess;
+        (proxyManager as unknown as { sessionId: string | null }).sessionId = baseConfig.sessionId;
+
+        fakeProcess.killed = true;
+        fakeProcess.exitCode = null;
+        fakeProcess.signalCode = null;
+        fakeProcess.send.mockClear();
+        fakeProcess.kill.mockClear();
+
+        const stopPromise = proxyManager.stop();
+
+        await vi.advanceTimersByTimeAsync(5000);
+        await vi.runOnlyPendingTimersAsync();
+        await stopPromise;
+
+        expect(fakeProcess.send).toHaveBeenCalledWith({ cmd: 'terminate', sessionId: baseConfig.sessionId });
+        expect(fakeProcess.kill).toHaveBeenCalledWith('SIGKILL');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('getProxyPid() reports the worker pid and survives stop()/cleanup (issue #502)', async () => {
+      await completeStart();
+      expect(proxyManager.getProxyPid()).toBe(4242);
+
+      const stopPromise = proxyManager.stop();
+      fakeProcess.exitCode = 0;
+      fakeProcess.emit('exit', 0, null);
+      await stopPromise;
+
+      // cleanup() nulls the process handle, but the pid must remain readable
+      // so callers can verify the worker actually died after teardown.
+      expect(proxyManager.getProxyPid()).toBe(4242);
     });
 
     it('does not log "exited before initialization" for the exit that follows a clean stop (issue #530)', async () => {

--- a/tests/unit/utils/logger-detach.test.ts
+++ b/tests/unit/utils/logger-detach.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { createLogger, detachSharedFileTransport } from '../../../src/utils/logger.js';
+import { createLogger, detachSharedFileTransport, attachSharedFileTransport } from '../../../src/utils/logger.js';
 
 let tmpDir: string;
 let logFile: string;
@@ -83,5 +83,35 @@ describe('detachSharedFileTransport (issue #404)', () => {
   it('is a no-op for a logger with no shared file transport', () => {
     const bare = createLogger('detach-test-bare');
     expect(() => detachSharedFileTransport(bare)).not.toThrow();
+  });
+});
+
+describe('attachSharedFileTransport (issue #502)', () => {
+  it('attaches the shared transport for a file to an existing logger, idempotently', () => {
+    const fileA = path.join(tmpDir, 'attach-a.log');
+    const fileB = path.join(tmpDir, 'attach-b.log');
+    // A logger created against file A (the CLI logger shape: exists before
+    // --log-file is known).
+    const logger = createLogger('attach-test-cli', { file: fileA });
+    const before = logger.transports.length;
+
+    attachSharedFileTransport(logger, fileB);
+    expect(logger.transports.length).toBe(before + 1);
+
+    // Idempotent: same file again adds nothing.
+    attachSharedFileTransport(logger, fileB);
+    expect(logger.transports.length).toBe(before + 1);
+
+    // The attached transport is the SHARED one for that path — a server
+    // logger created against the same file reuses it, so lines interleave.
+    const server = createLogger('attach-test-server', { file: fileB });
+    const sharedB = fileTransportOf(server);
+    expect(logger.transports).toContain(sharedB);
+  });
+
+  it('is best-effort: a logger without winston internals does not throw', () => {
+    const fileC = path.join(tmpDir, 'attach-c.log');
+    const notALogger = {} as Parameters<typeof attachSharedFileTransport>[0];
+    expect(() => attachSharedFileTransport(notALogger, fileC)).not.toThrow();
   });
 });


### PR DESCRIPTION
Closes #502.

## Root cause (sharper than the issue's audit)

The live mechanism is a race the worker loses against itself. On natural debuggee termination, `onTerminated`/`onClose` run `shutdown()` as a **floating promise**; state sits in `SHUTTING_DOWN` for ≥1s (two 500ms grace waits + adapter tree-kill). The parent reacts to the same DAP `terminated` event with `stop()` → IPC `terminate`, which lands inside that window (~7ms vs ~800ms): `handleTerminate` early-returned, and the runner's sole exit scheduler (post-`handleCommand`, `state === TERMINATED` exactly) scheduled nothing. The worker finished its own shutdown and sat alive **forever** in state `TERMINATED` — reaped only by the 5s SIGKILL, and not even that on the paths where the escalation was neutered (`.killed` latches on any *delivered* signal; `cleanup()` drops the handle before the escalation; the status-driven `'exit'` handler never stopped at all; no layer retained the worker pid).

Reproduced deterministically on Linux, first try — worker log:

```
21:44:15.058  [Worker] DAP event: terminated              ← floating shutdown() begins
21:44:15.065  [Worker] Already shutting down or terminated.   ← parent's terminate, 7ms later
21:44:15.065  [Worker] Completed command terminate … state=shutting_down   ← no exit scheduled
21:44:15.866  [Worker] Shutdown sequence completed.       ← alive forever, absent SIGKILL
21:44:20.064  [ProxyManager] Timeout waiting for proxy exit. Force killing.
```

## Fix

- **Worker** (`dap-proxy-worker.ts`): `shutdown()` re-entrant via a latched promise; `terminate` during `SHUTTING_DOWN` awaits the in-flight shutdown, so `handleCommand` completes in `TERMINATED` and the exit is always scheduled. Init-failure rollback no longer clobbers a completed shutdown's terminal state.
- **ProxyManager / process adapter**: `stop()`'s IPC-send, SIGKILL, and early-resolve guards key on `exitCode`/`signalCode` (actual death) instead of `.killed`; `ProxyProcessAdapter.kill()` likewise (win32 tree-kill preserved); worker pid retained across `cleanup()` and exposed as `IProxyManager.getProxyPid()`; `isRunning()` de-poisoned.
- **SessionManager**: terminal handlers record the pid and retain their `stop()` promise (`session.pendingProxyStop`); `closeSession`/`stopProxyPreservingSession` await it even after the reference was cleared; the status-driven `'exit'` (`expected !== undefined` — worker *claims* dead, OS process may not be) now stops the proxy; a post-close, unref'd 1.5s liveness probe logs `leaked worker (issue #502)` with the pid so any recurrence logs itself.
- **HTTP layer**: `MCP_HTTP_STALE_SWEEP_INTERVAL_MS` makes the hard-coded 60s sweep testable; `--log-file` now reaches the CLI logger (`attachSharedFileTransport`) so the `Reaping stale HTTP session` line is visible in the operator's log (the sse path has the same defect — #533).

## Tests

- Worker: terminate-during-in-flight-shutdown latches and completes in `TERMINATED`, one teardown, one status (`tests/proxy/dap-proxy-worker.test.ts`).
- ProxyManager: escalation fires when `killed=true` but the process never exited; `getProxyPid()` survives stop/cleanup; the pinned "resolves immediately when already exited" test now models death with `exitCode`, not `.killed` (semantics: Node latches `.killed` on signal send, not death).
- SessionManager: new `session-manager-worker-reap.test.ts` — status-driven exit reaps (`stopCalls === 1`), real child exit doesn't (pinned behavior preserved), `closeSession` awaits the in-flight stop, leak probe logs/stays silent by liveness.
- HTTP: sweep-override honored; invalid values warn + default.
- **New e2e** `mcp-server-smoke-http-stale-reap.test.ts`: real server + StreamableHTTP client (first use in the suite), mock session to natural termination, client abandoned **without DELETE**, worker pid captured via argv tags, polled to death, log asserted to contain the reap line and **not** the force-kill line. Red on unfixed main; green in ~7s with the fix (worker exits cleanly ~800ms after termination).

Full unit (4260), integration, and lint green; pre-push gate passed.

## Dogfooding

The bug was held open live with mcp-debugger on itself: one debug session frozen at a breakpoint **inside the parent's force-kill timer** (freezing the timer keeps the zombie alive indefinitely), and a second session attached to the zombie worker via `SIGUSR1` to inspect it from the inside (idle event loop, IPC pipe only, argv-tagged to the reaped session). Write-up: `docs/case-studies/the-zombie-worker-and-the-frozen-force-kill.md`. Dogfooding also filed #533 (sse `--log-file` gap) and #534 (worker stderr forwarded at error level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KnLteX47RBLM3ZYF1jGbc