### PR TITLE
fix(attach): preserve proxy initialization diagnostics

### DIFF
--- a/changelog.d/551.fixed.md
+++ b/changelog.d/551.fixed.md
@@ -1,1 +1,1 @@
-Preserve proxy initialization progress and log-path diagnostics when attach requests fail.
+**Failed attaches report where proxy initialization stalled** — `attach_to_process` and `create_debug_session` with a `port` now return the same `data.initProgress` / `data.proxyLogPath` diagnostics `start_debugging` already gave on a proxy init failure, instead of a bare error message (#551)

--- a/changelog.d/551.fixed.md
+++ b/changelog.d/551.fixed.md
@@ -1,0 +1,1 @@
+Preserve proxy initialization progress and log-path diagnostics when attach requests fail.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1352,13 +1352,21 @@ export class DebugMcpServer {
                     adapterConfig: args.adapterConfig,
                   });
 
+                  // Forward the attach payload the same way attach_to_process
+                  // does: structured failure diagnostics (initProgress /
+                  // proxyLogPath, issue #551) and the dropped-adapterConfig
+                  // warning (issue #450) must reach this entry point too.
+                  const attachData = attachResult.data as { warning?: string } | undefined;
+                  const attachWarning = attachResult.success ? attachData?.warning : undefined;
                   result = { content: [{ type: 'text', text: JSON.stringify({
                     success: attachResult.success,
                     sessionId: sessionInfo.id,
                     state: attachResult.state,
                     message: attachResult.success
                       ? `Created and attached ${sessionInfo.language} debug session: ${sessionInfo.name}`
-                      : `Created session but attach failed: ${attachResult.error || 'Unknown error'}`
+                      : `Created session but attach failed: ${attachResult.error || 'Unknown error'}`,
+                    ...(attachData ? { data: attachData } : {}),
+                    ...(attachWarning ? { warning: attachWarning } : {})
                   }) }] };
                 } catch (error) {
                   this.logger.error('session:attach-failed', {

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -971,13 +971,14 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         },
       };
     } catch (error) {
+      const diagnosticData = this.collectProxyFailureDiagnostics(session, error);
+      const initProgress = diagnosticData.initProgress as Record<string, unknown> | undefined;
+      const proxyLogPath = diagnosticData.proxyLogPath as string | undefined;
+
       // Attempt to capture proxy log tail for debugging initialization failures
       let proxyLogTail: string | undefined;
-      let proxyLogPath: string | undefined;
       try {
-        const latestSession = this._getSessionById(sessionId);
-        if (latestSession.logDir) {
-          proxyLogPath = path.join(latestSession.logDir, `proxy-${sessionId}.log`);
+        if (proxyLogPath) {
           const logExists = await this.fileSystem.pathExists(proxyLogPath);
           if (logExists) {
             const logContent = await this.fileSystem.readFile(proxyLogPath, 'utf-8');
@@ -992,9 +993,6 @@ export abstract class SessionManagerOperations extends SessionManagerData {
           logReadError instanceof Error ? logReadError.message : String(logReadError)
         }>>`;
       }
-
-      // Structured init-progress facts from a proxy init timeout (issue #493)
-      const initProgress = (error as { initProgress?: Record<string, unknown> })?.initProgress;
 
       // Comprehensive error capture for debugging Windows CI issues
       const errorDetails: Record<string, unknown> = {
@@ -1072,17 +1070,6 @@ export abstract class SessionManagerOperations extends SessionManagerData {
           errorType,
           errorCode,
         };
-      }
-
-      // Surface the diagnosis in the tool result, not just the server log
-      // (issue #493): which init stage stalled, and where the full proxy log
-      // lives — the agent reading the error has no other way to these facts.
-      const diagnosticData: Record<string, unknown> = {};
-      if (initProgress) {
-        diagnosticData.initProgress = initProgress;
-      }
-      if (proxyLogPath) {
-        diagnosticData.proxyLogPath = proxyLogPath;
       }
 
       return {
@@ -3058,6 +3045,9 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       };
     } catch (error) {
       this.logger.error(`[SessionManager] Failed to attach to process for session ${sessionId}:`, error);
+      // Capture initialization diagnostics before teardown, which can clear
+      // the proxy and its per-run log directory (issue #551).
+      const diagnosticData = this.collectProxyFailureDiagnostics(session, error);
       // Never leave a live proxy chain behind a failed attach — e.g.
       // ProxyManager.start()'s init timeout rejects after the worker was
       // spawned (issue #337). Idempotent with the verify-failure teardown
@@ -3069,9 +3059,32 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       return {
         success: false,
         state: SessionState.ERROR,
-        error: `Failed to attach: ${message}`
+        error: `Failed to attach: ${message}`,
+        ...(Object.keys(diagnosticData).length > 0 ? { data: diagnosticData } : {})
       };
     }
+  }
+
+  /**
+   * Collect display-safe pointers to proxy initialization diagnostics while
+   * the session still owns its current proxy run.
+   */
+  private collectProxyFailureDiagnostics(
+    session: ManagedSession,
+    error: unknown
+  ): Record<string, unknown> {
+    const diagnostics: Record<string, unknown> = {};
+    const initProgress = (error as { initProgress?: Record<string, unknown> } | null)
+      ?.initProgress;
+
+    if (initProgress) {
+      diagnostics.initProgress = initProgress;
+    }
+    if (session.logDir) {
+      diagnostics.proxyLogPath = path.join(session.logDir, `proxy-${session.id}.log`);
+    }
+
+    return diagnostics;
   }
 
   /**

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -24,7 +24,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import path from 'path';
 import { ProxyConfig } from '../proxy/proxy-config.js';
 import { MIRROR_EXPOSE_COMMAND, MIRROR_UNEXPOSE_COMMAND } from '../proxy/dap-proxy-interfaces.js';
-import { ErrorMessages } from '../utils/error-messages.js';
+import { ErrorMessages, ProxyInitProgress } from '../utils/error-messages.js';
 import { checkLaunchToolchain } from '../utils/language-availability.js';
 import { didYouMean } from '../utils/did-you-mean.js';
 import { resolveStatement } from '../utils/breakpoint-resolver.js';
@@ -972,8 +972,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       };
     } catch (error) {
       const diagnosticData = this.collectProxyFailureDiagnostics(session, error);
-      const initProgress = diagnosticData.initProgress as Record<string, unknown> | undefined;
-      const proxyLogPath = diagnosticData.proxyLogPath as string | undefined;
+      const { initProgress, proxyLogPath } = diagnosticData;
 
       // Attempt to capture proxy log tail for debugging initialization failures
       let proxyLogTail: string | undefined;
@@ -3045,9 +3044,6 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       };
     } catch (error) {
       this.logger.error(`[SessionManager] Failed to attach to process for session ${sessionId}:`, error);
-      // Capture initialization diagnostics before teardown, which can clear
-      // the proxy and its per-run log directory (issue #551).
-      const diagnosticData = this.collectProxyFailureDiagnostics(session, error);
       // Never leave a live proxy chain behind a failed attach — e.g.
       // ProxyManager.start()'s init timeout rejects after the worker was
       // spawned (issue #337). Idempotent with the verify-failure teardown
@@ -3055,6 +3051,11 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       await this.stopProxyPreservingSession(session);
       this._updateSessionState(session, SessionState.ERROR);
 
+      // Surface the same structured diagnostics the launch path returns
+      // (issue #551). Teardown only clears the proxy handle; logDir and the
+      // error's initProgress survive it, so this reads after the teardown
+      // and can never keep it from running.
+      const diagnosticData = this.collectProxyFailureDiagnostics(session, error);
       const message = error instanceof Error ? error.message : String(error);
       return {
         success: false,
@@ -3066,16 +3067,16 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   }
 
   /**
-   * Collect display-safe pointers to proxy initialization diagnostics while
-   * the session still owns its current proxy run.
+   * Pointers to proxy initialization diagnostics for a failed launch/attach
+   * (issue #493 / #551): which init stage stalled (from the timeout error) and
+   * where the proxy log for the session's current run lives.
    */
   private collectProxyFailureDiagnostics(
     session: ManagedSession,
     error: unknown
-  ): Record<string, unknown> {
-    const diagnostics: Record<string, unknown> = {};
-    const initProgress = (error as { initProgress?: Record<string, unknown> } | null)
-      ?.initProgress;
+  ): { initProgress?: ProxyInitProgress; proxyLogPath?: string } {
+    const diagnostics: { initProgress?: ProxyInitProgress; proxyLogPath?: string } = {};
+    const initProgress = (error as { initProgress?: ProxyInitProgress } | null)?.initProgress;
 
     if (initProgress) {
       diagnostics.initProgress = initProgress;

--- a/tests/core/unit/server/server-redefine-and-attach.test.ts
+++ b/tests/core/unit/server/server-redefine-and-attach.test.ts
@@ -432,6 +432,32 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
   });
 
   describe('attach warning join (issue #450)', () => {
+    it('preserves structured diagnostics on a failed attach (issue #551)', async () => {
+      const diagnosticData = {
+        initProgress: { transportConnected: true, pendingRequest: 'initialize' },
+        proxyLogPath: '/tmp/logs/session/proxy-session.log'
+      };
+      mockSessionManager.attachToProcess.mockResolvedValue({
+        success: false,
+        state: 'error',
+        error: 'Failed to attach: initialize stalled',
+        data: diagnosticData
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'attach_to_process',
+          arguments: { sessionId: 'test-session', port: 45999 }
+        }
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.success).toBe(false);
+      expect(payload.message).toContain('initialize stalled');
+      expect(payload.data).toEqual(diagnosticData);
+    });
+
     it('surfaces data.warning at the top level of the attach_to_process response', async () => {
       mockSessionManager.attachToProcess.mockResolvedValue({
         success: true,

--- a/tests/core/unit/server/server-redefine-and-attach.test.ts
+++ b/tests/core/unit/server/server-redefine-and-attach.test.ts
@@ -431,12 +431,13 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
     });
   });
 
-  describe('attach warning join (issue #450)', () => {
-    it('preserves structured diagnostics on a failed attach (issue #551)', async () => {
-      const diagnosticData = {
-        initProgress: { transportConnected: true, pendingRequest: 'initialize' },
-        proxyLogPath: '/tmp/logs/session/proxy-session.log'
-      };
+  describe('attach failure diagnostics (issue #551)', () => {
+    const diagnosticData = {
+      initProgress: { transportConnected: true, pendingCommand: 'initialize' },
+      proxyLogPath: '/tmp/logs/session/proxy-session.log'
+    };
+
+    it('preserves structured diagnostics on a failed attach_to_process', async () => {
       mockSessionManager.attachToProcess.mockResolvedValue({
         success: false,
         state: 'error',
@@ -458,6 +459,71 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
       expect(payload.data).toEqual(diagnosticData);
     });
 
+    it('forwards the same diagnostics from a create_debug_session inline attach', async () => {
+      const sessionInfo: DebugSessionInfo = {
+        id: 'inline-attach-session',
+        name: 'inline',
+        language: 'python' as DebugLanguage,
+        state: 'created' as SessionState,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+      mockSessionManager.createSession.mockResolvedValue(sessionInfo);
+      mockSessionManager.attachToProcess.mockResolvedValue({
+        success: false,
+        state: 'error',
+        error: 'Failed to attach: initialize stalled',
+        data: diagnosticData
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'create_debug_session',
+          arguments: { language: 'python', port: 45999 }
+        }
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.success).toBe(false);
+      expect(payload.sessionId).toBe('inline-attach-session');
+      expect(payload.message).toContain('initialize stalled');
+      expect(payload.data).toEqual(diagnosticData);
+      expect(payload.warning).toBeUndefined();
+    });
+
+    it('surfaces data.warning at the top level of a successful create_debug_session inline attach', async () => {
+      const sessionInfo: DebugSessionInfo = {
+        id: 'inline-attach-session',
+        name: 'inline',
+        language: 'python' as DebugLanguage,
+        state: 'created' as SessionState,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+      mockSessionManager.createSession.mockResolvedValue(sessionInfo);
+      mockSessionManager.attachToProcess.mockResolvedValue({
+        success: true,
+        state: 'paused',
+        data: { message: 'Attached', warning: 'adapterConfig key(s) were ignored: remoteRoot' }
+      });
+
+      const result = await callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'create_debug_session',
+          arguments: { language: 'python', port: 45999 }
+        }
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.success).toBe(true);
+      expect(payload.warning).toContain('remoteRoot');
+      expect(payload.data.warning).toContain('remoteRoot');
+    });
+  });
+
+  describe('attach warning join (issue #450)', () => {
     it('surfaces data.warning at the top level of the attach_to_process response', async () => {
       mockSessionManager.attachToProcess.mockResolvedValue({
         success: true,

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -1539,7 +1539,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     it('returns init progress and proxy log path when proxy initialization fails (issue #551)', async () => {
       const initProgress = {
         transportConnected: true,
-        pendingRequest: 'initialize'
+        pendingCommand: 'initialize'
       };
       const initError = Object.assign(
         new Error('Debug proxy initialization did not complete within 30s'),
@@ -1548,11 +1548,10 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       mockSession.proxyManager = undefined;
       mockSession.logDir = path.join('/tmp', 'logs', 'test-session', 'run-123');
       vi.spyOn(operations as any, 'startProxyManager').mockRejectedValue(initError);
+      // Teardown (which only clears the proxy handle) must still run on the
+      // failure path; the diagnostics come from the error and logDir.
       const stopSpy = vi.spyOn(operations as any, 'stopProxyPreservingSession')
         .mockImplementation(async (session: typeof mockSession) => {
-          // Diagnostics must be captured before teardown can clear runtime
-          // fields from the session.
-          session.logDir = undefined;
           session.proxyManager = undefined;
         });
 

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -1536,6 +1536,68 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       (operations as unknown as { attachPauseStopTimeoutMs: number }).attachPauseStopTimeoutMs = 50;
     });
 
+    it('returns init progress and proxy log path when proxy initialization fails (issue #551)', async () => {
+      const initProgress = {
+        transportConnected: true,
+        pendingRequest: 'initialize'
+      };
+      const initError = Object.assign(
+        new Error('Debug proxy initialization did not complete within 30s'),
+        { initProgress }
+      );
+      mockSession.proxyManager = undefined;
+      mockSession.logDir = path.join('/tmp', 'logs', 'test-session', 'run-123');
+      vi.spyOn(operations as any, 'startProxyManager').mockRejectedValue(initError);
+      const stopSpy = vi.spyOn(operations as any, 'stopProxyPreservingSession')
+        .mockImplementation(async (session: typeof mockSession) => {
+          // Diagnostics must be captured before teardown can clear runtime
+          // fields from the session.
+          session.logDir = undefined;
+          session.proxyManager = undefined;
+        });
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 45999,
+        host: '127.0.0.1'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.data).toEqual({
+        initProgress,
+        proxyLogPath: path.join('/tmp', 'logs', 'test-session', 'run-123', 'proxy-test-session.log')
+      });
+      expect(stopSpy).toHaveBeenCalled();
+    });
+
+    it('returns an available proxy log path even when init progress is absent', async () => {
+      mockSession.proxyManager = undefined;
+      mockSession.logDir = path.join('/tmp', 'logs', 'test-session', 'run-456');
+      vi.spyOn(operations as any, 'startProxyManager').mockRejectedValue(new Error('adapter exited'));
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 45999,
+        host: '127.0.0.1'
+      });
+
+      expect(result.data).toEqual({
+        proxyLogPath: path.join('/tmp', 'logs', 'test-session', 'run-456', 'proxy-test-session.log')
+      });
+    });
+
+    it('does not invent structured diagnostics for an ordinary pre-log failure', async () => {
+      mockSession.proxyManager = undefined;
+      mockSession.logDir = undefined;
+      vi.spyOn(operations as any, 'startProxyManager').mockRejectedValue(new Error('bad attach config'));
+
+      const result = await operations.attachToProcess('test-session', {
+        port: 45999,
+        host: '127.0.0.1'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.data).toBeUndefined();
+    });
+
     it('warns and proceeds when the registry lacks getFactoryMetadata (attach gate self-disabled)', async () => {
       delete (mockDependencies.adapterRegistry as Record<string, unknown>).getFactoryMetadata;
       mockProxyManager.sendDapRequest.mockImplementation(async (command: string) =>


### PR DESCRIPTION
## Summary

- factor proxy initialization diagnostics into a shared launch/attach helper
- capture attach `initProgress` and `proxyLogPath` before teardown
- preserve raw structured failure data through the MCP response without changing successful responses

## Validation

- reproduced the regression twice before the fix
- `pnpm build`
- `pnpm test:unit` (4,329 passed)
- `pnpm test:integration` (28 passed, 5 skipped)
- `pnpm lint`
- `pnpm check:all-personal-paths`
- `pnpm changelog:check`
- `git diff --check`

## Dogfooding

Ran a real MCP attach through the source dev proxy against the adversarial DAP scenario fixture, dropped the initialize response, and confirmed the failure retains transport progress and the proxy log path before cleanup.

Closes #551
