### PR TITLE
test(fakes): compile-checked FakeDebugAdapter and a cross-policy AdapterPolicy contract test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -111,6 +111,7 @@ tests/
 ├── stress/                    # Stress tests (SSE stress, cross-transport parity)
 │
 ├── test-utils/                # Shared test utilities
+│   ├── fakes/                 # Compile-checked fakes (classes that `implements` an interface)
 │   ├── fixtures/              # Script fixtures (python-scripts.ts)
 │   ├── helpers/               # Port manager, test dependencies, coverage tools
 │   └── mocks/                 # Mock DAP client, logger, processes, adapters, etc.
@@ -165,6 +166,7 @@ packages/
 
 `tests/test-utils/` provides reusable infrastructure:
 
+- **`fakes/fake-debug-adapter.ts`** — conformant `IDebugAdapter` double (see *Fakes vs mocks* below)
 - **`helpers/port-manager.ts`** — allocates unique ports to avoid conflicts between parallel tests
 - **`helpers/test-dependencies.ts`** — creates dependency injection containers pre-wired for testing
 - **`mocks/dap-client.ts`** — mock DAP client for simulating debugger communication
@@ -172,6 +174,17 @@ packages/
 - **`mocks/mock-proxy-manager.ts`** — mock proxy manager with controllable behavior
 - **`mocks/child-process.ts`**, **`mocks/net.ts`** — mock Node.js built-ins
 - **`fixtures/python-scripts.ts`** — Python script content for test fixtures
+
+### Fakes vs mocks
+
+A **fake** (`test-utils/fakes/`) is a class that `implements` a production interface, so the
+compiler rejects it the moment the interface moves — use one for the big behavioural interfaces
+whose doubles otherwise drift, `IDebugAdapter` (`fakes/fake-debug-adapter.ts`) and `IProxyManager`
+(`mocks/mock-proxy-manager.ts`, which predates the directory). A **mock** (`test-utils/mocks/`) is
+a `vi.fn` bag for a narrow seam, where an untyped literal costs little and reads more directly.
+
+Reach for a fake rather than hand-rolling an `as unknown as SomeInterface` literal: that cast
+silences exactly the divergence the double exists to avoid.
 
 ## Writing Tests
 

--- a/tests/core/unit/factories/proxy-manager-factory.test.ts
+++ b/tests/core/unit/factories/proxy-manager-factory.test.ts
@@ -6,91 +6,17 @@ import { IFileSystem, ILogger } from '../../../../src/interfaces/external-depend
 import { createMockLogger, createMockFileSystem } from '../../../test-utils/helpers/test-dependencies.js';
 import { MockProxyManager } from '../../../test-utils/mocks/mock-proxy-manager.js';
 import { IDebugAdapter } from '@debugmcp/shared';
