### PR TITLE
docs: remove stale tool count from dev_server_status description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,7 +501,7 @@ Each session also exposes its captured output as an MCP resource (`debug://sessi
 **Dev proxy only** (these 3 tools are injected by the dev proxy process itself, not by the main mcp-debugger server):
 - `dev_restart_debugger` - Restart the backend (pass `rebuild: true` to build first)
 - `dev_rebuild_and_restart` - Run `npm run build` then restart the backend
-- `dev_server_status` - Check backend state, PID, uptime, tool count
+- `dev_server_status` - Check backend state, PID, uptime, transport, project root, and port
 
 ### Troubleshooting MCP Connection
 - **If server shows "Failed to connect"**:

--- a/tools/dev-proxy/dev-proxy.mjs
+++ b/tools/dev-proxy/dev-proxy.mjs
@@ -611,7 +611,7 @@ const DEV_TOOLS = [
   {
     name: 'dev_server_status',
     description:
-      'Get the current status of the mcp-debugger backend (state, PID, uptime, tool count, port).',
+      'Get the current status of the mcp-debugger backend (state, PID, uptime, transport, project root, port).',
     inputSchema: {
       type: 'object',
       properties: {},


### PR DESCRIPTION
## Summary

Removes the stale "tool count" reference from the `dev_server_status` MCP tool description and the CLAUDE.md reference.

PR #537 corrected the README, but two other copies survived — including the one an LLM reads at call time.

## Changes

- `tools/dev-proxy/dev-proxy.mjs:614`: Updated MCP tool description to match README wording
- `CLAUDE.md:504`: Updated `dev_server_status` reference to match README wording

## Related Issues

Resolves #539