### PR TITLE
fix(go): normalize function breakpoint removal

### DIFF
--- a/changelog.d/550.fixed.md
+++ b/changelog.d/550.fixed.md
@@ -1,0 +1,1 @@
+**Go function breakpoints can be removed with the same bare name used to create them** — `remove_breakpoint {function: "main"}` now applies the same `main` to `main.main` normalization as `set_breakpoint`, discloses the effective name, and preserves direct qualified-name removal (#550)

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -279,11 +279,12 @@ Lists all breakpoints in a session with their current verified state and adapter
 
 ### remove_breakpoint
 
-Removes one breakpoint by id, or every breakpoint at a `file` + `line` location. Takes effect immediately while the program is running or paused (the file's remaining breakpoint set is re-sent to the adapter); also works after the program exits, so breakpoints can be adjusted before a relaunch.
+Removes one breakpoint by id, every function breakpoint with a given name, or every breakpoint at a `file` + `line` location. Takes effect immediately while the program is running or paused (the file's remaining breakpoint set is re-sent to the adapter); also works after the program exits, so breakpoints can be adjusted before a relaunch.
 
 **Parameters:**
 - `sessionId` (string, required): The ID of the debug session.
-- `breakpointId` (string, optional): Breakpoint id from `set_breakpoint` or `list_breakpoints`. Takes precedence over `file` + `line`.
+- `breakpointId` (string, optional): Breakpoint id from `set_breakpoint` or `list_breakpoints`. Takes precedence over `function` and `file` + `line`.
+- `function` (string, optional): Alternative addressing — remove **all** function breakpoints with this symbol name. The same per-language rewrite `set_breakpoint` applies is used here, so the name you set with is the name you remove with (a bare Go `main` matches the stored `main.main`); the response reports the effective name as `functionName` and, when it was rewritten, the original as `requestedName`.
 - `file` (string, optional): Alternative addressing — source file path (use together with `line`). Removes **all** breakpoints at that location.
 - `line` (number, optional): Alternative addressing — line number (use together with `file`).
 
@@ -299,7 +300,7 @@ Removes one breakpoint by id, or every breakpoint at a `file` + `line` location.
 ```
 
 **Notes:**
-- An unknown `breakpointId` (or an empty location) returns `success: false` with an explanatory error.
+- An unknown `breakpointId` (or an empty location or function name) returns `success: false` with an explanatory error; for a function name the error names the effective (rewritten) form, and a bare name with no rewrite gets the same package-qualification hint `set_breakpoint` gives.
 - If the live re-send to the adapter fails, the breakpoint is still removed from the session (it will not be re-applied on the next launch) and the response carries a `warning`.
 
 ---

--- a/src/server.ts
+++ b/src/server.ts
@@ -1154,7 +1154,7 @@ export class DebugMcpServer {
           { name: 'list_debug_sessions', description: 'List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. "breakpoint" vs "exception")', inputSchema: { type: 'object', properties: {} } },
           { name: 'set_breakpoint', description: 'Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. "com.example.MyClass" or "com.example.Outer$Inner") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths.' }, line: { type: 'number', description: 'Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior' }, ...setBreakpointExtraProps, condition: { type: 'string', description: 'Optional expression: only break (or log) when it evaluates truthy' }, logMessage: { type: 'string', description: 'Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. "order={orderId} total={total}"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby' }, suspendPolicy: { type: 'string', enum: ['all', 'thread'], description: 'Suspend policy when breakpoint is hit: "all" suspends all threads (default), "thread" only suspends the event thread. Only supported by the Java/JDI adapter.' } }, required: setBreakpointRequired } },
           { name: 'list_breakpoints', description: 'List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Optional: only list breakpoints in this file' } }, required: ['sessionId'] } },
-          { name: 'remove_breakpoint', description: 'Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, breakpointId: { type: 'string', description: 'Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line' }, function: { type: 'string', description: 'Alternative addressing: remove all function breakpoints with this symbol name' }, file: { type: 'string', description: 'Alternative addressing: source file path (use together with line)' }, line: { type: 'number', description: 'Alternative addressing: line number (use together with file)' } }, required: ['sessionId'] } },
+          { name: 'remove_breakpoint', description: 'Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, breakpointId: { type: 'string', description: 'Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line' }, function: { type: 'string', description: 'Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go "main" matches the stored "main.main"); the response reports the effective name as functionName and, when rewritten, the original as requestedName' }, file: { type: 'string', description: 'Alternative addressing: source file path (use together with line)' }, line: { type: 'number', description: 'Alternative addressing: line number (use together with file)' } }, required: ['sessionId'] } },
           { name: 'clear_breakpoints', description: 'Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Optional: only clear breakpoints in this file' } }, required: ['sessionId'] } },
           { name: 'start_debugging', description: 'Start debugging a script', inputSchema: {
               type: 'object', 
@@ -1643,46 +1643,53 @@ export class DebugMcpServer {
               try {
                 let removed: Array<Breakpoint | FunctionBreakpoint>;
                 let warning: string | undefined;
-                let requestedFunctionName: string | undefined;
-                let effectiveFunctionName: string | undefined;
+                // Function-addressed removal discloses names the way
+                // set_breakpoint does: `functionName` is always the effective
+                // name, `requestedName` appears only when a policy rewrite
+                // changed it (issue #550).
+                let functionDisclosure: { functionName: string; requestedName?: string } | undefined;
                 if (!args.breakpointId && args.function !== undefined) {
+                  const requestedName = args.function;
                   // Use the same policy-certain rewrite as set_breakpoint so
                   // the name the caller supplied can remove the normalized
-                  // record that was stored (issue #550).
-                  const normalized = this.normalizeFunctionBreakpointName(
-                    args.sessionId,
-                    args.function
-                  );
-                  const effectiveName = normalized?.name ?? args.function;
-                  if (normalized) {
-                    requestedFunctionName = args.function;
-                    effectiveFunctionName = effectiveName;
-                  }
+                  // record that was stored (issue #550). The literal name is
+                  // matched too — a record stored un-rewritten (policy lookup
+                  // failure, or set through another path) stays removable.
+                  const normalized = this.normalizeFunctionBreakpointName(args.sessionId, requestedName);
+                  const effectiveName = normalized?.name ?? requestedName;
+                  functionDisclosure = {
+                    functionName: effectiveName,
+                    ...(normalized ? { requestedName } : {})
+                  };
                   const matches = this.sessionManager
                     .listFunctionBreakpoints(args.sessionId)
-                    .filter((bp) => bp.functionName === effectiveName);
+                    .filter((bp) => bp.functionName === effectiveName || bp.functionName === requestedName);
                   removed = [];
-                  const warnings: string[] = normalized?.note ? [normalized.note] : [];
+                  const warnings: string[] = [];
                   for (const bp of matches) {
                     const res = await this.removeBreakpoint(args.sessionId, bp.id);
                     if (res.removed) removed.push(res.removed);
                     if (res.warning) warnings.push(res.warning);
                   }
-                  warning = warnings.length > 0 ? warnings.join('; ') : undefined;
                   if (removed.length === 0) {
+                    // Same per-adapter name advisory set_breakpoint gives
+                    // (issues #303/#308), so a bare Go name that never matched
+                    // learns the package-qualified form it should use.
+                    const nameHint = normalized
+                      ? undefined
+                      : this.getFunctionBreakpointNameHint(args.sessionId, effectiveName);
+                    if (nameHint) warnings.push(nameHint);
                     result = { content: [{ type: 'text', text: JSON.stringify({
                       success: false,
                       error: normalized
-                        ? `No function breakpoint found for ${args.function} (normalized to ${effectiveName})`
-                        : `No function breakpoint found for ${args.function}`,
-                      ...(normalized ? {
-                        requestedName: args.function,
-                        functionName: effectiveName,
-                        warning: normalized.note
-                      } : {})
+                        ? `No function breakpoint found for ${requestedName} (normalized to ${effectiveName})`
+                        : `No function breakpoint found for ${requestedName}`,
+                      ...functionDisclosure,
+                      warning: warnings.length > 0 ? warnings.join('; ') : undefined
                     }) }] };
                     break;
                   }
+                  warning = warnings.length > 0 ? warnings.join('; ') : undefined;
                 } else if (args.breakpointId) {
                   const res = await this.removeBreakpoint(args.sessionId, args.breakpointId);
                   removed = res.removed ? [res.removed] : [];
@@ -1710,10 +1717,7 @@ export class DebugMcpServer {
                   success: true,
                   removed,
                   message: `Removed ${removed.length} breakpoint(s)`,
-                  ...(requestedFunctionName !== undefined ? {
-                    requestedName: requestedFunctionName,
-                    functionName: effectiveFunctionName
-                  } : {}),
+                  ...(functionDisclosure ?? {}),
                   warning
                 }) }] };
               } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1643,13 +1643,26 @@ export class DebugMcpServer {
               try {
                 let removed: Array<Breakpoint | FunctionBreakpoint>;
                 let warning: string | undefined;
+                let requestedFunctionName: string | undefined;
+                let effectiveFunctionName: string | undefined;
                 if (!args.breakpointId && args.function !== undefined) {
-                  // Remove by function name (issue #271 phase 3)
+                  // Use the same policy-certain rewrite as set_breakpoint so
+                  // the name the caller supplied can remove the normalized
+                  // record that was stored (issue #550).
+                  const normalized = this.normalizeFunctionBreakpointName(
+                    args.sessionId,
+                    args.function
+                  );
+                  const effectiveName = normalized?.name ?? args.function;
+                  if (normalized) {
+                    requestedFunctionName = args.function;
+                    effectiveFunctionName = effectiveName;
+                  }
                   const matches = this.sessionManager
                     .listFunctionBreakpoints(args.sessionId)
-                    .filter((bp) => bp.functionName === args.function);
+                    .filter((bp) => bp.functionName === effectiveName);
                   removed = [];
-                  const warnings: string[] = [];
+                  const warnings: string[] = normalized?.note ? [normalized.note] : [];
                   for (const bp of matches) {
                     const res = await this.removeBreakpoint(args.sessionId, bp.id);
                     if (res.removed) removed.push(res.removed);
@@ -1659,7 +1672,14 @@ export class DebugMcpServer {
                   if (removed.length === 0) {
                     result = { content: [{ type: 'text', text: JSON.stringify({
                       success: false,
-                      error: `No function breakpoint found for ${args.function}`
+                      error: normalized
+                        ? `No function breakpoint found for ${args.function} (normalized to ${effectiveName})`
+                        : `No function breakpoint found for ${args.function}`,
+                      ...(normalized ? {
+                        requestedName: args.function,
+                        functionName: effectiveName,
+                        warning: normalized.note
+                      } : {})
                     }) }] };
                     break;
                   }
@@ -1690,6 +1710,10 @@ export class DebugMcpServer {
                   success: true,
                   removed,
                   message: `Removed ${removed.length} breakpoint(s)`,
+                  ...(requestedFunctionName !== undefined ? {
+                    requestedName: requestedFunctionName,
+                    functionName: effectiveFunctionName
+                  } : {}),
                   warning
                 }) }] };
               } catch (error) {

--- a/tests/core/unit/server/server-breakpoint-management-tools.test.ts
+++ b/tests/core/unit/server/server-breakpoint-management-tools.test.ts
@@ -276,10 +276,85 @@ describe('Server Breakpoint Management Tools', () => {
       expect(content.removed).toHaveLength(2);
       expect(content.requestedName).toBe('main');
       expect(content.functionName).toBe('main.main');
-      expect(content.warning).toContain('Auto-qualified');
-      expect(content.warning).toContain('adapter resync pending');
+      // The set-time "auto-qualified … never binds" note is create-path
+      // text; a removal only carries the removal's own warnings.
+      expect(content.warning).toBe('adapter resync pending');
       expect(mockSessionManager.removeBreakpoint).toHaveBeenCalledWith('test-session', 'fn-1');
       expect(mockSessionManager.removeBreakpoint).toHaveBeenCalledWith('test-session', 'fn-2');
+    });
+
+    it('removes a record stored under the literal bare name even when the policy rewrites it', async () => {
+      mockSessionManager.getSessionPolicy.mockReturnValue({
+        name: 'go',
+        normalizeFunctionBreakpointName: (name: string) =>
+          name === 'main' ? { name: 'main.main', note: 'Auto-qualified to main.main' } : undefined
+      });
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([
+        { id: 'fn-bare', functionName: 'main', verified: false }
+      ]);
+      mockSessionManager.removeBreakpoint.mockResolvedValue({
+        removed: { id: 'fn-bare', functionName: 'main', verified: false }
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'remove_breakpoint',
+          arguments: { sessionId: 'test-session', function: 'main' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.removed).toHaveLength(1);
+      expect(content.requestedName).toBe('main');
+      expect(content.functionName).toBe('main.main');
+      expect(mockSessionManager.removeBreakpoint).toHaveBeenCalledWith('test-session', 'fn-bare');
+    });
+
+    it('removes with the same name set_breakpoint stored, driven by the real GoAdapterPolicy (issue #550)', async () => {
+      const { GoAdapterPolicy } = await import('@debugmcp/shared');
+      mockSessionManager.getSessionPolicy.mockReturnValue(GoAdapterPolicy);
+      // Echo whatever name the set path stores, so the round-trip proves the
+      // two handlers agree through the policy rather than through a stub.
+      mockSessionManager.setFunctionBreakpoint.mockImplementation(
+        async (_sessionId: string, { functionName }: { functionName: string }) => ({
+          breakpoint: { id: 'fn-rt', functionName, verified: false }
+        })
+      );
+
+      const setResult = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'set_breakpoint',
+          arguments: { sessionId: 'test-session', function: 'main' }
+        }
+      });
+      const setContent = JSON.parse(setResult.content[0].text);
+      expect(setContent.success).toBe(true);
+      const storedName = setContent.functionName as string;
+      expect(storedName).toBe('main.main');
+
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([
+        { id: 'fn-rt', functionName: storedName, verified: false }
+      ]);
+      mockSessionManager.removeBreakpoint.mockResolvedValue({
+        removed: { id: 'fn-rt', functionName: storedName, verified: false }
+      });
+
+      const removeResult = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'remove_breakpoint',
+          arguments: { sessionId: 'test-session', function: 'main' }
+        }
+      });
+      const removeContent = JSON.parse(removeResult.content[0].text);
+      expect(removeContent.success).toBe(true);
+      expect(removeContent.removed).toHaveLength(1);
+      expect(removeContent.functionName).toBe(storedName);
+      expect(removeContent.requestedName).toBe('main');
+      expect(mockSessionManager.removeBreakpoint).toHaveBeenCalledWith('test-session', 'fn-rt');
     });
 
     it('continues to remove a directly qualified function name', async () => {
@@ -305,7 +380,7 @@ describe('Server Breakpoint Management Tools', () => {
       const content = JSON.parse(result.content[0].text);
       expect(content.success).toBe(true);
       expect(content.requestedName).toBeUndefined();
-      expect(content.functionName).toBeUndefined();
+      expect(content.functionName).toBe('main.main');
       expect(mockSessionManager.removeBreakpoint).toHaveBeenCalledWith('test-session', 'fn-1');
     });
 
@@ -331,7 +406,35 @@ describe('Server Breakpoint Management Tools', () => {
       expect(content.error).toContain('main.main');
       expect(content.requestedName).toBe('main');
       expect(content.functionName).toBe('main.main');
-      expect(content.warning).toBe('Auto-qualified to main.main');
+      expect(content.warning).toBeUndefined();
+    });
+
+    it('offers the package-qualification hint when a bare name with no rewrite matches nothing', async () => {
+      mockSessionManager.getSessionPolicy.mockReturnValue({
+        name: 'go',
+        normalizeFunctionBreakpointName: () => undefined,
+        functionBreakpointNameHint: (name: string) =>
+          name.includes('.') ? undefined : `for func ${name} in package main use 'main.${name}'`
+      });
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([
+        { id: 'fn-1', functionName: 'main.compute', verified: true }
+      ]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'remove_breakpoint',
+          arguments: { sessionId: 'test-session', function: 'compute' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(false);
+      expect(content.error).toBe('No function breakpoint found for compute');
+      expect(content.functionName).toBe('compute');
+      expect(content.requestedName).toBeUndefined();
+      expect(content.warning).toContain("use 'main.compute'");
+      expect(mockSessionManager.removeBreakpoint).not.toHaveBeenCalled();
     });
 
     it('preserves a directly qualified name in no-match diagnostics', async () => {
@@ -353,7 +456,7 @@ describe('Server Breakpoint Management Tools', () => {
       expect(content.success).toBe(false);
       expect(content.error).toBe('No function breakpoint found for main.main');
       expect(content.requestedName).toBeUndefined();
-      expect(content.functionName).toBeUndefined();
+      expect(content.functionName).toBe('main.main');
       expect(content.warning).toBeUndefined();
     });
   });

--- a/tests/core/unit/server/server-breakpoint-management-tools.test.ts
+++ b/tests/core/unit/server/server-breakpoint-management-tools.test.ts
@@ -245,6 +245,117 @@ describe('Server Breakpoint Management Tools', () => {
         }
       })).rejects.toThrow(/breakpointId|file/);
     });
+
+    it('normalizes a bare Go function name before removal and discloses it (issue #550)', async () => {
+      mockSessionManager.getSessionPolicy.mockReturnValue({
+        name: 'go',
+        normalizeFunctionBreakpointName: (name: string) =>
+          name === 'main'
+            ? { name: 'main.main', note: "Auto-qualified function breakpoint 'main' to 'main.main'" }
+            : undefined
+      });
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([
+        { id: 'fn-1', functionName: 'main.main', verified: true },
+        { id: 'fn-2', functionName: 'main.main', verified: false }
+      ]);
+      mockSessionManager.removeBreakpoint.mockImplementation(async (_sessionId: string, id: string) => ({
+        removed: { id, functionName: 'main.main', verified: id === 'fn-1' },
+        warning: id === 'fn-2' ? 'adapter resync pending' : undefined
+      }));
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'remove_breakpoint',
+          arguments: { sessionId: 'test-session', function: 'main' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.removed).toHaveLength(2);
+      expect(content.requestedName).toBe('main');
+      expect(content.functionName).toBe('main.main');
+      expect(content.warning).toContain('Auto-qualified');
+      expect(content.warning).toContain('adapter resync pending');
+      expect(mockSessionManager.removeBreakpoint).toHaveBeenCalledWith('test-session', 'fn-1');
+      expect(mockSessionManager.removeBreakpoint).toHaveBeenCalledWith('test-session', 'fn-2');
+    });
+
+    it('continues to remove a directly qualified function name', async () => {
+      mockSessionManager.getSessionPolicy.mockReturnValue({
+        name: 'go',
+        normalizeFunctionBreakpointName: () => undefined
+      });
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([
+        { id: 'fn-1', functionName: 'main.main', verified: true }
+      ]);
+      mockSessionManager.removeBreakpoint.mockResolvedValue({
+        removed: { id: 'fn-1', functionName: 'main.main', verified: true }
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'remove_breakpoint',
+          arguments: { sessionId: 'test-session', function: 'main.main' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(true);
+      expect(content.requestedName).toBeUndefined();
+      expect(content.functionName).toBeUndefined();
+      expect(mockSessionManager.removeBreakpoint).toHaveBeenCalledWith('test-session', 'fn-1');
+    });
+
+    it('names the requested and normalized function when no breakpoint matches', async () => {
+      mockSessionManager.getSessionPolicy.mockReturnValue({
+        name: 'go',
+        normalizeFunctionBreakpointName: (name: string) =>
+          name === 'main' ? { name: 'main.main', note: 'Auto-qualified to main.main' } : undefined
+      });
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'remove_breakpoint',
+          arguments: { sessionId: 'test-session', function: 'main' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(false);
+      expect(content.error).toContain('main');
+      expect(content.error).toContain('main.main');
+      expect(content.requestedName).toBe('main');
+      expect(content.functionName).toBe('main.main');
+      expect(content.warning).toBe('Auto-qualified to main.main');
+    });
+
+    it('preserves a directly qualified name in no-match diagnostics', async () => {
+      mockSessionManager.getSessionPolicy.mockReturnValue({
+        name: 'go',
+        normalizeFunctionBreakpointName: () => undefined
+      });
+      mockSessionManager.listFunctionBreakpoints.mockReturnValue([]);
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'remove_breakpoint',
+          arguments: { sessionId: 'test-session', function: 'main.main' }
+        }
+      });
+
+      const content = JSON.parse(result.content[0].text);
+      expect(content.success).toBe(false);
+      expect(content.error).toBe('No function breakpoint found for main.main');
+      expect(content.requestedName).toBeUndefined();
+      expect(content.functionName).toBeUndefined();
+      expect(content.warning).toBeUndefined();
+    });
   });
 
   describe('clear_breakpoints', () => {


### PR DESCRIPTION
## Summary

- normalize `remove_breakpoint.function` through the same adapter-policy hook used when setting function breakpoints
- preserve direct removal by qualified Go names
- disclose requested/effective names and normalization warnings, including useful no-match diagnostics

## Validation

- reproduced the regression twice before the fix
- `pnpm build`
- `pnpm test:unit` (4,328 passed)
- `pnpm test:integration` (28 passed, 5 skipped)
- `pnpm lint`
- `pnpm check:all-personal-paths`
- `pnpm changelog:check`
- `git diff --check`

## Dogfooding

Used the source dev proxy with the real Go example and Delve to set and remove a bare `main` function breakpoint, verify the disclosed `main.main` normalization, launch, pause, inspect frames, and continue.

Closes #550