-import { DebugLanguage } from '@debugmcp/shared';
+import { FakeDebugAdapter } from '../../../test-utils/fakes/fake-debug-adapter.js';
 
 describe('ProxyManagerFactory', () => {
   let mockProxyProcessLauncher: IProxyProcessLauncher;
   let mockFileSystem: IFileSystem;
   let mockLogger: ILogger;
 
-  // Helper function to create a mock debug adapter
+  // One compile-checked fake instead of a 75-line uncast literal, which had drifted into
+  // a sync transformLaunchConfig and two members the interface no longer declares.
   function createMockDebugAdapter(): IDebugAdapter {
-    return {
-      language: DebugLanguage.MOCK,
-      name: 'Mock Debug Adapter',
-      
-      // Lifecycle methods
-      initialize: vi.fn().mockResolvedValue(undefined),
-      dispose: vi.fn().mockResolvedValue(undefined),
-      
-      // State management
-      getState: vi.fn().mockReturnValue('ready'),
-      isReady: vi.fn().mockReturnValue(true),
-      getCurrentThreadId: vi.fn().mockReturnValue(1),
-      
-      // Environment validation
-      validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-      getRequiredDependencies: vi.fn().mockReturnValue([]),
-      
-      // Executable management
-      resolveExecutablePath: vi.fn().mockResolvedValue('mock-executable'),
-      getDefaultExecutableName: vi.fn().mockReturnValue('mock'),
-      getExecutableSearchPaths: vi.fn().mockReturnValue([]),
-      
-      // Adapter configuration
-      buildAdapterCommand: vi.fn().mockImplementation((config) => ({
-        command: config.executablePath || 'node',
-        args: ['mock-adapter.js', '--port', String(config.adapterPort)],
-        env: {}
-      })),
-      getAdapterModuleName: vi.fn().mockReturnValue('mock-adapter'),
-      getAdapterInstallCommand: vi.fn().mockReturnValue('echo "Mock adapter built-in"'),
-      
-      // Debug configuration
-      transformLaunchConfig: vi.fn().mockImplementation(config => config),
-      getDefaultLaunchConfig: vi.fn().mockReturnValue({}),
-      
-      // Path translation
-      translateScriptPath: vi.fn().mockImplementation(path => path),
-      translateBreakpointPath: vi.fn().mockImplementation(path => path),
-      
-      // DAP protocol operations
-      sendDapRequest: vi.fn().mockResolvedValue({}),
-      handleDapEvent: vi.fn(),
-      handleDapResponse: vi.fn(),
-      
-      // Connection management
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn().mockResolvedValue(undefined),
-      isConnected: vi.fn().mockReturnValue(true),
-      
-      // Error handling
-      getInstallationInstructions: vi.fn().mockReturnValue('Mock adapter needs no installation'),
-      getMissingExecutableError: vi.fn().mockReturnValue('Mock executable not found'),
-      translateErrorMessage: vi.fn().mockImplementation(err => err.message),
-      
-      // Feature support
-      supportsFeature: vi.fn().mockReturnValue(true),
-      getFeatureRequirements: vi.fn().mockReturnValue([]),
-      getCapabilities: vi.fn().mockReturnValue({}),
-      
-      // EventEmitter methods
-      on: vi.fn(),
-      off: vi.fn(),
-      emit: vi.fn(),
-      removeListener: vi.fn(),
-      once: vi.fn(),
-      removeAllListeners: vi.fn(),
-      setMaxListeners: vi.fn(),
-      getMaxListeners: vi.fn().mockReturnValue(10),
-      listeners: vi.fn().mockReturnValue([]),
-      rawListeners: vi.fn().mockReturnValue([]),
-      listenerCount: vi.fn().mockReturnValue(0),
-      prependListener: vi.fn(),
-      prependOnceListener: vi.fn(),
-      eventNames: vi.fn().mockReturnValue([]),
-      addListener: vi.fn()
-    } as unknown as IDebugAdapter;
+    return new FakeDebugAdapter({ name: 'Mock Debug Adapter' });
   }
 
   beforeEach(() => {

--- a/tests/test-utils/fakes/fake-debug-adapter.ts
+++ b/tests/test-utils/fakes/fake-debug-adapter.ts
@@ -181,6 +181,9 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
 
   /**
    * Opt into the attach members as a set, the way a real attach-capable adapter declares them.
+   *
+   * The builder wins: it replaces any same-member constructor override, so pass attach
+   * behaviour through `options` rather than through the constructor.
    */
   withAttachSupport(options: FakeAttachSupportOptions = {}): this {
     this.supportsAttach = vi.fn<Impl<'supportsAttach'>>(() => true);
@@ -204,6 +207,8 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
   /**
    * Opt into `createLaunchBarrier`, returning `barrier` for every request. Pass `undefined`
    * to define the member but decline the barrier — the "adapter offers none" branch.
+   *
+   * The builder wins: it replaces any `createLaunchBarrier` passed to the constructor.
    */
   withLaunchBarrier(barrier: AdapterLaunchBarrier | undefined): this {
     this.createLaunchBarrier = vi.fn<Impl<'createLaunchBarrier'>>(() => barrier);
@@ -222,6 +227,12 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
   /**
    * Install the constructor's method overrides.
    *
+   * Each override REPLACES the member with a fresh `vi.fn(impl)` rather than calling
+   * `mockImplementation` on the default one. That matters after a reset: vitest's `mockReset`
+   * restores the implementation a mock was *constructed* with, so overriding in place would
+   * make `vi.resetAllMocks()` silently revert the test's behaviour to the fake's production
+   * default. Constructing with the override makes a reset restore the override.
+   *
    * The keys are only known dynamically here, so the per-key correlation between `K` and
    * `Impl<K>` — enforced on `FakeDebugAdapterOverrides` at the call site — cannot be carried
    * through `Object.keys`. The two casts below are that erasure and nothing more.
@@ -231,16 +242,7 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
       if (key === 'language' || key === 'name' || key === 'supportedAttachKeys') continue;
 
       const impl = overrides[key] as (...args: never[]) => unknown;
-      const current: unknown = this[key];
-
-      if (typeof current === 'function' && 'mockImplementation' in current) {
-        // Required member: keep the existing mock identity so a caller that captured it
-        // before overriding still observes the calls.
-        (current as Mock).mockImplementation(impl);
-      } else {
-        // Optional member being opted into: create the mock now.
-        (this as Record<string, unknown>)[key] = vi.fn(impl);
-      }
+      (this as Record<string, unknown>)[key] = vi.fn(impl);
     }
   }
 }

--- a/tests/test-utils/fakes/fake-debug-adapter.ts
+++ b/tests/test-utils/fakes/fake-debug-adapter.ts
@@ -1,0 +1,246 @@
+/**
+ * Compile-checked fake for `IDebugAdapter`.
+ *
+ * The suite used to hand-roll ~40 object literals shaped like a debug adapter and force
+ * them through `as unknown as IDebugAdapter`. That cast silenced every divergence, so the
+ * literals drifted: a *sync* `transformLaunchConfig` (the interface returns a Promise), two
+ * members (`translateScriptPath` / `translateBreakpointPath`) that no longer exist, and
+ * fifteen stubbed EventEmitter methods that never emitted anything.
+ *
+ * This class is the single conformant double, following `MockProxyManager`'s precedent of a
+ * class that `implements` the real interface — so the compiler, not review, catches drift.
+ *
+ * Two rules make it useful beyond "it compiles":
+ *
+ * - Every REQUIRED member is a `vi.fn` with a production-shaped default, so a test only
+ *   states the behaviour it actually cares about and can still assert on the rest.
+ * - The seven OPTIONAL members are ABSENT unless opted in via `withAttachSupport()` /
+ *   `withLaunchBarrier()`. Production code guards them (`adapter.supportsAttach?.()`), and a
+ *   double that always defines them would only ever exercise one side of that branch.
+ */
+import { EventEmitter } from 'events';
+import { vi, type Mock } from 'vitest';
+import type { DebugProtocol } from '@vscode/debugprotocol';
+import {
+  AdapterState,
+  DebugLanguage,
+  type AdapterCapabilities,
+  type AdapterCommand,
+  type AdapterConfig,
+  type AdapterLaunchBarrier,
+  type DependencyInfo,
+  type FeatureRequirement,
+  type GenericAttachConfig,
+  type GenericLaunchConfig,
+  type IDebugAdapter,
+  type LanguageSpecificAttachConfig,
+  type LanguageSpecificLaunchConfig,
+  type ValidationResult
+} from '@debugmcp/shared';
+
+/**
+ * The behavioural surface of `IDebugAdapter`: everything except the EventEmitter machinery
+ * (supplied by the base class) and the three data members, which are plain values rather
+ * than implementations.
+ */
+type AdapterMethods = Exclude<
+  keyof IDebugAdapter,
+  keyof EventEmitter | 'language' | 'name' | 'supportedAttachKeys'
+>;
+
+/** The implementation type of one adapter member, with the optionality stripped. */
+type Impl<K extends AdapterMethods> = NonNullable<IDebugAdapter[K]>;
+
+/**
+ * `sendDapRequest` is the one generic member (`<T extends DebugProtocol.Response>`), and
+ * vitest's `Mock<T>` collapses a generic signature to a single instantiation — so a bare mock
+ * does not satisfy `implements IDebugAdapter`. Intersecting the mock with the interface's own
+ * signature restores the generic call; the cast at the field is that restoration and nothing
+ * more. Callers still get the full mock API (`mockResolvedValue`, call assertions).
+ */
+type DapRequestMock =
+  Mock<(command: string, args?: unknown) => Promise<DebugProtocol.Response>> &
+  IDebugAdapter['sendDapRequest'];
+
+/**
+ * Constructor overrides. Each entry is an *implementation* typed against the real interface —
+ * not a bare `vi.fn()` — so a wrong argument list or return type is a compile error at the
+ * call site rather than a silent no-op at runtime.
+ */
+export type FakeDebugAdapterOverrides =
+  Partial<Pick<IDebugAdapter, 'language' | 'name' | 'supportedAttachKeys'>> &
+  { [K in AdapterMethods]?: Impl<K> };
+
+/** Options for {@link FakeDebugAdapter.withAttachSupport}. */
+export interface FakeAttachSupportOptions {
+  /** Value returned by `usesDirectConnectForAttach()` (default false — spawn-mode attach). */
+  directConnect?: boolean;
+  /** Value returned by `supportsDetach()` (default true). */
+  detach?: boolean;
+  /** Implementation for `transformAttachConfig` (default: pass the config through). */
+  transform?: Impl<'transformAttachConfig'>;
+  /** Value exposed as the readonly `supportedAttachKeys` list. */
+  supportedAttachKeys?: readonly string[];
+}
+
+export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
+  readonly language: DebugLanguage;
+  readonly name: string;
+
+  // ===== Lifecycle =====
+  initialize = vi.fn<Impl<'initialize'>>(async () => {});
+  dispose = vi.fn<Impl<'dispose'>>(async () => {});
+
+  // ===== State =====
+  getState = vi.fn<Impl<'getState'>>(() => AdapterState.READY);
+  isReady = vi.fn<Impl<'isReady'>>(() => true);
+  getCurrentThreadId = vi.fn<Impl<'getCurrentThreadId'>>(() => 1);
+
+  // ===== Environment validation =====
+  validateEnvironment = vi.fn<Impl<'validateEnvironment'>>(
+    async (): Promise<ValidationResult> => ({ valid: true, errors: [], warnings: [] })
+  );
+  getRequiredDependencies = vi.fn<Impl<'getRequiredDependencies'>>((): DependencyInfo[] => []);
+
+  // ===== Executable management =====
+  resolveExecutablePath = vi.fn<Impl<'resolveExecutablePath'>>(
+    async (preferredPath?: string) => preferredPath ?? 'fake-executable'
+  );
+  getDefaultExecutableName = vi.fn<Impl<'getDefaultExecutableName'>>(() => 'fake');
+  getExecutableSearchPaths = vi.fn<Impl<'getExecutableSearchPaths'>>((): string[] => []);
+
+  // ===== Adapter configuration =====
+  buildAdapterCommand = vi.fn<Impl<'buildAdapterCommand'>>(
+    (config: AdapterConfig): AdapterCommand => ({
+      command: config.executablePath || 'node',
+      args: ['fake-adapter.js', '--port', String(config.adapterPort)],
+      env: {}
+    })
+  );
+  getAdapterModuleName = vi.fn<Impl<'getAdapterModuleName'>>(() => 'fake-adapter');
+  getAdapterInstallCommand = vi.fn<Impl<'getAdapterInstallCommand'>>(
+    () => 'echo "fake adapter is built in"'
+  );
+
+  // ===== Debug configuration =====
+  // ASYNC, per the interface — the literals this replaces returned the config synchronously.
+  transformLaunchConfig = vi.fn<Impl<'transformLaunchConfig'>>(
+    async (config: GenericLaunchConfig): Promise<LanguageSpecificLaunchConfig> => ({ ...config })
+  );
+  getDefaultLaunchConfig = vi.fn<Impl<'getDefaultLaunchConfig'>>(
+    (): Partial<GenericLaunchConfig> => ({})
+  );
+
+  // ===== DAP protocol operations =====
+  sendDapRequest = vi.fn(
+    async (): Promise<DebugProtocol.Response> => ({}) as DebugProtocol.Response
+  ) as DapRequestMock;
+  handleDapEvent = vi.fn<Impl<'handleDapEvent'>>(() => {});
+  handleDapResponse = vi.fn<Impl<'handleDapResponse'>>(() => {});
+
+  // ===== Connection management =====
+  connect = vi.fn<Impl<'connect'>>(async () => {});
+  disconnect = vi.fn<Impl<'disconnect'>>(async () => {});
+  isConnected = vi.fn<Impl<'isConnected'>>(() => true);
+
+  // ===== Error handling =====
+  getInstallationInstructions = vi.fn<Impl<'getInstallationInstructions'>>(
+    () => 'The fake adapter needs no installation'
+  );
+  getMissingExecutableError = vi.fn<Impl<'getMissingExecutableError'>>(
+    () => 'Fake executable not found'
+  );
+  translateErrorMessage = vi.fn<Impl<'translateErrorMessage'>>((error: Error) => error.message);
+
+  // ===== Feature support =====
+  supportsFeature = vi.fn<Impl<'supportsFeature'>>(() => true);
+  getFeatureRequirements = vi.fn<Impl<'getFeatureRequirements'>>((): FeatureRequirement[] => []);
+  getCapabilities = vi.fn<Impl<'getCapabilities'>>((): AdapterCapabilities => ({}));
+
+  // ===== Optional members =====
+  // Deliberately left undefined: production code reaches them through optional calls, and a
+  // double that always defines them can only ever exercise the defined branch.
+  createLaunchBarrier?: Mock<Impl<'createLaunchBarrier'>>;
+  supportsAttach?: Mock<Impl<'supportsAttach'>>;
+  supportsDetach?: Mock<Impl<'supportsDetach'>>;
+  usesDirectConnectForAttach?: Mock<Impl<'usesDirectConnectForAttach'>>;
+  transformAttachConfig?: Mock<Impl<'transformAttachConfig'>>;
+  getDefaultAttachConfig?: Mock<Impl<'getDefaultAttachConfig'>>;
+  /** Interface-readonly; mutable here so `withAttachSupport()` can set it. */
+  supportedAttachKeys?: readonly string[];
+
+  constructor(overrides: FakeDebugAdapterOverrides = {}) {
+    super();
+    this.language = overrides.language ?? DebugLanguage.MOCK;
+    this.name = overrides.name ?? `${this.language} Debug Adapter (fake)`;
+    if (overrides.supportedAttachKeys !== undefined) {
+      this.supportedAttachKeys = overrides.supportedAttachKeys;
+    }
+    this.applyOverrides(overrides);
+  }
+
+  /**
+   * Opt into the attach members as a set, the way a real attach-capable adapter declares them.
+   */
+  withAttachSupport(options: FakeAttachSupportOptions = {}): this {
+    this.supportsAttach = vi.fn<Impl<'supportsAttach'>>(() => true);
+    this.supportsDetach = vi.fn<Impl<'supportsDetach'>>(() => options.detach ?? true);
+    this.usesDirectConnectForAttach = vi.fn<Impl<'usesDirectConnectForAttach'>>(
+      () => options.directConnect ?? false
+    );
+    this.transformAttachConfig = vi.fn<Impl<'transformAttachConfig'>>(
+      options.transform ??
+        ((config: GenericAttachConfig): LanguageSpecificAttachConfig => ({ ...config }))
+    );
+    this.getDefaultAttachConfig = vi.fn<Impl<'getDefaultAttachConfig'>>(
+      (): Partial<GenericAttachConfig> => ({})
+    );
+    if (options.supportedAttachKeys !== undefined) {
+      this.supportedAttachKeys = options.supportedAttachKeys;
+    }
+    return this;
+  }
+
+  /**
+   * Opt into `createLaunchBarrier`, returning `barrier` for every request. Pass `undefined`
+   * to define the member but decline the barrier — the "adapter offers none" branch.
+   */
+  withLaunchBarrier(barrier: AdapterLaunchBarrier | undefined): this {
+    this.createLaunchBarrier = vi.fn<Impl<'createLaunchBarrier'>>(() => barrier);
+    return this;
+  }
+
+  /**
+   * Attach adapter-specific members that are not on `IDebugAdapter` but that production code
+   * duck-types for (e.g. the C/C++ adapter's `consumeLastToolchainValidation`), keeping them
+   * visible to the compiler at the call site instead of hiding them behind a cast.
+   */
+  withExtras<E extends object>(extras: E): this & E {
+    return Object.assign(this, extras);
+  }
+
+  /**
+   * Install the constructor's method overrides.
+   *
+   * The keys are only known dynamically here, so the per-key correlation between `K` and
+   * `Impl<K>` — enforced on `FakeDebugAdapterOverrides` at the call site — cannot be carried
+   * through `Object.keys`. The two casts below are that erasure and nothing more.
+   */
+  private applyOverrides(overrides: FakeDebugAdapterOverrides): void {
+    for (const key of Object.keys(overrides) as Array<keyof FakeDebugAdapterOverrides>) {
+      if (key === 'language' || key === 'name' || key === 'supportedAttachKeys') continue;
+
+      const impl = overrides[key] as (...args: never[]) => unknown;
+      const current: unknown = this[key];
+
+      if (typeof current === 'function' && 'mockImplementation' in current) {
+        // Required member: keep the existing mock identity so a caller that captured it
+        // before overriding still observes the calls.
+        (current as Mock).mockImplementation(impl);
+      } else {
+        // Optional member being opted into: create the mock now.
+        (this as Record<string, unknown>)[key] = vi.fn(impl);
+      }
+    }
+  }
+}

--- a/tests/test-utils/fakes/fake-debug-adapter.ts
+++ b/tests/test-utils/fakes/fake-debug-adapter.ts
@@ -52,17 +52,6 @@ type AdapterMethods = Exclude<
 type Impl<K extends AdapterMethods> = NonNullable<IDebugAdapter[K]>;
 
 /**
- * `sendDapRequest` is the one generic member (`<T extends DebugProtocol.Response>`), and
- * vitest's `Mock<T>` collapses a generic signature to a single instantiation — so a bare mock
- * does not satisfy `implements IDebugAdapter`. Intersecting the mock with the interface's own
- * signature restores the generic call; the cast at the field is that restoration and nothing
- * more. Callers still get the full mock API (`mockResolvedValue`, call assertions).
- */
-type DapRequestMock =
-  Mock<(command: string, args?: unknown) => Promise<DebugProtocol.Response>> &
-  IDebugAdapter['sendDapRequest'];
-
-/**
  * Constructor overrides. Each entry is an *implementation* typed against the real interface —
  * not a bare `vi.fn()` — so a wrong argument list or return type is a compile error at the
  * call site rather than a silent no-op at runtime.
@@ -103,8 +92,11 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
   getRequiredDependencies = vi.fn<Impl<'getRequiredDependencies'>>((): DependencyInfo[] => []);
 
   // ===== Executable management =====
+  // `||`, not `??`: an empty preferred path is not a path. Real adapters fall back to a PATH
+  // search on '', and the proxy worker's init-payload validation rejects an empty
+  // executablePath — so returning '' verbatim would be a fake of something that cannot happen.
   resolveExecutablePath = vi.fn<Impl<'resolveExecutablePath'>>(
-    async (preferredPath?: string) => preferredPath ?? 'fake-executable'
+    async (preferredPath?: string) => preferredPath || 'fake-executable'
   );
   getDefaultExecutableName = vi.fn<Impl<'getDefaultExecutableName'>>(() => 'fake');
   getExecutableSearchPaths = vi.fn<Impl<'getExecutableSearchPaths'>>((): string[] => []);
@@ -132,9 +124,17 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
   );
 
   // ===== DAP protocol operations =====
-  sendDapRequest = vi.fn(
-    async (): Promise<DebugProtocol.Response> => ({}) as DebugProtocol.Response
-  ) as DapRequestMock;
+  // A plain method, not a mock: `sendDapRequest` is the interface's only generic member, and
+  // vitest's `Mock<T>` collapses a generic signature to one instantiation — making it a mock
+  // costs an intersection type and a cast. Nothing needs it: ProxyManager never calls
+  // `adapter.sendDapRequest`, and the DAP-request assertions in these suites are all on
+  // ProxyManager. Reach for `vi.spyOn(adapter, 'sendDapRequest')` if that ever changes.
+  async sendDapRequest<T extends DebugProtocol.Response>(
+    _command: string,
+    _args?: unknown
+  ): Promise<T> {
+    return {} as T;
+  }
   handleDapEvent = vi.fn<Impl<'handleDapEvent'>>(() => {});
   handleDapResponse = vi.fn<Impl<'handleDapResponse'>>(() => {});
 
@@ -158,16 +158,23 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
   getCapabilities = vi.fn<Impl<'getCapabilities'>>((): AdapterCapabilities => ({}));
 
   // ===== Optional members =====
-  // Deliberately left undefined: production code reaches them through optional calls, and a
-  // double that always defines them can only ever exercise the defined branch.
-  createLaunchBarrier?: Mock<Impl<'createLaunchBarrier'>>;
-  supportsAttach?: Mock<Impl<'supportsAttach'>>;
-  supportsDetach?: Mock<Impl<'supportsDetach'>>;
-  usesDirectConnectForAttach?: Mock<Impl<'usesDirectConnectForAttach'>>;
-  transformAttachConfig?: Mock<Impl<'transformAttachConfig'>>;
-  getDefaultAttachConfig?: Mock<Impl<'getDefaultAttachConfig'>>;
+  // Genuinely ABSENT until opted in: production code reaches them through optional calls
+  // (`adapter.supportsAttach?.()`), and a double that always defines them can only ever
+  // exercise the defined branch.
+  //
+  // `declare` is load-bearing. Under ES2022 class-field *define* semantics an uninitialised
+  // field is emitted as an own property set to undefined — which would make
+  // `'supportsAttach' in adapter` true and list every optional member in `Object.keys`, the
+  // opposite of what this block promises. `declare` emits no field at all, so the property
+  // exists only once a builder or an override assigns it.
+  declare createLaunchBarrier?: Mock<Impl<'createLaunchBarrier'>>;
+  declare supportsAttach?: Mock<Impl<'supportsAttach'>>;
+  declare supportsDetach?: Mock<Impl<'supportsDetach'>>;
+  declare usesDirectConnectForAttach?: Mock<Impl<'usesDirectConnectForAttach'>>;
+  declare transformAttachConfig?: Mock<Impl<'transformAttachConfig'>>;
+  declare getDefaultAttachConfig?: Mock<Impl<'getDefaultAttachConfig'>>;
   /** Interface-readonly; mutable here so `withAttachSupport()` can set it. */
-  supportedAttachKeys?: readonly string[];
+  declare supportedAttachKeys?: readonly string[];
 
   constructor(overrides: FakeDebugAdapterOverrides = {}) {
     super();
@@ -233,6 +240,13 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
    * make `vi.resetAllMocks()` silently revert the test's behaviour to the fake's production
    * default. Constructing with the override makes a reset restore the override.
    *
+   * An explicitly-undefined value is skipped rather than installed. `Object.keys` cannot tell
+   * `{ transformAttachConfig: undefined }` from an omitted key, and `vi.fn(undefined)` is a
+   * perfectly truthy mock returning undefined — so a conditional override
+   * (`{ transformAttachConfig: cond ? fn : undefined }`) would turn an optional member that
+   * must stay absent into one the session layer's
+   * `supportsAttach() && transformAttachConfig` chain happily calls.
+   *
    * The keys are only known dynamically here, so the per-key correlation between `K` and
    * `Impl<K>` — enforced on `FakeDebugAdapterOverrides` at the call site — cannot be carried
    * through `Object.keys`. The two casts below are that erasure and nothing more.
@@ -241,7 +255,9 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
     for (const key of Object.keys(overrides) as Array<keyof FakeDebugAdapterOverrides>) {
       if (key === 'language' || key === 'name' || key === 'supportedAttachKeys') continue;
 
-      const impl = overrides[key] as (...args: never[]) => unknown;
+      const impl = overrides[key] as ((...args: never[]) => unknown) | undefined;
+      if (impl === undefined) continue;
+
       (this as Record<string, unknown>)[key] = vi.fn(impl);
     }
   }

--- a/tests/test-utils/mocks/mock-adapter-registry.ts
+++ b/tests/test-utils/mocks/mock-adapter-registry.ts
@@ -62,14 +62,26 @@ export function createMockAdapterRegistry(
     // IDebugAdapter, so the compiler now catches the drift this block used to carry
     // (a sync transformLaunchConfig, the long-removed translateScriptPath /
     // translateBreakpointPath, and 15 inert EventEmitter stubs in place of a real emitter).
-    create: vi.fn<IAdapterRegistry['create']>(
-      async (language, config) =>
-        options.createAdapter?.(language, config) ??
-        new FakeDebugAdapter({
-          language: language as DebugLanguage,
-          name: `${language} Debug Adapter`
-        })
-    ),
+    create: vi.fn<IAdapterRegistry['create']>(async (language, config) => {
+      // Branch on the option, not on the result: `createAdapter` returns a Promise, which is
+      // never nullish, so a `??` fallback here would be dead code the moment the option is
+      // supplied. Awaiting it also lets a stub that resolves nothing fail here, with the
+      // language named, instead of as a TypeError deep inside startProxyManager.
+      if (options.createAdapter) {
+        const adapter = await options.createAdapter(language, config);
+        if (!adapter) {
+          throw new Error(
+            `createMockAdapterRegistry: createAdapter returned no adapter for ${language}`
+          );
+        }
+        return adapter;
+      }
+
+      return new FakeDebugAdapter({
+        language: language as DebugLanguage,
+        name: `${language} Debug Adapter`
+      });
+    }),
 
     register: vi.fn().mockResolvedValue(undefined),
 

--- a/tests/test-utils/mocks/mock-adapter-registry.ts
+++ b/tests/test-utils/mocks/mock-adapter-registry.ts
@@ -6,11 +6,23 @@
 import { vi } from 'vitest';
 import { IAdapterRegistry, AdapterInfo } from '@debugmcp/shared';
 import { DebugLanguage } from '@debugmcp/shared';
+import { FakeDebugAdapter } from '../fakes/fake-debug-adapter.js';
+
+/** Options for {@link createMockAdapterRegistry}. */
+export interface MockAdapterRegistryOptions {
+  /**
+   * Replace what `create()` hands back. Defaults to a {@link FakeDebugAdapter} for the
+   * requested language.
+   */
+  createAdapter?: IAdapterRegistry['create'];
+}
 
 /**
  * Create a standard mock adapter registry with default behavior
  */
-export function createMockAdapterRegistry(): IAdapterRegistry {
+export function createMockAdapterRegistry(
+  options: MockAdapterRegistryOptions = {}
+): IAdapterRegistry {
   const supportedLanguages = ['python', 'mock'];
   
   // Create realistic adapter info
@@ -46,83 +58,19 @@ export function createMockAdapterRegistry(): IAdapterRegistry {
       supportedLanguages.includes(lang)
     ),
     
-    create: vi.fn().mockImplementation(async (language: string, _config?: unknown) => ({
-      language: language as DebugLanguage,
-      name: `${language} Debug Adapter`,
-      
-      // IDebugAdapter lifecycle methods
-      initialize: vi.fn().mockResolvedValue(undefined),
-      dispose: vi.fn().mockResolvedValue(undefined),
-      
-      // State management
-      getState: vi.fn().mockReturnValue('ready'),
-      isReady: vi.fn().mockReturnValue(true),
-      getCurrentThreadId: vi.fn().mockReturnValue(1),
-      
-      // Environment validation
-      validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-      getRequiredDependencies: vi.fn().mockReturnValue([]),
-      
-      // Executable management
-      resolveExecutablePath: vi.fn().mockResolvedValue('mock-executable'),
-      getDefaultExecutableName: vi.fn().mockReturnValue('mock'),
-      getExecutableSearchPaths: vi.fn().mockReturnValue([]),
-      
-      // Adapter configuration - THIS IS THE CRITICAL METHOD
-      buildAdapterCommand: vi.fn().mockImplementation((config) => ({
-        command: config.executablePath || 'node',
-        args: ['mock-adapter.js', '--port', String(config.adapterPort)],
-        env: {}
-      })),
-      getAdapterModuleName: vi.fn().mockReturnValue('mock-adapter'),
-      getAdapterInstallCommand: vi.fn().mockReturnValue('echo "Mock adapter built-in"'),
-      
-      // Debug configuration
-      transformLaunchConfig: vi.fn().mockImplementation(config => config),
-      getDefaultLaunchConfig: vi.fn().mockReturnValue({}),
-      
-      // Path translation
-      translateScriptPath: vi.fn().mockImplementation(path => path),
-      translateBreakpointPath: vi.fn().mockImplementation(path => path),
-      
-      // DAP protocol operations
-      sendDapRequest: vi.fn().mockResolvedValue({}),
-      handleDapEvent: vi.fn(),
-      handleDapResponse: vi.fn(),
-      
-      // Connection management
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn().mockResolvedValue(undefined),
-      isConnected: vi.fn().mockReturnValue(true),
-      
-      // Error handling
-      getInstallationInstructions: vi.fn().mockReturnValue('Mock adapter needs no installation'),
-      getMissingExecutableError: vi.fn().mockReturnValue('Mock executable not found'),
-      translateErrorMessage: vi.fn().mockImplementation(err => err.message),
-      
-      // Feature support
-      supportsFeature: vi.fn().mockReturnValue(true),
-      getFeatureRequirements: vi.fn().mockReturnValue([]),
-      getCapabilities: vi.fn().mockReturnValue({}),
-      
-      // EventEmitter methods
-      on: vi.fn(),
-      off: vi.fn(),
-      emit: vi.fn(),
-      removeListener: vi.fn(),
-      once: vi.fn(),
-      removeAllListeners: vi.fn(),
-      setMaxListeners: vi.fn(),
-      getMaxListeners: vi.fn().mockReturnValue(10),
-      listeners: vi.fn().mockReturnValue([]),
-      rawListeners: vi.fn().mockReturnValue([]),
-      listenerCount: vi.fn().mockReturnValue(0),
-      prependListener: vi.fn(),
-      prependOnceListener: vi.fn(),
-      eventNames: vi.fn().mockReturnValue([]),
-      addListener: vi.fn()
-    })),
-    
+    // One conformant fake, not a re-typed literal: FakeDebugAdapter implements
+    // IDebugAdapter, so the compiler now catches the drift this block used to carry
+    // (a sync transformLaunchConfig, the long-removed translateScriptPath /
+    // translateBreakpointPath, and 15 inert EventEmitter stubs in place of a real emitter).
+    create: vi.fn<IAdapterRegistry['create']>(
+      async (language, config) =>
+        options.createAdapter?.(language, config) ??
+        new FakeDebugAdapter({
+          language: language as DebugLanguage,
+          name: `${language} Debug Adapter`
+        })
+    ),
+
     register: vi.fn().mockResolvedValue(undefined),
 
     unregister: vi.fn().mockReturnValue(true),

--- a/tests/unit/proxy/proxy-manager-message-handling.test.ts
+++ b/tests/unit/proxy/proxy-manager-message-handling.test.ts
@@ -933,7 +933,6 @@ describe('ProxyManager Message Handling', () => {
         resolveExecutablePath: async () => '/usr/bin/node',
         getAdapterModuleName: () => 'js-debug'
       }).withLaunchBarrier(barrier);
-      const createLaunchBarrier = adapter.createLaunchBarrier;
 
       const proxyManager = new ProxyManager(
         adapter,
@@ -952,7 +951,7 @@ describe('ProxyManager Message Handling', () => {
 
       const response = await proxyManager.sendDapRequest('launch', { foo: 'bar' });
 
-      expect(createLaunchBarrier).toHaveBeenCalledWith('launch', { foo: 'bar' });
+      expect(adapter.createLaunchBarrier).toHaveBeenCalledWith('launch', { foo: 'bar' });
       expect(barrier.onRequestSent).toHaveBeenCalled();
       expect(barrier.waitUntilReady).toHaveBeenCalled();
       expect(sendCommand).toHaveBeenCalledWith(

--- a/tests/unit/proxy/proxy-manager-message-handling.test.ts
+++ b/tests/unit/proxy/proxy-manager-message-handling.test.ts
@@ -12,7 +12,8 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { TestProxyManager } from '../test-utils/test-proxy-manager.js';
 import { ProxyConfig } from '../../../src/proxy/proxy-config.js';
-import { DebugLanguage, type IDebugAdapter, type IProxyProcess } from '@debugmcp/shared';
+import { DebugLanguage, type IProxyProcess } from '@debugmcp/shared';
+import { FakeDebugAdapter } from '../../test-utils/fakes/fake-debug-adapter.js';
 import { createMockLogger, createMockFileSystem } from '../test-utils/mock-factories.js';
 import { ProxyManager } from '../../../src/proxy/proxy-manager.js';
 import { createInitialState } from '../../../src/dap-core/index.js';
@@ -880,14 +881,14 @@ describe('ProxyManager Message Handling', () => {
     });
 
     it('throws when adapter validation fails during spawn preparation', async () => {
-      const adapter = {
+      const adapter = new FakeDebugAdapter({
         language: DebugLanguage.JAVASCRIPT,
-        validateEnvironment: vi.fn().mockResolvedValue({
+        validateEnvironment: async () => ({
           valid: false,
-          errors: [{ message: 'bad env' }],
+          errors: [{ code: 'ENV_INVALID', message: 'bad env', recoverable: false }],
           warnings: []
         })
-      } as unknown as IDebugAdapter;
+      });
 
       const logger = createMockLogger();
       const fileSystem = createMockFileSystem();
@@ -927,15 +928,12 @@ describe('ProxyManager Message Handling', () => {
         waitUntilReady: vi.fn().mockResolvedValue(undefined),
         dispose: vi.fn()
       };
-      const createLaunchBarrier = vi.fn().mockReturnValue(barrier);
-
-      const adapter = {
+      const adapter = new FakeDebugAdapter({
         language: DebugLanguage.JAVASCRIPT,
-        validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-        resolveExecutablePath: vi.fn().mockResolvedValue('/usr/bin/node'),
-        getAdapterModuleName: () => 'js-debug',
-        createLaunchBarrier
-      } as unknown as IDebugAdapter;
+        resolveExecutablePath: async () => '/usr/bin/node',
+        getAdapterModuleName: () => 'js-debug'
+      }).withLaunchBarrier(barrier);
+      const createLaunchBarrier = adapter.createLaunchBarrier;
 
       const proxyManager = new ProxyManager(
         adapter,
@@ -981,12 +979,10 @@ describe('ProxyManager Message Handling', () => {
         dispose: vi.fn()
       };
 
-      const adapter = {
+      const adapter = new FakeDebugAdapter({
         language: DebugLanguage.JAVASCRIPT,
-        validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-        resolveExecutablePath: vi.fn().mockResolvedValue('/usr/bin/node'),
-        createLaunchBarrier: vi.fn().mockReturnValue(barrier)
-      } as unknown as IDebugAdapter;
+        resolveExecutablePath: async () => '/usr/bin/node'
+      }).withLaunchBarrier(barrier);
 
       const proxyManager = new ProxyManager(
         adapter,
@@ -1032,12 +1028,10 @@ describe('ProxyManager Message Handling', () => {
         dispose: vi.fn()
       };
 
-      const adapter = {
+      const adapter = new FakeDebugAdapter({
         language: DebugLanguage.JAVASCRIPT,
-        validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-        resolveExecutablePath: vi.fn().mockResolvedValue('/usr/bin/node'),
-        createLaunchBarrier: vi.fn().mockReturnValue(barrier)
-      } as unknown as IDebugAdapter;
+        resolveExecutablePath: async () => '/usr/bin/node'
+      }).withLaunchBarrier(barrier);
 
       const proxyManager = new ProxyManager(
         adapter,
@@ -1094,12 +1088,10 @@ describe('ProxyManager Message Handling', () => {
         dispose: vi.fn()
       };
 
-      const adapter = {
+      const adapter = new FakeDebugAdapter({
         language: DebugLanguage.JAVASCRIPT,
-        validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-        resolveExecutablePath: vi.fn().mockResolvedValue('/usr/bin/node'),
-        createLaunchBarrier: vi.fn().mockReturnValue(barrier)
-      } as unknown as IDebugAdapter;
+        resolveExecutablePath: async () => '/usr/bin/node'
+      }).withLaunchBarrier(barrier);
 
       const proxyManager = new ProxyManager(
         adapter,

--- a/tests/unit/proxy/proxy-manager.branch-coverage.test.ts
+++ b/tests/unit/proxy/proxy-manager.branch-coverage.test.ts
@@ -5,13 +5,13 @@ import { createInitialState } from '../../../src/dap-core/index.js';
 import * as dapCore from '../../../src/dap-core/index.js';
 import {
   DebugLanguage,
-  type IDebugAdapter,
   type IFileSystem,
   type ILogger,
   type IProxyProcess,
   type IProxyProcessLauncher,
   type AdapterLaunchBarrier
 } from '@debugmcp/shared';
+import { FakeDebugAdapter } from '../../test-utils/fakes/fake-debug-adapter.js';
 
 class StubProxyProcess extends EventEmitter implements IProxyProcess {
   pid = 9999;
@@ -245,12 +245,9 @@ describe('ProxyManager branch coverage scenarios', () => {
       waitUntilReady: vi.fn(),
       dispose: vi.fn()
     };
-    const adapter: IDebugAdapter = {
-      language: DebugLanguage.JAVASCRIPT,
-      validateEnvironment: vi.fn(),
-      resolveExecutablePath: vi.fn(),
-      createLaunchBarrier: vi.fn().mockReturnValue(barrier)
-    } as unknown as IDebugAdapter;
+    const adapter = new FakeDebugAdapter({
+      language: DebugLanguage.JAVASCRIPT
+    }).withLaunchBarrier(barrier);
 
     manager = new ProxyManager(adapter, launcher, fileSystem, logger);
     proxyProcess = new StubProxyProcess();
@@ -300,12 +297,9 @@ describe('ProxyManager branch coverage scenarios', () => {
       waitUntilReady: vi.fn(),
       dispose: vi.fn()
     };
-    const adapter: IDebugAdapter = {
-      language: DebugLanguage.JAVASCRIPT,
-      validateEnvironment: vi.fn(),
-      resolveExecutablePath: vi.fn(),
-      createLaunchBarrier: vi.fn().mockReturnValue(barrier)
-    } as unknown as IDebugAdapter;
+    const adapter = new FakeDebugAdapter({
+      language: DebugLanguage.JAVASCRIPT
+    }).withLaunchBarrier(barrier);
 
     manager = new ProxyManager(adapter, launcher, fileSystem, logger);
     proxyProcess = new StubProxyProcess();

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -8,7 +8,8 @@ import {
 } from '../../../src/proxy/proxy-manager.js';
 import { createInitialState } from '../../../src/dap-core/index.js';
 import type { ProxyConfig } from '../../../src/proxy/proxy-config.js';
-import { DebugLanguage, type IProxyProcess, type IProxyProcessLauncher, type IFileSystem, type ILogger, type IDebugAdapter, type AdapterLaunchBarrier } from '@debugmcp/shared';
+import { DebugLanguage, type IProxyProcess, type IProxyProcessLauncher, type IFileSystem, type ILogger, type AdapterLaunchBarrier } from '@debugmcp/shared';
+import { FakeDebugAdapter } from '../../test-utils/fakes/fake-debug-adapter.js';
 
 class FakeProxyProcess extends EventEmitter implements IProxyProcess {
   pid = 4242;
@@ -302,15 +303,14 @@ describe('ProxyManager.start', () => {
   });
 
   it('fails to start when adapter environment validation fails', async () => {
-    const adapter = {
+    const adapter = new FakeDebugAdapter({
       language: DebugLanguage.PYTHON,
-      validateEnvironment: vi.fn().mockResolvedValue({
+      validateEnvironment: async () => ({
         valid: false,
-        errors: [{ message: 'Missing Python runtime' }],
+        errors: [{ code: 'PYTHON_MISSING', message: 'Missing Python runtime', recoverable: false }],
         warnings: []
-      }),
-      resolveExecutablePath: vi.fn()
-    } as unknown as IDebugAdapter;
+      })
+    });
 
     proxyManager = new ProxyManager(
       adapter,
@@ -331,15 +331,12 @@ describe('ProxyManager.start', () => {
   });
 
   it('fails to start when executable resolution throws', async () => {
-    const adapter = {
+    const adapter = new FakeDebugAdapter({
       language: DebugLanguage.PYTHON,
-      validateEnvironment: vi.fn().mockResolvedValue({
-        valid: true,
-        errors: [],
-        warnings: []
-      }),
-      resolveExecutablePath: vi.fn().mockRejectedValue(new Error('resolution failed'))
-    } as unknown as IDebugAdapter;
+      resolveExecutablePath: async () => {
+        throw new Error('resolution failed');
+      }
+    });
 
     proxyManager = new ProxyManager(
       adapter,
@@ -360,13 +357,7 @@ describe('ProxyManager.start', () => {
   });
 
   it('validates the user-configured interpreter, not an auto-detected one (issue #106)', async () => {
-    const validateEnvironment = vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] });
-    const resolveExecutablePath = vi.fn();
-    const adapter = {
-      language: DebugLanguage.PYTHON,
-      validateEnvironment,
-      resolveExecutablePath
-    } as unknown as IDebugAdapter;
+    const adapter = new FakeDebugAdapter({ language: DebugLanguage.PYTHON });
 
     proxyManager = new ProxyManager(
       adapter,
@@ -384,19 +375,22 @@ describe('ProxyManager.start', () => {
     await proxyManager.start(config);
 
     // The configured venv interpreter must be the one validated for debugpy.
-    expect(validateEnvironment).toHaveBeenCalledWith('/project/.venv/bin/python');
+    expect(adapter.validateEnvironment).toHaveBeenCalledWith('/project/.venv/bin/python');
     // A provided path is used directly — no auto-detection fallback.
-    expect(resolveExecutablePath).not.toHaveBeenCalled();
+    expect(adapter.resolveExecutablePath).not.toHaveBeenCalled();
   });
 
   it('skips environment probing for direct-connect attach sessions (issue #331)', async () => {
-    const adapter = {
+    const adapter = new FakeDebugAdapter({
       language: DebugLanguage.RUBY,
-      validateEnvironment: vi.fn().mockRejectedValue(new Error('should not be called')),
-      resolveExecutablePath: vi.fn().mockRejectedValue(new Error('should not be called')),
-      usesDirectConnectForAttach: vi.fn().mockReturnValue(true),
-      getDefaultExecutableName: vi.fn().mockReturnValue('ruby')
-    } as unknown as IDebugAdapter;
+      validateEnvironment: async () => {
+        throw new Error('should not be called');
+      },
+      resolveExecutablePath: async () => {
+        throw new Error('should not be called');
+      },
+      getDefaultExecutableName: () => 'ruby'
+    }).withAttachSupport({ directConnect: true });
 
     proxyManager = new ProxyManager(
       adapter,
@@ -423,12 +417,8 @@ describe('ProxyManager.start', () => {
   });
 
   it('still probes the environment for attach sessions on spawn-mode adapters', async () => {
-    const adapter = {
-      language: DebugLanguage.PYTHON,
-      validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-      resolveExecutablePath: vi.fn(),
-      usesDirectConnectForAttach: vi.fn().mockReturnValue(false)
-    } as unknown as IDebugAdapter;
+    const adapter = new FakeDebugAdapter({ language: DebugLanguage.PYTHON })
+      .withAttachSupport({ directConnect: false });
 
     proxyManager = new ProxyManager(
       adapter,
@@ -1390,12 +1380,9 @@ describe('ProxyManager.start', () => {
         waitUntilReady: vi.fn().mockResolvedValue(undefined),
         dispose: vi.fn()
       };
-      const adapter = {
-        language: DebugLanguage.JAVASCRIPT,
-        validateEnvironment: vi.fn(),
-        resolveExecutablePath: vi.fn(),
-        createLaunchBarrier: vi.fn().mockReturnValue(barrier)
-      } as unknown as IDebugAdapter;
+      const adapter = new FakeDebugAdapter({
+        language: DebugLanguage.JAVASCRIPT
+      }).withLaunchBarrier(barrier);
 
       const manager = new ProxyManager(adapter, proxyProcessLauncher, fileSystem, logger);
       (manager as unknown as { proxyProcess: IProxyProcess | null }).proxyProcess = fakeProcess;
@@ -1436,11 +1423,10 @@ describe('ProxyManager.start', () => {
   });
 
   it('emits lifecycle events when adapter-driven statuses arrive', async () => {
-    const adapter = {
+    const adapter = new FakeDebugAdapter({
       language: DebugLanguage.PYTHON,
-      validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-      resolveExecutablePath: vi.fn().mockResolvedValue('python-auto')
-    } as unknown as IDebugAdapter;
+      resolveExecutablePath: async () => 'python-auto'
+    });
 
     proxyManager = new ProxyManager(
       adapter,
@@ -2102,11 +2088,10 @@ describe('ProxyManager helpers', () => {
   });
 
   it('prepares spawn context using adapter resolution and cloned environment', async () => {
-    const adapter = {
+    const adapter = new FakeDebugAdapter({
       language: DebugLanguage.JAVASCRIPT,
-      validateEnvironment: vi.fn().mockResolvedValue({ valid: true, errors: [], warnings: [] }),
-      resolveExecutablePath: vi.fn().mockResolvedValue('/usr/bin/node')
-    } as unknown as IDebugAdapter;
+      resolveExecutablePath: async () => '/usr/bin/node'
+    });
 
     const runtimeEnv = {
       moduleUrl: pathToFileURL(path.join(process.cwd(), 'fake', 'src', 'proxy', 'proxy-manager.ts')).href,
@@ -2141,15 +2126,14 @@ describe('ProxyManager helpers', () => {
   });
 
   it('throws when adapter validation fails during spawn context preparation', async () => {
-    const adapter = {
+    const adapter = new FakeDebugAdapter({
       language: DebugLanguage.PYTHON,
-      validateEnvironment: vi.fn().mockResolvedValue({
+      validateEnvironment: async () => ({
         valid: false,
-        errors: [{ message: 'Python missing' }],
+        errors: [{ code: 'PYTHON_MISSING', message: 'Python missing', recoverable: false }],
         warnings: []
-      }),
-      resolveExecutablePath: vi.fn()
-    } as unknown as IDebugAdapter;
+      })
+    });
 
     const runtimeEnv = {
       moduleUrl: pathToFileURL(path.join(process.cwd(), 'fake', 'src', 'proxy', 'proxy-manager.ts')).href,

--- a/tests/unit/shared/adapter-policy-contract.test.ts
+++ b/tests/unit/shared/adapter-policy-contract.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Cross-policy contract test.
+ *
+ * Nine `AdapterPolicy` implementations satisfy one interface, and until now each was tested
+ * only on its own terms — the rules that must hold for *every* policy lived in doc comments
+ * on `adapter-policy.ts` and in the head of whoever added a language last. A tenth adapter
+ * can currently ship with, say, `functionBreakpointsVia: 'cdp'` and no
+ * `supportsFunctionBreakpoints`, and nothing complains until a user hits it.
+ *
+ * These assertions run against the REAL policies via `getPolicyForLanguage` — no mocks — so
+ * they double as a description of what a new policy has to provide.
+ *
+ * The pinned capability table is deliberately a duplicate of what the policies declare: a
+ * capability flipping is a user-visible behaviour change (it gates `set_breakpoint` up front),
+ * so it should require editing this table on purpose rather than passing silently.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  DebugLanguage,
+  DefaultAdapterPolicy,
+  getPolicyForLanguage,
+  resolveExceptionFilters,
+  type AdapterPolicy,
+  type ChildSessionStrategy,
+  type ExceptionBreakMode
+} from '@debugmcp/shared';
+
+/** The abstract break-on-exception modes `resolveExceptionFilters` accepts. */
+const EXCEPTION_MODES: ExceptionBreakMode[] = ['none', 'uncaught', 'all'];
+
+interface PinnedCapabilities {
+  /** `policy.name` — the diagnostics identifier. */
+  policyName: string;
+  /** Static function-breakpoint verdict; `undefined` means "unknown, re-check live". */
+  supportsFunctionBreakpoints: boolean | undefined;
+  /** Static logpoint verdict; `undefined` means "unknown, re-check live". */
+  supportsLogPoints: boolean | undefined;
+  childSessionStrategy: ChildSessionStrategy;
+  requiresCommandQueueing: boolean;
+}
+
+/**
+ * What each language's policy declares today. `javascript -> 'js-debug'` is the one place a
+ * policy name deviates from its language; ruby is the one adapter with no static
+ * function-breakpoint verdict, and ruby/java/dotnet are the three that reject logpoints.
+ */
+const PINNED: Record<DebugLanguage, PinnedCapabilities> = {
+  [DebugLanguage.PYTHON]: {
+    policyName: 'python',
+    supportsFunctionBreakpoints: true,
+    supportsLogPoints: true,
+    childSessionStrategy: 'none',
+    requiresCommandQueueing: false
+  },
+  [DebugLanguage.RUBY]: {
+    policyName: 'ruby',
+    supportsFunctionBreakpoints: undefined,
+    supportsLogPoints: false,
+    childSessionStrategy: 'none',
+    requiresCommandQueueing: false
+  },
+  [DebugLanguage.JAVASCRIPT]: {
+    policyName: 'js-debug',
+    supportsFunctionBreakpoints: true,
+    supportsLogPoints: true,
+    childSessionStrategy: 'launchWithPendingTarget',
+    requiresCommandQueueing: true
+  },
+  [DebugLanguage.RUST]: {
+    policyName: 'rust',
+    supportsFunctionBreakpoints: true,
+    supportsLogPoints: true,
+    childSessionStrategy: 'none',
+    requiresCommandQueueing: false
+  },
+  [DebugLanguage.GO]: {
+    policyName: 'go',
+    supportsFunctionBreakpoints: true,
+    supportsLogPoints: true,
+    childSessionStrategy: 'none',
+    requiresCommandQueueing: false
+  },
+  [DebugLanguage.JAVA]: {
+    policyName: 'java',
+    supportsFunctionBreakpoints: true,
+    supportsLogPoints: false,
+    childSessionStrategy: 'none',
+    requiresCommandQueueing: false
+  },
+  [DebugLanguage.DOTNET]: {
+    policyName: 'dotnet',
+    supportsFunctionBreakpoints: true,
+    supportsLogPoints: false,
+    childSessionStrategy: 'none',
+    requiresCommandQueueing: false
+  },
+  [DebugLanguage.CPP]: {
+    policyName: 'cpp',
+    supportsFunctionBreakpoints: true,
+    supportsLogPoints: true,
+    childSessionStrategy: 'none',
+    requiresCommandQueueing: false
+  },
+  [DebugLanguage.MOCK]: {
+    policyName: 'mock',
+    supportsFunctionBreakpoints: true,
+    supportsLogPoints: true,
+    childSessionStrategy: 'none',
+    requiresCommandQueueing: false
+  }
+};
+
+const LANGUAGES = Object.values(DebugLanguage);
+
+/** `getLocalScopeName()` may return one name or several; callers treat both as a list. */
+function normaliseScopeNames(policy: AdapterPolicy): string[] {
+  const names = policy.getLocalScopeName?.();
+  if (names === undefined) return [];
+  return Array.isArray(names) ? names : [names];
+}
+
+describe('AdapterPolicy contract — dispatch', () => {
+  it('maps every DebugLanguage to a real policy, never the placeholder', () => {
+    for (const language of LANGUAGES) {
+      const policy = getPolicyForLanguage(language);
+      expect(policy, language).not.toBe(DefaultAdapterPolicy);
+      expect(policy.name, language).not.toBe('default');
+    }
+  });
+
+  it('gives every policy a unique name', () => {
+    const names = LANGUAGES.map((language) => getPolicyForLanguage(language).name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('falls back to DefaultAdapterPolicy for an unknown language', () => {
+    expect(getPolicyForLanguage('klingon')).toBe(DefaultAdapterPolicy);
+  });
+});
+
+describe.each(LANGUAGES)('AdapterPolicy contract — %s', (language) => {
+  const policy = getPolicyForLanguage(language);
+  const pinned = PINNED[language];
+
+  // ===== 1. Identity =====
+
+  it('declares the pinned policy name', () => {
+    expect(policy.name).toBe(pinned.policyName);
+  });
+
+  // ===== 2. Reverse startDebugging is exactly "has a child session strategy" =====
+
+  it('ties supportsReverseStartDebugging to childSessionStrategy', () => {
+    expect(policy.childSessionStrategy).toBe(pinned.childSessionStrategy);
+    expect(policy.supportsReverseStartDebugging).toBe(policy.childSessionStrategy !== 'none');
+  });
+
+  // ===== 3. Command queueing is all-or-nothing =====
+
+  it('pairs command queueing with the handshake it implies', () => {
+    // A policy that queues commands owns the whole DAP start sequence: the proxy worker's
+    // built-in launch/attach flow does not run for it, so performHandshake is mandatory, and
+    // the queue it built has to be drained by processQueuedCommands.
+    expect(policy.requiresCommandQueueing()).toBe(pinned.requiresCommandQueueing);
+    expect(Boolean(policy.performHandshake)).toBe(policy.requiresCommandQueueing());
+    expect(Boolean(policy.processQueuedCommands)).toBe(policy.requiresCommandQueueing());
+  });
+
+  // ===== 4. Breakpoint capabilities =====
+
+  it('declares the pinned breakpoint capabilities', () => {
+    expect(policy.supportsFunctionBreakpoints).toBe(pinned.supportsFunctionBreakpoints);
+    expect(policy.supportsLogPoints).toBe(pinned.supportsLogPoints);
+  });
+
+  it('only claims a function-breakpoint delivery quirk when it supports them at all', () => {
+    // 'cdp' delivery means our proxy arms them out of band, and bind-late means verified:false
+    // at launch is expected — both are refinements of "supported", not substitutes for it.
+    if (policy.functionBreakpointsVia === 'cdp') {
+      expect(policy.supportsFunctionBreakpoints).toBe(true);
+    }
+    if (policy.functionBreakpointsBindLate) {
+      expect(policy.supportsFunctionBreakpoints).toBe(true);
+    }
+  });
+
+  // ===== 5. Initialization behavior =====
+
+  it('returns a well-formed initialization behavior', () => {
+    const behavior = policy.getInitializationBehavior();
+    expect(behavior).toBeTypeOf('object');
+
+    // Both modes must name a list. The list may legitimately be empty — cpp has no
+    // uncaught-only LLDB filter — which the session layer reads as "mode unsupported here".
+    const filters = behavior.exceptionFilters;
+    expect(filters, 'every policy declares exception filters').toBeDefined();
+    expect(Array.isArray(filters?.uncaught)).toBe(true);
+    expect(Array.isArray(filters?.all)).toBe(true);
+
+    if (behavior.defaultExceptionBreakMode !== undefined) {
+      // Only launch sessions get a default, and 'uncaught' is the only sane one — 'all' would
+      // pause on routine caught exceptions, 'none' is what omitting the field already means
+      // (and names no filter list at all).
+      expect(behavior.defaultExceptionBreakMode).toBe('uncaught');
+    }
+  });
+
+  it('resolves every exception mode to an array of filter ids', () => {
+    for (const mode of EXCEPTION_MODES) {
+      const resolved = resolveExceptionFilters(policy, mode);
+      expect(Array.isArray(resolved), mode).toBe(true);
+      for (const filter of resolved) expect(typeof filter).toBe('string');
+    }
+    expect(resolveExceptionFilters(policy, 'none')).toEqual([]);
+    expect(resolveExceptionFilters(policy, undefined)).toEqual([]);
+  });
+
+  // ===== 6. Local-variable extraction =====
+
+  it('implements local-variable extraction and names its local scopes', () => {
+    // The session layer's get_local_variables path calls both; a policy missing either
+    // silently degrades to the generic scope scan.
+    expect(policy.extractLocalVariables).toBeTypeOf('function');
+    expect(policy.getLocalScopeName).toBeTypeOf('function');
+
+    const names = normaliseScopeNames(policy);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(typeof name).toBe('string');
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+
+  // ===== 7. Configuration surfaces =====
+
+  it('returns usable configuration objects', () => {
+    const dapConfig = policy.getDapAdapterConfiguration();
+    expect(dapConfig.type).toBeTypeOf('string');
+    expect(dapConfig.type.length).toBeGreaterThan(0);
+
+    expect(policy.getDebuggerConfiguration()).toBeTypeOf('object');
+
+    const clientBehavior = policy.getDapClientBehavior();
+    expect(clientBehavior).toBeTypeOf('object');
+    if (clientBehavior.childInitTimeout !== undefined) {
+      expect(clientBehavior.childInitTimeout).toBeGreaterThan(0);
+    }
+
+    const attachBehavior = policy.getAttachBehavior?.();
+    if (attachBehavior !== undefined) {
+      for (const value of Object.values(attachBehavior)) {
+        expect(typeof value).toBe('boolean');
+      }
+    }
+  });
+
+  // ===== 8. State lifecycle =====
+
+  it('creates a fresh, uninitialized state on every call', () => {
+    const first = policy.createInitialState();
+    const second = policy.createInitialState();
+
+    // Shared state would leak one session's progress into the next.
+    expect(first).not.toBe(second);
+    expect(first.initialized).toBe(false);
+    expect(first.configurationDone).toBe(false);
+
+    expect(policy.isInitialized(first)).toBe(false);
+    expect(policy.isConnected(first)).toBe(false);
+  });
+
+  // ===== 9. Executable resolution =====
+
+  it('honours an explicitly provided executable path', () => {
+    expect(policy.resolveExecutablePath('/explicit/bin')).toBe('/explicit/bin');
+  });
+
+  // ===== 10. Adapter matching =====
+
+  it('does not match an empty adapter command', () => {
+    expect(policy.matchesAdapter({ command: '', args: [] })).toBe(false);
+  });
+});

--- a/tests/unit/shared/adapter-policy-contract.test.ts
+++ b/tests/unit/shared/adapter-policy-contract.test.ts
@@ -35,78 +35,120 @@ interface PinnedCapabilities {
   supportsFunctionBreakpoints: boolean | undefined;
   /** Static logpoint verdict; `undefined` means "unknown, re-check live". */
   supportsLogPoints: boolean | undefined;
+  /** Out-of-band function-breakpoint delivery; `undefined` means the standard DAP request. */
+  functionBreakpointsVia: 'dap' | 'cdp' | undefined;
+  /** Whether verified:false at launch is by design rather than a warning. */
+  functionBreakpointsBindLate: boolean | undefined;
   childSessionStrategy: ChildSessionStrategy;
   requiresCommandQueueing: boolean;
+  /**
+   * Break-on-exception mode applied to LAUNCH sessions when the user named none.
+   * `undefined` means the policy deliberately declines a default.
+   */
+  defaultExceptionBreakMode: ExceptionBreakMode | undefined;
 }
 
 /**
- * What each language's policy declares today. `javascript -> 'js-debug'` is the one place a
- * policy name deviates from its language; ruby is the one adapter with no static
- * function-breakpoint verdict, and ruby/java/dotnet are the three that reject logpoints.
+ * What each language's policy declares today. Every field is pinned for every language — the
+ * `undefined`s included — so an adapter that starts declaring one fails a test instead of
+ * quietly switching an assertion off.
+ *
+ * The deviations worth knowing: `javascript -> 'js-debug'` is the one policy name that differs
+ * from its language, and the only policy delivering function breakpoints over CDP; ruby is the
+ * only adapter with no static function-breakpoint verdict and the only one declining a default
+ * exception mode; ruby/java/dotnet are the three that reject logpoints; js and java are the two
+ * that bind function breakpoints late.
  */
 const PINNED: Record<DebugLanguage, PinnedCapabilities> = {
   [DebugLanguage.PYTHON]: {
     policyName: 'python',
     supportsFunctionBreakpoints: true,
     supportsLogPoints: true,
+    functionBreakpointsVia: undefined,
+    functionBreakpointsBindLate: undefined,
     childSessionStrategy: 'none',
-    requiresCommandQueueing: false
+    requiresCommandQueueing: false,
+    defaultExceptionBreakMode: 'uncaught'
   },
   [DebugLanguage.RUBY]: {
     policyName: 'ruby',
     supportsFunctionBreakpoints: undefined,
     supportsLogPoints: false,
+    functionBreakpointsVia: undefined,
+    functionBreakpointsBindLate: undefined,
     childSessionStrategy: 'none',
-    requiresCommandQueueing: false
+    requiresCommandQueueing: false,
+    defaultExceptionBreakMode: undefined
   },
   [DebugLanguage.JAVASCRIPT]: {
     policyName: 'js-debug',
     supportsFunctionBreakpoints: true,
     supportsLogPoints: true,
+    functionBreakpointsVia: 'cdp',
+    functionBreakpointsBindLate: true,
     childSessionStrategy: 'launchWithPendingTarget',
-    requiresCommandQueueing: true
+    requiresCommandQueueing: true,
+    defaultExceptionBreakMode: 'uncaught'
   },
   [DebugLanguage.RUST]: {
     policyName: 'rust',
     supportsFunctionBreakpoints: true,
     supportsLogPoints: true,
+    functionBreakpointsVia: undefined,
+    functionBreakpointsBindLate: undefined,
     childSessionStrategy: 'none',
-    requiresCommandQueueing: false
+    requiresCommandQueueing: false,
+    defaultExceptionBreakMode: 'uncaught'
   },
   [DebugLanguage.GO]: {
     policyName: 'go',
     supportsFunctionBreakpoints: true,
     supportsLogPoints: true,
+    functionBreakpointsVia: undefined,
+    functionBreakpointsBindLate: undefined,
     childSessionStrategy: 'none',
-    requiresCommandQueueing: false
+    requiresCommandQueueing: false,
+    defaultExceptionBreakMode: 'uncaught'
   },
   [DebugLanguage.JAVA]: {
     policyName: 'java',
     supportsFunctionBreakpoints: true,
     supportsLogPoints: false,
+    functionBreakpointsVia: undefined,
+    functionBreakpointsBindLate: true,
     childSessionStrategy: 'none',
-    requiresCommandQueueing: false
+    requiresCommandQueueing: false,
+    defaultExceptionBreakMode: 'uncaught'
   },
   [DebugLanguage.DOTNET]: {
     policyName: 'dotnet',
     supportsFunctionBreakpoints: true,
     supportsLogPoints: false,
+    functionBreakpointsVia: undefined,
+    functionBreakpointsBindLate: undefined,
     childSessionStrategy: 'none',
-    requiresCommandQueueing: false
+    requiresCommandQueueing: false,
+    defaultExceptionBreakMode: 'uncaught'
   },
   [DebugLanguage.CPP]: {
     policyName: 'cpp',
     supportsFunctionBreakpoints: true,
     supportsLogPoints: true,
+    functionBreakpointsVia: undefined,
+    functionBreakpointsBindLate: undefined,
     childSessionStrategy: 'none',
-    requiresCommandQueueing: false
+    requiresCommandQueueing: false,
+    defaultExceptionBreakMode: 'uncaught'
   },
   [DebugLanguage.MOCK]: {
     policyName: 'mock',
     supportsFunctionBreakpoints: true,
     supportsLogPoints: true,
+    functionBreakpointsVia: undefined,
+    functionBreakpointsBindLate: undefined,
     childSessionStrategy: 'none',
-    requiresCommandQueueing: false
+    requiresCommandQueueing: false,
+    defaultExceptionBreakMode: 'uncaught'
   }
 };
 
@@ -174,6 +216,9 @@ describe.each(LANGUAGES)('AdapterPolicy contract — %s', (language) => {
   });
 
   it('only claims a function-breakpoint delivery quirk when it supports them at all', () => {
+    expect(policy.functionBreakpointsVia).toBe(pinned.functionBreakpointsVia);
+    expect(policy.functionBreakpointsBindLate).toBe(pinned.functionBreakpointsBindLate);
+
     // 'cdp' delivery means our proxy arms them out of band, and bind-late means verified:false
     // at launch is expected — both are refinements of "supported", not substitutes for it.
     if (policy.functionBreakpointsVia === 'cdp') {
@@ -197,11 +242,17 @@ describe.each(LANGUAGES)('AdapterPolicy contract — %s', (language) => {
     expect(Array.isArray(filters?.uncaught)).toBe(true);
     expect(Array.isArray(filters?.all)).toBe(true);
 
+    // Pinned for every language, ruby's deliberate `undefined` included — guarding this on
+    // "if defined" is how it would stop testing anything the day a policy dropped the field.
+    expect(behavior.defaultExceptionBreakMode).toBe(pinned.defaultExceptionBreakMode);
+
     if (behavior.defaultExceptionBreakMode !== undefined) {
       // Only launch sessions get a default, and 'uncaught' is the only sane one — 'all' would
       // pause on routine caught exceptions, 'none' is what omitting the field already means
-      // (and names no filter list at all).
+      // (and names no filter list at all, which is why the mode has to be one of the two the
+      // block above proved are arrays).
       expect(behavior.defaultExceptionBreakMode).toBe('uncaught');
+      expect(Array.isArray(filters?.uncaught)).toBe(true);
     }
   });
 

--- a/tests/unit/test-utils/fake-debug-adapter.test.ts
+++ b/tests/unit/test-utils/fake-debug-adapter.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the test double itself.
+ *
+ * `FakeDebugAdapter` is used by every proxy and session suite, so its own contract has to hold
+ * or a whole class of tests quietly stops testing what it claims. The four properties below
+ * are exactly the ones that were wrong (or only true by accident) before review:
+ *
+ * - an optional member the production code guards must be genuinely ABSENT, not present-and-
+ *   undefined, or `adapter.supportsAttach?.()` only ever exercises one branch;
+ * - an explicitly-undefined override must not resurrect such a member as a truthy mock;
+ * - a constructor override must survive `vi.resetAllMocks()`, which restores the
+ *   implementation a mock was CONSTRUCTED with;
+ * - the builders deliberately win over constructor overrides.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DebugLanguage, type AdapterLaunchBarrier, type GenericAttachConfig } from '@debugmcp/shared';
+import { FakeDebugAdapter } from '../../test-utils/fakes/fake-debug-adapter.js';
+
+/** The seven members production code reaches through an optional call. */
+const OPTIONAL_MEMBERS = [
+  'createLaunchBarrier',
+  'supportsAttach',
+  'supportsDetach',
+  'usesDirectConnectForAttach',
+  'transformAttachConfig',
+  'getDefaultAttachConfig',
+  'supportedAttachKeys'
+] as const;
+
+function makeBarrier(): AdapterLaunchBarrier {
+  return {
+    awaitResponse: false,
+    onRequestSent: vi.fn(),
+    onProxyStatus: vi.fn(),
+    onDapEvent: vi.fn(),
+    onProxyExit: vi.fn(),
+    waitUntilReady: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn()
+  };
+}
+
+describe('FakeDebugAdapter', () => {
+  describe('optional members are absent until opted in', () => {
+    it('defines no own property for any optional member', () => {
+      const adapter = new FakeDebugAdapter();
+
+      for (const member of OPTIONAL_MEMBERS) {
+        // `in` and Object.keys, not just `=== undefined`: an uninitialised ES2022 class field
+        // is emitted as an own property holding undefined, which passes a truthiness check on
+        // the value but fails these — and would make the fake claim a capability it lacks.
+        expect(member in adapter, member).toBe(false);
+        expect(Object.keys(adapter), member).not.toContain(member);
+      }
+    });
+
+    it('keeps a member absent when an override passes undefined explicitly', () => {
+      // The shape a conditional override produces: `{ transformAttachConfig: cond ? fn : undefined }`.
+      const adapter = new FakeDebugAdapter({ transformAttachConfig: undefined });
+
+      expect('transformAttachConfig' in adapter).toBe(false);
+      expect(adapter.transformAttachConfig).toBeUndefined();
+    });
+
+    it('defines a member when an override supplies one', () => {
+      const adapter = new FakeDebugAdapter({
+        transformAttachConfig: (config: GenericAttachConfig) => ({ ...config, tagged: true })
+      });
+
+      expect('transformAttachConfig' in adapter).toBe(true);
+      expect(adapter.transformAttachConfig?.({ request: 'attach' })).toEqual({
+        request: 'attach',
+        tagged: true
+      });
+    });
+
+    it('defines the attach set only after withAttachSupport()', () => {
+      const adapter = new FakeDebugAdapter().withAttachSupport({ directConnect: true });
+
+      expect(adapter.supportsAttach?.()).toBe(true);
+      expect(adapter.usesDirectConnectForAttach?.()).toBe(true);
+      expect(adapter.supportsDetach?.()).toBe(true);
+      expect('transformAttachConfig' in adapter).toBe(true);
+      expect('getDefaultAttachConfig' in adapter).toBe(true);
+    });
+  });
+
+  describe('overrides', () => {
+    it('survives vi.resetAllMocks()', () => {
+      // mockReset restores the implementation a mock was CONSTRUCTED with, so an override
+      // installed via mockImplementation would silently revert to the fake's own default here.
+      const adapter = new FakeDebugAdapter({ getDefaultExecutableName: () => 'overridden' });
+      expect(adapter.getDefaultExecutableName()).toBe('overridden');
+
+      vi.resetAllMocks();
+
+      expect(adapter.getDefaultExecutableName()).toBe('overridden');
+    });
+
+    it('sets language and name, defaulting language to mock', () => {
+      expect(new FakeDebugAdapter().language).toBe(DebugLanguage.MOCK);
+      expect(new FakeDebugAdapter({ language: DebugLanguage.RUBY }).language).toBe(
+        DebugLanguage.RUBY
+      );
+      expect(new FakeDebugAdapter({ name: 'Explicit' }).name).toBe('Explicit');
+    });
+  });
+
+  describe('builders win over constructor overrides', () => {
+    it('withAttachSupport() replaces a same-member override', () => {
+      const adapter = new FakeDebugAdapter({ supportsDetach: () => false }).withAttachSupport();
+
+      expect(adapter.supportsDetach?.()).toBe(true);
+    });
+
+    it('withLaunchBarrier() replaces a same-member override', () => {
+      const constructed = makeBarrier();
+      const built = makeBarrier();
+      const adapter = new FakeDebugAdapter({
+        createLaunchBarrier: () => constructed
+      }).withLaunchBarrier(built);
+
+      expect(adapter.createLaunchBarrier?.('launch')).toBe(built);
+    });
+
+    it('withLaunchBarrier(undefined) defines the member but declines the barrier', () => {
+      const adapter = new FakeDebugAdapter().withLaunchBarrier(undefined);
+
+      expect('createLaunchBarrier' in adapter).toBe(true);
+      expect(adapter.createLaunchBarrier?.('launch')).toBeUndefined();
+    });
+  });
+
+  describe('production-shaped defaults', () => {
+    it('falls back to a real executable name for an empty preferred path', async () => {
+      // '' is not a path: real adapters treat it as "search PATH", and the proxy worker's
+      // init-payload validation rejects an empty executablePath outright.
+      const adapter = new FakeDebugAdapter();
+
+      await expect(adapter.resolveExecutablePath('')).resolves.toBe('fake-executable');
+      await expect(adapter.resolveExecutablePath(undefined)).resolves.toBe('fake-executable');
+      await expect(adapter.resolveExecutablePath('/usr/bin/python3')).resolves.toBe(
+        '/usr/bin/python3'
+      );
+    });
+
+    it('transforms launch config asynchronously, as the interface requires', async () => {
+      const adapter = new FakeDebugAdapter();
+      const config = { stopOnEntry: true };
+
+      const transformed = adapter.transformLaunchConfig(config);
+      expect(transformed).toBeInstanceOf(Promise);
+      // A copy, not the caller's object — a transform that aliased its input would hide
+      // mutation bugs in the code under test.
+      await expect(transformed).resolves.toEqual(config);
+      await expect(transformed).resolves.not.toBe(config);
+    });
+
+    it('is a real EventEmitter', () => {
+      const adapter = new FakeDebugAdapter();
+      const listener = vi.fn();
+
+      adapter.on('exited', listener);
+      adapter.emit('exited', 0);
+
+      expect(listener).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('withExtras', () => {
+    it('exposes adapter-specific members to the compiler and at runtime', () => {
+      const consumeLastToolchainValidation = vi.fn(() => 'clean');
+      const adapter = new FakeDebugAdapter().withExtras({ consumeLastToolchainValidation });
+
+      expect(adapter.consumeLastToolchainValidation()).toBe('clean');
+      // Same object, so a collaborator holding the IDebugAdapter still sees the extras.
+      expect(adapter).toBeInstanceOf(FakeDebugAdapter);
+    });
+  });
+});

--- a/tests/unit/test-utils/mock-factories.ts
+++ b/tests/unit/test-utils/mock-factories.ts
@@ -105,23 +105,6 @@ export function createMockSessionManager() {
 }
 
 /**
- * Create a mock adapter registry with all methods
- */
-export function createMockAdapterRegistry() {
-  return {
-    getSupportedLanguages: vi.fn().mockReturnValue(['python', 'mock']),
-    listLanguages: vi.fn().mockResolvedValue(['python', 'mock']),
-    listAvailableAdapters: vi.fn().mockResolvedValue(['python', 'mock']),
-    isLanguageSupported: vi.fn().mockReturnValue(true),
-    create: vi.fn().mockResolvedValue(null),
-    register: vi.fn(),
-    getAdapter: vi.fn().mockResolvedValue(null),
-    hasAdapter: vi.fn().mockReturnValue(false),
-    listAdapters: vi.fn().mockReturnValue([])
-  };
-}
-
-/**
  * Create a mock WhichCommandFinder that always works
  */
 export function createMockWhichFinder() {


### PR DESCRIPTION
## Summary

Test-only. Second PR of the structural-refactor series (after #563).

The unit suite carried ~40 hand-rolled `IDebugAdapter` object literals, every one escaping the type checker via `as unknown as IDebugAdapter`. Two "factories" were near-verbatim copies of each other with a **synchronous** `transformLaunchConfig` (the interface returns a Promise), two members that no longer exist on the interface (`translateScriptPath`/`translateBreakpointPath`), and none of the seven optional attach members. A third registry factory modelled an `IAdapterRegistry` that doesn't exist. Because the casts silenced every divergence, these contributed **zero** errors to the new test-typing baseline while being wrong — which is the point of this PR.

- **`tests/test-utils/fakes/fake-debug-adapter.ts`** — `class FakeDebugAdapter extends EventEmitter implements IDebugAdapter`, compile-checked against the interface (mirrors the existing `MockProxyManager implements IProxyManager` precedent). Every required member is a typed `vi.fn` with a production-shaped default; the seven optional members are **absent unless opted in** (`withAttachSupport()`, `withLaunchBarrier()`, or a constructor override), so `adapter.supportsAttach?.()` branches run both ways. Constructor overrides are implementations typed against the interface and are installed as fresh `vi.fn`s so `vi.resetAllMocks()` restores the override, not the fake's default. No `any`.
- The shared registry mock's `create()` now returns a `FakeDebugAdapter`; the duplicate `createMockDebugAdapter` and the untyped registry factory are gone; the proxy-manager unit tests are migrated. The fake immediately surfaced four malformed `ValidationError` literals (missing `code`/`recoverable`) in the old stubs.
- **`tests/unit/shared/adapter-policy-contract.test.ts`** — runs every real `AdapterPolicy` (all nine languages via `getPolicyForLanguage`) against shared invariants: registry coverage and name identity, `supportsReverseStartDebugging ⇔ childSessionStrategy`, the queueing/handshake triad, a pinned per-language capability table (`supportsFunctionBreakpoints`, `supportsLogPoints`, `functionBreakpointsVia`, `functionBreakpointsBindLate`, `defaultExceptionBreakMode`), well-formed exception filters, local-scope metadata, config getters, fresh state, explicit-path-wins executable resolution, and conservative `matchesAdapter`. The table is `Record<DebugLanguage, …>`, so a tenth language cannot be added without pinning its capabilities. 129 assertions, all true today.

`grep -rn "as unknown as IDebugAdapter" tests/ src/ packages/` now returns only the fake's own doc comment. The two remaining files with adapter stubs (`session-manager-attach-modes.test.ts`, `session-manager-operations-coverage.test.ts`) are migrated in a later PR of the series because the session-manager split reshapes them first.

## Test plan

- [x] `pnpm run typecheck` → 0; `pnpm run typecheck:all` → exit 0 (baseline unchanged at 751/92; both new files type-clean)
- [x] `npx vitest run tests/unit/proxy tests/core/unit/factories tests/core/unit/session tests/unit/shared` → 52 files / 1154 tests
- [x] `npx vitest run --project unit` → all green
- [x] `npm run lint`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eq9fRrPuacc6ScMEkEGX9T
