### PR TITLE
fix(attach): log errorDetails and proxy-log tail on attach failure; AdapterLease for explicit adapter ownership (#561)

### DIFF
--- a/changelog.d/561.fixed.md
+++ b/changelog.d/561.fixed.md
@@ -5,5 +5,6 @@ log the same structured `errorDetails` record `start_debugging` has always logge
 type, code and syscall, which initialization stage stalled, and the last 80 lines of the proxy
 log — under `Detailed error in attachToProcess`. The tool result is unchanged: the log tail goes
 only to the log. Internally, launch and attach now share one failure-diagnostics module, and the
-adapter created for a launch is held by an explicit lease, so a launch that fails during setup
-can no longer strand a registry slot and exhaust the per-language adapter limit (#561)
+adapter-ownership window in the launch path became an explicit lease object rather than a boolean
+flag — no behaviour change on any path, but the ownership rule is now structural instead of a
+convention the next edit has to remember (#561)

--- a/changelog.d/561.fixed.md
+++ b/changelog.d/561.fixed.md
@@ -1,0 +1,9 @@
+**A failed `attach_to_process` now explains itself in the server log** — when the debug proxy
+died while an attach was initializing, the adapter's own complaint stayed in the per-session
+proxy log and nothing pointed at it, so the failure read as a bare timeout. Attach failures now
+log the same structured `errorDetails` record `start_debugging` has always logged — the error's
+type, code and syscall, which initialization stage stalled, and the last 80 lines of the proxy
+log — under `Detailed error in attachToProcess`. The tool result is unchanged: the log tail goes
+only to the log. Internally, launch and attach now share one failure-diagnostics module, and the
+adapter created for a launch is held by an explicit lease, so a launch that fails during setup
+can no longer strand a registry slot and exhaust the per-language adapter limit (#561)

--- a/docs/architecture/component-design.md
+++ b/docs/architecture/component-design.md
@@ -278,7 +278,9 @@ From the `handleInitCommand` method:
 
 3. **Logger Creation**
    ```typescript
-   const logPath = path.join(payload.logDir, `proxy-${payload.sessionId}.log`);
+   // proxyLogPathFor is the single home for this name (src/proxy/proxy-log-path.ts);
+   // the session layer's failure diagnostics read the log back through it.
+   const logPath = proxyLogPathFor(payload.logDir, payload.sessionId);
    this.logger = await this.dependencies.loggerFactory(payload.sessionId, payload.logDir);
    ```
 

--- a/src/adapters/adapter-lease.ts
+++ b/src/adapters/adapter-lease.ts
@@ -24,10 +24,14 @@
  * remembering to set anything. (`await using` would express this directly, but
  * the project's `lib` has no `ESNext.Disposable`.)
  *
- * After a transfer, `ProxyManager.cleanup()` is the disposer, exactly as before.
+ * The lease covers only the setup window. After a transfer the ProxyManager is
+ * the owner, and disposal happens through its teardown — `ProxyManager.cleanup()`
+ * calls `adapter.dispose()`, which the callers' catches reach by stopping
+ * `session.proxyManager` — exactly as before.
  */
 import type { AdapterConfig, IAdapterRegistry, IDebugAdapter } from '@debugmcp/shared';
 import type { ILogger, IProxyManagerFactory } from '../interfaces/external-dependencies.js';
+import { getErrorMessage } from '../errors/debug-errors.js';
 import type { IProxyManager } from '../proxy/proxy-manager.js';
 
 /**
@@ -65,11 +69,6 @@ export class AdapterLease {
     return new AdapterLease(adapter, logger, config.sessionId);
   }
 
-  /** True while this lease is still responsible for disposing the adapter. */
-  get isHeld(): boolean {
-    return this.state === 'held';
-  }
-
   /** Which of the three ownership states this lease is in. */
   getState(): AdapterLeaseState {
     return this.state;
@@ -96,11 +95,14 @@ export class AdapterLease {
    * Dispose the adapter if this lease still owns it. Idempotent, and a no-op
    * after a transfer, so it is safe as the sole `finally` of a setup block.
    *
-   * Never throws. A failing `dispose()` is swallowed with a warning: the setup
-   * error that sent us here is the one worth reporting, and a teardown failure
-   * replacing it from inside a `finally` would hide the actual cause. Both
-   * failure shapes are caught — a rejected promise and a *synchronous* throw,
-   * which a bare `.catch()` on the returned promise would have let escape.
+   * **Never throws, and that is load-bearing**: this is the `finally` of
+   * `startProxyManager`, so anything escaping here replaces the setup error
+   * that sent us there with a teardown error — hiding the cause the caller was
+   * about to report. So every step is inside the guard, not just the call:
+   * a missing or nullish adapter (a partial registry double), a `dispose()`
+   * that throws *synchronously* (no promise ever exists, so `.catch()` on the
+   * result would never run), a rejected `dispose()`, and a logger that throws
+   * while reporting one of those.
    */
   async release(): Promise<void> {
     if (this.state !== 'held') {
@@ -108,21 +110,34 @@ export class AdapterLease {
     }
     this.state = 'released';
 
-    // Duck-typed for parity with ProxyManager.cleanup(), whose adapter handle
-    // is likewise optional-shaped.
-    const disposable = this.adapter as { dispose?: () => Promise<void> };
-    if (typeof disposable.dispose !== 'function') {
-      return;
-    }
-
     try {
+      // Duck-typed for parity with ProxyManager.cleanup(), whose adapter handle
+      // is likewise optional-shaped — and read inside the guard, because the
+      // property access itself throws if the adapter is nullish.
+      const disposable = this.adapter as { dispose?: () => Promise<void> } | undefined;
+      if (typeof disposable?.dispose !== 'function') {
+        return;
+      }
       await disposable.dispose();
     } catch (disposeError: unknown) {
+      this.warnDisposeFailed(disposeError);
+    }
+  }
+
+  /**
+   * Report a failed disposal. Guarded in turn: a logger that throws must not
+   * become the failure `release()` promises never to raise, and there is
+   * nowhere left to report it.
+   */
+  private warnDisposeFailed(disposeError: unknown): void {
+    try {
       this.logger.warn(
-        `[SessionManager] Failed to dispose adapter after launch setup error for session ${this.sessionId}: ${
-          disposeError instanceof Error ? disposeError.message : String(disposeError)
-        }`
+        `[SessionManager] Failed to dispose adapter after launch setup error for session ${
+          this.sessionId
+        }: ${getErrorMessage(disposeError)}`
       );
+    } catch {
+      // Deliberately empty — see above.
     }
   }
 }

--- a/src/adapters/adapter-lease.ts
+++ b/src/adapters/adapter-lease.ts
@@ -1,0 +1,107 @@
+/**
+ * Explicit ownership of one adapter instance for the duration of a launch or
+ * attach setup.
+ *
+ * The registry caps concurrent adapters per language (`maxInstancesPerLanguage`,
+ * `adapter-registry.ts`) and releases a slot only when the adapter emits
+ * 'disposed'. Ownership used to be a *time window* inside `startProxyManager`
+ * guarded by a `let adapterOwnedByProxy = false` flag: every `throw` between
+ * `registry.create()` and `session.proxyManager = …` had to be caught by one
+ * catch that consulted the flag. A new early-return or a new throw site added
+ * outside that window leaked a registry slot, and ten leaks turned every
+ * subsequent launch of that language into "Maximum adapter instances (10)
+ * reached" — a failure whose message says nothing about the real error that
+ * caused it (issue #552 review, issue #561).
+ *
+ * A lease makes the window an object instead of a flag. Acquire it, do the
+ * setup inside `try`, hand ownership to the ProxyManager with `transferTo`,
+ * and `release()` in `finally`. Release after a transfer is a no-op, so the
+ * one `finally` covers every path: a throw anywhere in the body disposes, a
+ * successful transfer does not, and neither depends on remembering to set a
+ * flag. (`await using` would express this directly, but the project's `lib`
+ * has no `ESNext.Disposable`.)
+ *
+ * After a transfer, `ProxyManager.cleanup()` is the disposer, exactly as before.
+ */
+import type { AdapterConfig, IAdapterRegistry, IDebugAdapter } from '@debugmcp/shared';
+import type { ILogger } from '../interfaces/external-dependencies.js';
+import type { IProxyManagerFactory } from '../factories/proxy-manager-factory.js';
+import type { IProxyManager } from '../proxy/proxy-manager.js';
+
+export class AdapterLease {
+  private held = true;
+
+  private constructor(
+    /** The leased adapter. Valid whether or not the lease is still held. */
+    readonly adapter: IDebugAdapter,
+    private readonly logger: ILogger,
+    private readonly sessionId: string
+  ) {}
+
+  /**
+   * Create an adapter through the registry and take ownership of it.
+   *
+   * The instance limit and the 'disposed' bookkeeping stay in the registry;
+   * this only wraps the result in an owner that knows how to give it back.
+   * A rejection from `create` yields no lease — nothing was allocated.
+   */
+  static async acquire(
+    registry: Pick<IAdapterRegistry, 'create'>,
+    language: string,
+    config: AdapterConfig,
+    logger: ILogger
+  ): Promise<AdapterLease> {
+    const adapter = await registry.create(language, config);
+    return new AdapterLease(adapter, logger, config.sessionId);
+  }
+
+  /** True while this lease is still responsible for disposing the adapter. */
+  get isHeld(): boolean {
+    return this.held;
+  }
+
+  /**
+   * Hand the adapter to a ProxyManager, which becomes its owner and disposer.
+   *
+   * Ownership moves only after `factory.create` returns: a throwing factory
+   * leaves the lease held, so the caller's `finally` still disposes.
+   */
+  transferTo(factory: IProxyManagerFactory): IProxyManager {
+    if (!this.held) {
+      throw new Error(
+        `Adapter lease for session ${this.sessionId} was already transferred or released`
+      );
+    }
+    const proxyManager = factory.create(this.adapter);
+    this.held = false;
+    return proxyManager;
+  }
+
+  /**
+   * Dispose the adapter if this lease still owns it. Idempotent, and a no-op
+   * after a transfer, so it is safe as the sole `finally` of a setup block.
+   *
+   * A failing `dispose()` is swallowed with a warning: the setup error that
+   * sent us here is the one worth reporting, and masking it with a teardown
+   * failure would hide the actual cause.
+   */
+  async release(): Promise<void> {
+    if (!this.held) {
+      return;
+    }
+    this.held = false;
+
+    // Duck-typed for parity with ProxyManager.cleanup(), whose adapter handle
+    // is likewise optional-shaped.
+    const disposable = this.adapter as { dispose?: () => Promise<void> };
+    if (typeof disposable.dispose === 'function') {
+      await disposable.dispose().catch((disposeError: unknown) => {
+        this.logger.warn(
+          `[SessionManager] Failed to dispose adapter after launch setup error for session ${this.sessionId}: ${
+            disposeError instanceof Error ? disposeError.message : String(disposeError)
+          }`
+        );
+      });
+    }
+  }
+}

--- a/src/adapters/adapter-lease.ts
+++ b/src/adapters/adapter-lease.ts
@@ -4,32 +4,42 @@
  *
  * The registry caps concurrent adapters per language (`maxInstancesPerLanguage`,
  * `adapter-registry.ts`) and releases a slot only when the adapter emits
- * 'disposed'. Ownership used to be a *time window* inside `startProxyManager`
- * guarded by a `let adapterOwnedByProxy = false` flag: every `throw` between
+ * 'disposed'. Ownership was a *time window* inside `startProxyManager` guarded
+ * by a `let adapterOwnedByProxy = false` flag: every `throw` between
  * `registry.create()` and `session.proxyManager = …` had to be caught by one
- * catch that consulted the flag. A new early-return or a new throw site added
- * outside that window leaked a registry slot, and ten leaks turned every
- * subsequent launch of that language into "Maximum adapter instances (10)
- * reached" — a failure whose message says nothing about the real error that
- * caused it (issue #552 review, issue #561).
+ * catch that consulted the flag. That flag closed a real leak (#557, from the
+ * #552 review) — a rejected transform used to strand the slot, and ten stranded
+ * slots turned every later launch of that language into "Maximum adapter
+ * instances (10) reached", a message that says nothing about the error that
+ * actually caused it.
  *
- * A lease makes the window an object instead of a flag. Acquire it, do the
- * setup inside `try`, hand ownership to the ProxyManager with `transferTo`,
- * and `release()` in `finally`. Release after a transfer is a no-op, so the
- * one `finally` covers every path: a throw anywhere in the body disposes, a
- * successful transfer does not, and neither depends on remembering to set a
- * flag. (`await using` would express this directly, but the project's `lib`
- * has no `ESNext.Disposable`.)
+ * The lease is *behaviour-equivalent to that flag on every path*. What it
+ * changes is that correctness stops being a discipline: the flag has to be
+ * assigned at exactly one point and consulted from exactly one catch, so the
+ * next `throw` site added outside that window silently reopens the leak.
+ * Acquire the lease, do the setup inside `try`, hand ownership to the
+ * ProxyManager with `transferTo`, and `release()` in `finally`. Release after a
+ * transfer is a no-op, so the one `finally` covers every path: a throw anywhere
+ * in the body disposes, a successful transfer does not, and neither depends on
+ * remembering to set anything. (`await using` would express this directly, but
+ * the project's `lib` has no `ESNext.Disposable`.)
  *
  * After a transfer, `ProxyManager.cleanup()` is the disposer, exactly as before.
  */
 import type { AdapterConfig, IAdapterRegistry, IDebugAdapter } from '@debugmcp/shared';
-import type { ILogger } from '../interfaces/external-dependencies.js';
-import type { IProxyManagerFactory } from '../factories/proxy-manager-factory.js';
+import type { ILogger, IProxyManagerFactory } from '../interfaces/external-dependencies.js';
 import type { IProxyManager } from '../proxy/proxy-manager.js';
 
+/**
+ * Where the adapter's ownership currently sits. Three states, not a boolean:
+ * 'transferred' and 'released' are both "not ours any more", but confusing them
+ * is how a caller ends up looking for a disposed adapter inside a running proxy,
+ * so the error a misuse raises names which one actually happened.
+ */
+export type AdapterLeaseState = 'held' | 'transferred' | 'released';
+
 export class AdapterLease {
-  private held = true;
+  private state: AdapterLeaseState = 'held';
 
   private constructor(
     /** The leased adapter. Valid whether or not the lease is still held. */
@@ -57,7 +67,12 @@ export class AdapterLease {
 
   /** True while this lease is still responsible for disposing the adapter. */
   get isHeld(): boolean {
-    return this.held;
+    return this.state === 'held';
+  }
+
+  /** Which of the three ownership states this lease is in. */
+  getState(): AdapterLeaseState {
+    return this.state;
   }
 
   /**
@@ -67,13 +82,13 @@ export class AdapterLease {
    * leaves the lease held, so the caller's `finally` still disposes.
    */
   transferTo(factory: IProxyManagerFactory): IProxyManager {
-    if (!this.held) {
+    if (this.state !== 'held') {
       throw new Error(
-        `Adapter lease for session ${this.sessionId} was already transferred or released`
+        `Adapter lease for session ${this.sessionId} was already ${this.state}`
       );
     }
     const proxyManager = factory.create(this.adapter);
-    this.held = false;
+    this.state = 'transferred';
     return proxyManager;
   }
 
@@ -81,27 +96,33 @@ export class AdapterLease {
    * Dispose the adapter if this lease still owns it. Idempotent, and a no-op
    * after a transfer, so it is safe as the sole `finally` of a setup block.
    *
-   * A failing `dispose()` is swallowed with a warning: the setup error that
-   * sent us here is the one worth reporting, and masking it with a teardown
-   * failure would hide the actual cause.
+   * Never throws. A failing `dispose()` is swallowed with a warning: the setup
+   * error that sent us here is the one worth reporting, and a teardown failure
+   * replacing it from inside a `finally` would hide the actual cause. Both
+   * failure shapes are caught — a rejected promise and a *synchronous* throw,
+   * which a bare `.catch()` on the returned promise would have let escape.
    */
   async release(): Promise<void> {
-    if (!this.held) {
+    if (this.state !== 'held') {
       return;
     }
-    this.held = false;
+    this.state = 'released';
 
     // Duck-typed for parity with ProxyManager.cleanup(), whose adapter handle
     // is likewise optional-shaped.
     const disposable = this.adapter as { dispose?: () => Promise<void> };
-    if (typeof disposable.dispose === 'function') {
-      await disposable.dispose().catch((disposeError: unknown) => {
-        this.logger.warn(
-          `[SessionManager] Failed to dispose adapter after launch setup error for session ${this.sessionId}: ${
-            disposeError instanceof Error ? disposeError.message : String(disposeError)
-          }`
-        );
-      });
+    if (typeof disposable.dispose !== 'function') {
+      return;
+    }
+
+    try {
+      await disposable.dispose();
+    } catch (disposeError: unknown) {
+      this.logger.warn(
+        `[SessionManager] Failed to dispose adapter after launch setup error for session ${this.sessionId}: ${
+          disposeError instanceof Error ? disposeError.message : String(disposeError)
+        }`
+      );
     }
   }
 }

--- a/src/proxy/dap-proxy-dependencies.ts
+++ b/src/proxy/dap-proxy-dependencies.ts
@@ -4,9 +4,9 @@
 
 import { spawn } from 'child_process';
 import fs from 'fs-extra';
-import path from 'path';
 import { MinimalDapClient } from './minimal-dap.js';
 import { DapMirrorServer } from './dap-mirror-server.js';
+import { proxyLogPathFor } from './proxy-log-path.js';
 import { createLogger, redirectProxyLoggers } from '../utils/logger.js';
 import {
   DapProxyDependencies,
@@ -28,7 +28,7 @@ export function createProductionDependencies(
   // payload (CLI --log-level / DEBUG_MCP_LOG_LEVEL, issue #403); legacy parents
   // that send no level keep the historical 'debug'.
   const loggerFactory: ILoggerFactory = async (sessionId: string, logDir: string, level?: string) => {
-    const logPath = path.join(logDir, `proxy-${sessionId}.log`);
+    const logPath = proxyLogPathFor(logDir, sessionId);
     return createLogger(`dap-proxy:${sessionId}`, {
       level: level ?? 'debug',
       file: logPath

--- a/src/proxy/dap-proxy-worker.ts
+++ b/src/proxy/dap-proxy-worker.ts
@@ -26,6 +26,7 @@ import {
 import type { IDapMirrorServer, MirrorEndpoint } from './dap-mirror-server.js';
 import { CallbackRequestTracker } from './dap-proxy-request-tracker.js';
 import { GenericAdapterManager, AdapterStdioSource } from './dap-proxy-adapter-manager.js';
+import { proxyLogPathFor } from './proxy-log-path.js';
 import { DapConnectionManager } from './dap-proxy-connection-manager.js';
 import { 
   validateProxyInitPayload
@@ -315,7 +316,7 @@ export class DapProxyWorker {
 
     try {
       // Create logger
-      const logPath = path.join(payload.logDir, `proxy-${payload.sessionId}.log`);
+      const logPath = proxyLogPathFor(payload.logDir, payload.sessionId);
       await this.dependencies.fileSystem.ensureDir(path.dirname(logPath));
       this.logger = await this.dependencies.loggerFactory(payload.sessionId, payload.logDir, payload.logLevel);
       this.logger.info(`[Worker] DAP Proxy worker initialized for session ${payload.sessionId}`);

--- a/src/proxy/proxy-log-path.ts
+++ b/src/proxy/proxy-log-path.ts
@@ -1,0 +1,24 @@
+/**
+ * The single home for the per-session proxy log file name.
+ *
+ * `proxy-<sessionId>.log` was built by hand in three places — the production
+ * logger factory, the worker's own `redirectProxyLoggers` target, and the
+ * session layer's failure diagnostics — so the path the diagnostics point a
+ * user at was only *coincidentally* the path the proxy writes. Renaming the
+ * file in one place and not the others would have produced a `proxyLogPath`
+ * that never exists, with no test able to notice.
+ *
+ * Kept dependency-free: the worker half of this module is bundled into
+ * `proxy-bundle.cjs`, so it must not pull anything but `path` in behind it.
+ */
+import path from 'path';
+
+/** File name (no directory) of the proxy log for one debug session. */
+export function proxyLogFileName(sessionId: string): string {
+  return `proxy-${sessionId}.log`;
+}
+
+/** Absolute path to the proxy log for one debug session's run directory. */
+export function proxyLogPathFor(logDir: string, sessionId: string): string {
+  return path.join(logDir, proxyLogFileName(sessionId));
+}

--- a/src/session/launch/proxy-failure-diagnostics.ts
+++ b/src/session/launch/proxy-failure-diagnostics.ts
@@ -1,0 +1,155 @@
+/**
+ * Diagnostics for a launch or attach that failed while the debug proxy was
+ * coming up.
+ *
+ * Two audiences, deliberately kept apart:
+ *
+ * - The **tool result** gets pointers only — which init stage stalled and where
+ *   the proxy log lives. That shape is pinned by tests and is what an agent
+ *   reads; dumping 80 lines of adapter chatter into it would bury the error.
+ * - The **server log** gets the full record: the error's type/code/errno/syscall,
+ *   the init progress, and the tail of the proxy log, which is usually the only
+ *   place the adapter's own complaint appears.
+ *
+ * Launch had all of this; attach had only the pointers, so an attach that died
+ * during proxy initialization left the actual cause unreadable (issue #561).
+ * Both paths now call `logProxyFailure`, which is why it lives here rather than
+ * in either one.
+ */
+import type { ManagedSession } from '../session-store.js';
+import type { IFileSystem, ILogger } from '../../interfaces/external-dependencies.js';
+import type { ProxyInitProgress } from '../../utils/error-messages.js';
+import { proxyLogPathFor } from '../../proxy/proxy-log-path.js';
+
+/** How many trailing proxy-log lines are worth reading after a failure. */
+const PROXY_LOG_TAIL_LINES = 80;
+
+/** The pointers a failed launch/attach returns to the caller (issue #493 / #551). */
+export interface ProxyFailureDiagnostics {
+  initProgress?: ProxyInitProgress;
+  proxyLogPath?: string;
+}
+
+/**
+ * What `logProxyFailure` needs. Declared here, as the narrowest possible slice,
+ * so the module has no dependency on the session manager's shape.
+ */
+export interface ProxyFailureLogDeps {
+  logger: ILogger;
+  fileSystem: Pick<IFileSystem, 'pathExists' | 'readFile'>;
+}
+
+/** The two operations that can fail this way, named as they appear in the log. */
+export type ProxyFailureOperation = 'startDebugging' | 'attachToProcess';
+
+/**
+ * Pointers to proxy initialization diagnostics for a failed launch/attach
+ * (issue #493 / #551): which init stage stalled (from the timeout error) and
+ * where the proxy log for the session's current run lives.
+ */
+export function collectProxyFailureDiagnostics(
+  session: Pick<ManagedSession, 'id' | 'logDir'>,
+  error: unknown
+): ProxyFailureDiagnostics {
+  const diagnostics: ProxyFailureDiagnostics = {};
+  const initProgress = (error as { initProgress?: ProxyInitProgress } | null)?.initProgress;
+
+  if (initProgress) {
+    diagnostics.initProgress = initProgress;
+  }
+  if (session.logDir) {
+    diagnostics.proxyLogPath = proxyLogPathFor(session.logDir, session.id);
+  }
+
+  return diagnostics;
+}
+
+/**
+ * Read the last `tailLineCount` lines of the proxy log, if there is one.
+ *
+ * Never throws: a failure to read the log is itself reported *as* the tail, so
+ * the setup error that sent us here still reaches the log intact.
+ */
+export async function readProxyLogTail(
+  fileSystem: Pick<IFileSystem, 'pathExists' | 'readFile'>,
+  proxyLogPath: string | undefined,
+  tailLineCount: number = PROXY_LOG_TAIL_LINES
+): Promise<string | undefined> {
+  try {
+    if (!proxyLogPath) {
+      return undefined;
+    }
+    const logExists = await fileSystem.pathExists(proxyLogPath);
+    if (!logExists) {
+      return undefined;
+    }
+    const logContent = await fileSystem.readFile(proxyLogPath, 'utf-8');
+    const logLines = logContent.split(/\r?\n/);
+    const startIndex = Math.max(0, logLines.length - tailLineCount);
+    return logLines.slice(startIndex).join('\n');
+  } catch (logReadError) {
+    return `<<Failed to read proxy log: ${
+      logReadError instanceof Error ? logReadError.message : String(logReadError)
+    }>>`;
+  }
+}
+
+/**
+ * The comprehensive error record written to the server log — originally added
+ * to make Windows CI failures diagnosable from the log alone.
+ */
+export function buildProxyFailureErrorDetails(
+  error: unknown,
+  diagnostics: ProxyFailureDiagnostics,
+  proxyLogTail: string | undefined
+): Record<string, unknown> {
+  const errorDetails: Record<string, unknown> = {
+    type: error?.constructor?.name || 'Unknown',
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : 'No stack available',
+    code: (error as Record<string, unknown>)?.code,
+    errno: (error as Record<string, unknown>)?.errno,
+    syscall: (error as Record<string, unknown>)?.syscall,
+    path: (error as Record<string, unknown>)?.path,
+    toString: error?.toString ? error.toString() : 'No toString',
+    initProgress: diagnostics.initProgress,
+    proxyLogPath: diagnostics.proxyLogPath,
+    proxyLogTail
+  };
+
+  // Try to capture raw error object
+  try {
+    errorDetails.raw = JSON.stringify(error);
+  } catch {
+    errorDetails.raw = 'Error not JSON serializable';
+  }
+
+  return errorDetails;
+}
+
+/**
+ * Log the full failure record and hand back the pointers for the tool result.
+ *
+ * Returning the diagnostics is what keeps the two audiences consistent: the
+ * caller reports exactly the paths that were just written to the log, without
+ * collecting them twice.
+ */
+export async function logProxyFailure(
+  deps: ProxyFailureLogDeps,
+  session: Pick<ManagedSession, 'id' | 'logDir'>,
+  error: unknown,
+  operation: ProxyFailureOperation
+): Promise<ProxyFailureDiagnostics> {
+  const diagnostics = collectProxyFailureDiagnostics(session, error);
+
+  // Attempt to capture proxy log tail for debugging initialization failures
+  const proxyLogTail = await readProxyLogTail(deps.fileSystem, diagnostics.proxyLogPath);
+
+  // Log comprehensive error details
+  deps.logger.error(
+    `[SessionManager] Detailed error in ${operation} for session ${session.id}:`,
+    buildProxyFailureErrorDetails(error, diagnostics, proxyLogTail)
+  );
+
+  return diagnostics;
+}

--- a/src/session/launch/proxy-failure-diagnostics.ts
+++ b/src/session/launch/proxy-failure-diagnostics.ts
@@ -128,11 +128,45 @@ export function buildProxyFailureErrorDetails(
 }
 
 /**
+ * Describe a thrown value without trusting it. `String(error)` runs the value's
+ * own `toString`, and `error.message` runs its own getter — either can throw.
+ */
+function describeErrorSafely(error: unknown): string {
+  try {
+    return error instanceof Error ? error.message : String(error);
+  } catch {
+    return '<<error could not be described>>';
+  }
+}
+
+/**
+ * Log without trusting the logger. There is nowhere left to report a logger
+ * that throws, so it is dropped rather than allowed to become the caller's
+ * failure.
+ */
+function logSafely(logger: ILogger, message: string, meta: unknown): void {
+  try {
+    logger.error(message, meta);
+  } catch {
+    // Deliberately empty — see above.
+  }
+}
+
+/**
  * Log the full failure record and hand back the pointers for the tool result.
  *
  * Returning the diagnostics is what keeps the two audiences consistent: the
  * caller reports exactly the paths that were just written to the log, without
  * collecting them twice.
+ *
+ * **Total by construction.** Both callers `await` this from inside a `catch`
+ * that is about to `return { success: false, … }`, so anything thrown here
+ * would convert a reported failure into a rejection out of `start_debugging` /
+ * `attach_to_process` — turning a diagnosable error into an opaque one, which
+ * is the exact opposite of the point. The record is built from a value that has
+ * already misbehaved once, and any of its property reads (`toString`, a
+ * `message` getter) can misbehave again, so building and logging are both
+ * guarded: a failure there degrades to a minimal record instead of escaping.
  */
 export async function logProxyFailure(
   deps: ProxyFailureLogDeps,
@@ -140,16 +174,29 @@ export async function logProxyFailure(
   error: unknown,
   operation: ProxyFailureOperation
 ): Promise<ProxyFailureDiagnostics> {
-  const diagnostics = collectProxyFailureDiagnostics(session, error);
+  const header = `[SessionManager] Detailed error in ${operation} for session ${session.id}:`;
+  let diagnostics: ProxyFailureDiagnostics = {};
+  let errorDetails: Record<string, unknown>;
 
-  // Attempt to capture proxy log tail for debugging initialization failures
-  const proxyLogTail = await readProxyLogTail(deps.fileSystem, diagnostics.proxyLogPath);
+  try {
+    diagnostics = collectProxyFailureDiagnostics(session, error);
+
+    // Attempt to capture proxy log tail for debugging initialization failures
+    const proxyLogTail = await readProxyLogTail(deps.fileSystem, diagnostics.proxyLogPath);
+
+    errorDetails = buildProxyFailureErrorDetails(error, diagnostics, proxyLogTail);
+  } catch (diagnosticsError: unknown) {
+    // Keep whatever was collected before the failure — the pointers are the
+    // half the caller returns — and say why the rest is missing.
+    errorDetails = {
+      message: describeErrorSafely(error),
+      ...diagnostics,
+      diagnosticsUnavailable: describeErrorSafely(diagnosticsError)
+    };
+  }
 
   // Log comprehensive error details
-  deps.logger.error(
-    `[SessionManager] Detailed error in ${operation} for session ${session.id}:`,
-    buildProxyFailureErrorDetails(error, diagnostics, proxyLogTail)
-  );
+  logSafely(deps.logger, header, errorDetails);
 
   return diagnostics;
 }

--- a/src/session/launch/proxy-failure-diagnostics.ts
+++ b/src/session/launch/proxy-failure-diagnostics.ts
@@ -16,13 +16,22 @@
  * Both paths now call `logProxyFailure`, which is why it lives here rather than
  * in either one.
  */
+import { sanitizeStderrTail } from '@debugmcp/shared';
 import type { ManagedSession } from '../session-store.js';
 import type { IFileSystem, ILogger } from '../../interfaces/external-dependencies.js';
 import type { ProxyInitProgress } from '../../utils/error-messages.js';
+import { getErrorMessage } from '../../errors/debug-errors.js';
 import { proxyLogPathFor } from '../../proxy/proxy-log-path.js';
 
 /** How many trailing proxy-log lines are worth reading after a failure. */
 const PROXY_LOG_TAIL_LINES = 80;
+
+/**
+ * Character cap on the tail. Generous on purpose: it exists so a proxy log with
+ * one pathological multi-megabyte line cannot blow up the record, not to trim a
+ * normal 80-line tail, which is a few kilobytes.
+ */
+const PROXY_LOG_TAIL_CHARS = 64 * 1024;
 
 /** The pointers a failed launch/attach returns to the caller (issue #493 / #551). */
 export interface ProxyFailureDiagnostics {
@@ -36,7 +45,7 @@ export interface ProxyFailureDiagnostics {
  */
 export interface ProxyFailureLogDeps {
   logger: ILogger;
-  fileSystem: Pick<IFileSystem, 'pathExists' | 'readFile'>;
+  fileSystem: Pick<IFileSystem, 'readFile'>;
 }
 
 /** The two operations that can fail this way, named as they appear in the log. */
@@ -52,13 +61,23 @@ export function collectProxyFailureDiagnostics(
   error: unknown
 ): ProxyFailureDiagnostics {
   const diagnostics: ProxyFailureDiagnostics = {};
-  const initProgress = (error as { initProgress?: ProxyInitProgress } | null)?.initProgress;
 
-  if (initProgress) {
-    diagnostics.initProgress = initProgress;
-  }
+  // The log path comes from the session, not from the error, so it is derived
+  // FIRST: it is the pointer that survives a hostile error object, and losing
+  // it would drop `data` from the tool result entirely.
   if (session.logDir) {
     diagnostics.proxyLogPath = proxyLogPathFor(session.logDir, session.id);
+  }
+
+  // The error, by contrast, is a value that has already misbehaved once — a
+  // throwing getter or a Proxy trap here must cost only this one field.
+  try {
+    const initProgress = (error as { initProgress?: ProxyInitProgress } | null)?.initProgress;
+    if (initProgress) {
+      diagnostics.initProgress = initProgress;
+    }
+  } catch {
+    // Unreadable init progress: report the pointer we do have.
   }
 
   return diagnostics;
@@ -67,30 +86,41 @@ export function collectProxyFailureDiagnostics(
 /**
  * Read the last `tailLineCount` lines of the proxy log, if there is one.
  *
- * Never throws: a failure to read the log is itself reported *as* the tail, so
- * the setup error that sent us here still reaches the log intact.
+ * Reads straight through rather than asking `pathExists` first: the proxy is
+ * still writing (and may rotate) this file, so an exists-then-read pair can
+ * report "no log" for a file that appeared a millisecond later, and spends a
+ * second syscall to do it. `ENOENT` — the answer that check was buying — is
+ * simply the "no log yet" case.
+ *
+ * The tail goes through `sanitizeStderrTail`, which redacts secret-shaped lines
+ * (issue #237's corpus) as well as tailing. The proxy log carries raw adapter
+ * argv and DAP `output` bodies, so an attach token or an env secret can be
+ * sitting in the very lines a failure makes interesting — copying those
+ * un-redacted into the server log is exactly the leak the shared sanitizer
+ * exists to prevent.
+ *
+ * Never throws: any other read failure is reported *as* the tail, so the setup
+ * error that sent us here still reaches the log intact.
  */
 export async function readProxyLogTail(
-  fileSystem: Pick<IFileSystem, 'pathExists' | 'readFile'>,
+  fileSystem: Pick<IFileSystem, 'readFile'>,
   proxyLogPath: string | undefined,
   tailLineCount: number = PROXY_LOG_TAIL_LINES
 ): Promise<string | undefined> {
+  if (!proxyLogPath) {
+    return undefined;
+  }
   try {
-    if (!proxyLogPath) {
-      return undefined;
-    }
-    const logExists = await fileSystem.pathExists(proxyLogPath);
-    if (!logExists) {
-      return undefined;
-    }
     const logContent = await fileSystem.readFile(proxyLogPath, 'utf-8');
-    const logLines = logContent.split(/\r?\n/);
-    const startIndex = Math.max(0, logLines.length - tailLineCount);
-    return logLines.slice(startIndex).join('\n');
+    return sanitizeStderrTail(logContent, {
+      maxLines: tailLineCount,
+      maxChars: PROXY_LOG_TAIL_CHARS
+    });
   } catch (logReadError) {
-    return `<<Failed to read proxy log: ${
-      logReadError instanceof Error ? logReadError.message : String(logReadError)
-    }>>`;
+    if ((logReadError as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return undefined;
+    }
+    return `<<Failed to read proxy log: ${getErrorMessage(logReadError)}>>`;
   }
 }
 
@@ -105,7 +135,7 @@ export function buildProxyFailureErrorDetails(
 ): Record<string, unknown> {
   const errorDetails: Record<string, unknown> = {
     type: error?.constructor?.name || 'Unknown',
-    message: error instanceof Error ? error.message : String(error),
+    message: getErrorMessage(error),
     stack: error instanceof Error ? error.stack : 'No stack available',
     code: (error as Record<string, unknown>)?.code,
     errno: (error as Record<string, unknown>)?.errno,
@@ -133,7 +163,7 @@ export function buildProxyFailureErrorDetails(
  */
 function describeErrorSafely(error: unknown): string {
   try {
-    return error instanceof Error ? error.message : String(error);
+    return getErrorMessage(error);
   } catch {
     return '<<error could not be described>>';
   }

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -23,6 +23,7 @@ import { ManagedSession, ToolchainValidationState } from './session-store.js';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import path from 'path';
 import { ProxyConfig } from '../proxy/proxy-config.js';
+import { proxyLogPathFor } from '../proxy/proxy-log-path.js';
 import { MIRROR_EXPOSE_COMMAND, MIRROR_UNEXPOSE_COMMAND } from '../proxy/dap-proxy-interfaces.js';
 import { ErrorMessages, ProxyInitProgress } from '../utils/error-messages.js';
 import { checkLaunchToolchain } from '../utils/language-availability.js';
@@ -3124,7 +3125,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       diagnostics.initProgress = initProgress;
     }
     if (session.logDir) {
-      diagnostics.proxyLogPath = path.join(session.logDir, `proxy-${session.id}.log`);
+      diagnostics.proxyLogPath = proxyLogPathFor(session.logDir, session.id);
     }
 
     return diagnostics;

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -216,10 +216,10 @@ export abstract class SessionManagerOperations extends SessionManagerData {
 
     // The lease owns the adapter — and its registry slot — until a ProxyManager
     // takes it, so every throw in the body lands in one `finally` that gives the
-    // slot back. The boolean this replaces had to be kept in sync by hand, and
-    // any throw site added outside its window leaked a slot until launches of
-    // that language failed with "Maximum adapter instances (10) reached"
-    // (issue #552 review, issue #561).
+    // slot back. Same behaviour as the `adapterOwnedByProxy` boolean it replaces
+    // (#557); the difference is that the boolean had to be assigned at one point
+    // and consulted from one catch, so the next throw site added outside that
+    // window would have silently reopened the leak.
     const lease = await AdapterLease.acquire(
       this.adapterRegistry,
       session.language,

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -23,9 +23,8 @@ import { ManagedSession, ToolchainValidationState } from './session-store.js';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import path from 'path';
 import { ProxyConfig } from '../proxy/proxy-config.js';
-import { proxyLogPathFor } from '../proxy/proxy-log-path.js';
 import { MIRROR_EXPOSE_COMMAND, MIRROR_UNEXPOSE_COMMAND } from '../proxy/dap-proxy-interfaces.js';
-import { ErrorMessages, ProxyInitProgress } from '../utils/error-messages.js';
+import { ErrorMessages } from '../utils/error-messages.js';
 import { checkLaunchToolchain } from '../utils/language-availability.js';
 import { didYouMean } from '../utils/did-you-mean.js';
 import { resolveStatement } from '../utils/breakpoint-resolver.js';
@@ -33,6 +32,7 @@ import { normalizeBreakpointMessage } from '../utils/breakpoint-message.js';
 import { consumeChildSourced } from '../utils/child-origin-events.js';
 import { SessionManagerData } from './session-manager-data.js';
 import { AdapterLease } from '../adapters/adapter-lease.js';
+import { logProxyFailure } from './launch/proxy-failure-diagnostics.js';
 import { CustomLaunchRequestArguments, DebugResult } from './session-manager-core.js';
 import {
   AdapterConfig,
@@ -1167,56 +1167,13 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         },
       };
     } catch (error) {
-      const diagnosticData = this.collectProxyFailureDiagnostics(session, error);
-      const { initProgress, proxyLogPath } = diagnosticData;
-
-      // Attempt to capture proxy log tail for debugging initialization failures
-      let proxyLogTail: string | undefined;
-      try {
-        if (proxyLogPath) {
-          const logExists = await this.fileSystem.pathExists(proxyLogPath);
-          if (logExists) {
-            const logContent = await this.fileSystem.readFile(proxyLogPath, 'utf-8');
-            const logLines = logContent.split(/\r?\n/);
-            const tailLineCount = 80;
-            const startIndex = Math.max(0, logLines.length - tailLineCount);
-            proxyLogTail = logLines.slice(startIndex).join('\n');
-          }
-        }
-      } catch (logReadError) {
-        proxyLogTail = `<<Failed to read proxy log: ${
-          logReadError instanceof Error ? logReadError.message : String(logReadError)
-        }>>`;
-      }
-
-      // Comprehensive error capture for debugging Windows CI issues
-      const errorDetails: Record<string, unknown> = {
-        type: error?.constructor?.name || 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : 'No stack available',
-        code: (error as Record<string, unknown>)?.code,
-        errno: (error as Record<string, unknown>)?.errno,
-        syscall: (error as Record<string, unknown>)?.syscall,
-        path: (error as Record<string, unknown>)?.path,
-        toString: error?.toString ? error.toString() : 'No toString',
-        initProgress,
-        proxyLogPath,
-        proxyLogTail
-      };
-
-      // Try to capture raw error object
-      try {
-        errorDetails.raw = JSON.stringify(error);
-      } catch {
-        errorDetails.raw = 'Error not JSON serializable';
-      }
-
-      // Log comprehensive error details
-      this.logger.error(
-        `[SessionManager] Detailed error in startDebugging for session ${sessionId}:`,
-        errorDetails
+      const diagnosticData = await logProxyFailure(
+        { logger: this.logger, fileSystem: this.fileSystem },
+        session,
+        error,
+        'startDebugging'
       );
-      
+
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       const toolchainValidation =
@@ -3248,10 +3205,18 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       this._updateSessionState(session, SessionState.ERROR);
 
       // Surface the same structured diagnostics the launch path returns
-      // (issue #551). Teardown only clears the proxy handle; logDir and the
-      // error's initProgress survive it, so this reads after the teardown
-      // and can never keep it from running.
-      const diagnosticData = this.collectProxyFailureDiagnostics(session, error);
+      // (issue #551) and log the same full failure record it logs, proxy-log
+      // tail included (issue #561) — an attach that dies during proxy
+      // initialization used to leave the adapter's own complaint unreadable.
+      // Teardown only clears the proxy handle; logDir and the error's
+      // initProgress survive it, so this reads after the teardown and can
+      // never keep it from running.
+      const diagnosticData = await logProxyFailure(
+        { logger: this.logger, fileSystem: this.fileSystem },
+        session,
+        error,
+        'attachToProcess'
+      );
       const message = error instanceof Error ? error.message : String(error);
       return {
         success: false,
@@ -3260,28 +3225,6 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         ...(Object.keys(diagnosticData).length > 0 ? { data: diagnosticData } : {})
       };
     }
-  }
-
-  /**
-   * Pointers to proxy initialization diagnostics for a failed launch/attach
-   * (issue #493 / #551): which init stage stalled (from the timeout error) and
-   * where the proxy log for the session's current run lives.
-   */
-  private collectProxyFailureDiagnostics(
-    session: ManagedSession,
-    error: unknown
-  ): { initProgress?: ProxyInitProgress; proxyLogPath?: string } {
-    const diagnostics: { initProgress?: ProxyInitProgress; proxyLogPath?: string } = {};
-    const initProgress = (error as { initProgress?: ProxyInitProgress } | null)?.initProgress;
-
-    if (initProgress) {
-      diagnostics.initProgress = initProgress;
-    }
-    if (session.logDir) {
-      diagnostics.proxyLogPath = proxyLogPathFor(session.logDir, session.id);
-    }
-
-    return diagnostics;
   }
 
   /**

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -32,6 +32,7 @@ import { resolveStatement } from '../utils/breakpoint-resolver.js';
 import { normalizeBreakpointMessage } from '../utils/breakpoint-message.js';
 import { consumeChildSourced } from '../utils/child-origin-events.js';
 import { SessionManagerData } from './session-manager-data.js';
+import { AdapterLease } from '../adapters/adapter-lease.js';
 import { CustomLaunchRequestArguments, DebugResult } from './session-manager-core.js';
 import {
   AdapterConfig,
@@ -107,6 +108,45 @@ export interface UnexposeSessionResult {
 }
 
 /**
+ * The seven positional arguments `startProxyManager` has always taken, named.
+ * They are threaded through the launch preparation unchanged; giving them a
+ * type is what lets the preparation split into steps without each step growing
+ * its own six-argument signature.
+ */
+export interface ProxyLaunchRequest {
+  scriptPath: string;
+  scriptArgs?: string[];
+  dapLaunchArgs?: Partial<CustomLaunchRequestArguments>;
+  dryRunSpawn?: boolean;
+  adapterLaunchConfig?: Record<string, unknown>;
+  breakOnExceptions?: ExceptionBreakMode;
+}
+
+/**
+ * What a launch computes before it has an adapter — the inputs every later
+ * step reads. `adapterConfig` is handed to the registry to create the adapter
+ * and then updated in place with the resolved executable path, exactly as the
+ * single long method did.
+ */
+export interface LaunchInputs {
+  sessionLogDir: string;
+  adapterPort: number;
+  initialBreakpoints: NonNullable<ProxyConfig['initialBreakpoints']>;
+  initialFunctionBreakpoints: NonNullable<ProxyConfig['initialFunctionBreakpoints']>;
+  effectiveLaunchArgs: Partial<CustomLaunchRequestArguments>;
+  isAttachMode: boolean;
+  genericLaunchConfig: Record<string, unknown>;
+  adapterExtraKeys: string[];
+  adapterConfig: AdapterConfig;
+}
+
+/** The two products of adapter-side preparation: what to start, and what to return. */
+export interface AdapterLaunchPlan {
+  launchConfig: LanguageSpecificLaunchConfig;
+  proxyConfig: ProxyConfig;
+}
+
+/**
  * Debug operations functionality for session management
  */
 export abstract class SessionManagerOperations extends SessionManagerData {
@@ -158,12 +198,67 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     adapterLaunchConfig?: Record<string, unknown>,
     breakOnExceptions?: ExceptionBreakMode
   ): Promise<LanguageSpecificLaunchConfig> {
-    const sessionId = session.id;
-    
+    const request: ProxyLaunchRequest = {
+      scriptPath,
+      scriptArgs,
+      dapLaunchArgs,
+      dryRunSpawn,
+      adapterLaunchConfig,
+      breakOnExceptions
+    };
+
     // Log entrance for Windows CI debugging
     this.logger.info(
-      `[SessionManager] Entering startProxyManager for session ${sessionId}, dryRunSpawn: ${dryRunSpawn}, scriptPath: ${scriptPath}`
+      `[SessionManager] Entering startProxyManager for session ${session.id}, dryRunSpawn: ${dryRunSpawn}, scriptPath: ${scriptPath}`
     );
+
+    const inputs = await this.prepareLaunchInputs(session, request);
+
+    // The lease owns the adapter — and its registry slot — until a ProxyManager
+    // takes it, so every throw in the body lands in one `finally` that gives the
+    // slot back. The boolean this replaces had to be kept in sync by hand, and
+    // any throw site added outside its window leaked a slot until launches of
+    // that language failed with "Maximum adapter instances (10) reached"
+    // (issue #552 review, issue #561).
+    const lease = await AdapterLease.acquire(
+      this.adapterRegistry,
+      session.language,
+      inputs.adapterConfig,
+      this.logger
+    );
+    try {
+      const plan = await this.prepareAdapterLaunch(session, lease.adapter, inputs, request);
+
+      // Create and start ProxyManager with the adapter. Ownership moves here:
+      // ProxyManager.cleanup() becomes the disposer and release() below is a
+      // no-op.
+      const proxyManager = lease.transferTo(this.proxyManagerFactory);
+      session.proxyManager = proxyManager;
+
+      // Set up event handlers
+      this.setupProxyEventHandlers(session, proxyManager, inputs.effectiveLaunchArgs);
+
+      // Start the proxy
+      await proxyManager.start(plan.proxyConfig);
+
+      return plan.launchConfig;
+    } finally {
+      await lease.release();
+    }
+  }
+
+  /**
+   * Everything the launch needs before an adapter exists: this run's log
+   * directory, a free adapter port, the breakpoint snapshots, and the generic
+   * launch configuration the adapter will transform. Nothing here allocates a
+   * registry slot, so a failure needs no cleanup.
+   */
+  private async prepareLaunchInputs(
+    session: ManagedSession,
+    request: ProxyLaunchRequest
+  ): Promise<LaunchInputs> {
+    const sessionId = session.id;
+    const { scriptPath, scriptArgs, dapLaunchArgs, adapterLaunchConfig } = request;
 
     // Create session log directory
     const sessionLogDir = path.join(this.logDirBase, sessionId, `run-${Date.now()}`);
@@ -277,245 +372,303 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       attachMode: isAttachMode,
     };
 
-    const adapter = await this.adapterRegistry.create(session.language, adapterConfig);
+    return {
+      sessionLogDir,
+      adapterPort,
+      initialBreakpoints,
+      initialFunctionBreakpoints,
+      effectiveLaunchArgs,
+      isAttachMode,
+      genericLaunchConfig,
+      adapterExtraKeys,
+      adapterConfig
+    };
+  }
 
-    // Until session.proxyManager owns the adapter, a throw below must release
-    // its registry slot (see the catch at the end of this method).
-    let adapterOwnedByProxy = false;
+  /**
+   * Everything that needs the adapter, in the order the adapters depend on:
+   * transform the configuration, record which attach keys the transform
+   * dropped, settle the toolchain verdict, resolve the executable, then
+   * assemble the proxy configuration. Runs inside the lease, so any step here
+   * may throw without stranding the adapter's registry slot.
+   */
+  private async prepareAdapterLaunch(
+    session: ManagedSession,
+    adapter: IDebugAdapter,
+    inputs: LaunchInputs,
+    request: ProxyLaunchRequest
+  ): Promise<AdapterLaunchPlan> {
+    const transformedLaunchConfig = await this.transformAdapterConfig(session, adapter, inputs);
+
+    this.recordAttachKeyDiff(session, adapter, inputs, transformedLaunchConfig);
+
+    this.applyToolchainValidation(session.id, adapter);
+
+    const resolvedExecutablePath = await this.resolveAdapterExecutable(session, adapter, inputs);
+
+    // Update adapter config with resolved executable path
+    inputs.adapterConfig.executablePath = resolvedExecutablePath;
+
+    return this.buildAdapterLaunchPlan(
+      session,
+      adapter,
+      inputs,
+      request,
+      transformedLaunchConfig,
+      resolvedExecutablePath
+    );
+  }
+
+  /**
+   * Turn the generic configuration into the adapter's language-specific form.
+   */
+  private async transformAdapterConfig(
+    session: ManagedSession,
+    adapter: IDebugAdapter,
+    inputs: LaunchInputs
+  ): Promise<LanguageSpecificLaunchConfig> {
+    const { isAttachMode, genericLaunchConfig } = inputs;
     try {
-      // isAttachMode already detected above
-
-      let transformedLaunchConfig: LanguageSpecificLaunchConfig;
-      try {
-        if (isAttachMode && adapter.supportsAttach && adapter.supportsAttach() && adapter.transformAttachConfig) {
-          // Call transformAttachConfig for attach operations
-          transformedLaunchConfig = adapter.transformAttachConfig(genericLaunchConfig as GenericAttachConfig);
-          this.logger.info(`[SessionManager] Using attach config for ${session.language}`);
-        } else {
-          // Call transformLaunchConfig for launch operations
-          transformedLaunchConfig = await adapter.transformLaunchConfig(genericLaunchConfig as GenericLaunchConfig);
-        }
-      } catch (error) {
-        this.logger.warn(
-          `[SessionManager] transform${isAttachMode ? 'Attach' : 'Launch'}Config failed for ${session.language}: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
-        // A transform can perform required work (such as compiling a C++ source
-        // file) or reject invalid attach arguments. Forwarding the generic
-        // configuration after that failure starts the adapter with inputs known
-        // to be wrong and hides the actionable error (issue #552). A toolchain
-        // verdict recorded before the rejection (CPP/RUST_MSVC_BEHAVIOR=error
-        // rejects from inside the transform) still becomes the structured
-        // MSVC_TOOLCHAIN_DETECTED sentinel rather than a bare error.
-        this.applyToolchainValidation(sessionId, adapter);
-        throw error;
+      if (isAttachMode && adapter.supportsAttach && adapter.supportsAttach() && adapter.transformAttachConfig) {
+        // Call transformAttachConfig for attach operations
+        const transformedAttachConfig = adapter.transformAttachConfig(genericLaunchConfig as GenericAttachConfig);
+        this.logger.info(`[SessionManager] Using attach config for ${session.language}`);
+        return transformedAttachConfig;
       }
-
-      // Attach transforms may strip adapterConfig keys (issue #450) — record the
-      // drops so attachToProcess can warn the caller. Keys the transform kept but
-      // the adapter doesn't declare in supportedAttachKeys are forwarded to the
-      // debug adapter as-is, and recorded separately so the caller learns they
-      // weren't recognized (issue #466) — never deleted, so upstream debugger
-      // capabilities stay reachable without an mcp-debugger release. Both records
-      // are assigned unconditionally so a prior attach's record never leaks.
-      if (isAttachMode) {
-        const supportedKeys = adapter.supportedAttachKeys;
-        // A typo of a supported key is the likeliest caller mistake — annotate
-        // both buckets with an edit-distance suggestion when a list is declared.
-        const describeKey = (key: string): string => {
-          const suggestion = supportedKeys ? didYouMean(key, supportedKeys) : null;
-          return suggestion ? `${key} (did you mean ${suggestion}?)` : key;
-        };
-
-        const dropped: string[] = [];
-        const forwardedUnknown: string[] = [];
-        for (const key of adapterExtraKeys) {
-          if (!(key in transformedLaunchConfig)) {
-            dropped.push(describeKey(key));
-          } else if (supportedKeys && !supportedKeys.includes(key)) {
-            forwardedUnknown.push(describeKey(key));
-          }
-        }
-
-        if (dropped.length > 0) {
-          this.logger.warn(
-            `[SessionManager] ${session.language} attach transform dropped adapterConfig key(s) for session ${sessionId}: ${dropped.join(', ')}`
-          );
-        }
-        if (forwardedUnknown.length > 0) {
-          this.logger.warn(
-            `[SessionManager] ${session.language} attach forwarded unrecognized adapterConfig key(s) for session ${sessionId}: ${forwardedUnknown.join(', ')}`
-          );
-        }
-        session.attachDroppedConfigKeys = dropped.length > 0 ? dropped : undefined;
-        session.attachForwardedUnknownConfigKeys = forwardedUnknown.length > 0 ? forwardedUnknown : undefined;
-      }
-
-      this.applyToolchainValidation(sessionId, adapter);
-
-      // Use the adapter to resolve the executable path. Direct-connect attach
-      // sessions (e.g. Ruby/rdbg, Python/debugpy) spawn no local process, so no
-      // toolchain lookup runs — a nominal, unverified name keeps the proxy init
-      // payload (which requires a non-empty string) satisfied (issue #331).
-      const isDirectConnectAttach = isAttachMode && adapter.usesDirectConnectForAttach?.() === true;
-
-      let resolvedExecutablePath: string;
-      if (isDirectConnectAttach) {
-        resolvedExecutablePath =
-          session.executablePath || adapter.getDefaultExecutableName?.() || session.language;
-        this.logger.info(
-          `[SessionManager] Direct-connect attach for ${session.language}; skipping executable resolution`
-        );
-      } else {
-        try {
-          resolvedExecutablePath = await adapter.resolveExecutablePath(session.executablePath);
-          this.logger.info(`[SessionManager] Adapter resolved executable path: ${resolvedExecutablePath}`);
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          this.logger.error(
-            `[SessionManager] Failed to resolve executable for ${session.language}:`,
-            msg
-          );
-
-          // Convert to appropriate error type based on language
-          if (session.language === 'python' && msg.includes('not found')) {
-            throw new PythonNotFoundError(session.executablePath || 'python');
-          }
-
-          // On launch, adapters with an attach mode may still work without the
-          // local toolchain — point the user at attach_to_process (issue #331)
-          const attachHint =
-            !isAttachMode && adapter.supportsAttach?.()
-              ? ` ${ErrorMessages.attachMayStillWork(session.language)}`
-              : '';
-
-          throw new DebugSessionCreationError(
-            `Failed to resolve ${session.language} executable: ${msg}${attachHint}`,
-            error instanceof Error ? error : undefined
-          );
-        }
-      }
-
-      // Update adapter config with resolved executable path
-      adapterConfig.executablePath = resolvedExecutablePath;
-
-      // Build adapter command using the adapter. Direct-connect attach sessions
-      // (e.g. Ruby/rdbg) have no adapter process to spawn, so no command is built;
-      // the adapter policy connects straight to the attach host/port instead.
-      const adapterCommand =
-        isAttachMode && adapter.usesDirectConnectForAttach?.()
-          ? undefined
-          : adapter.buildAdapterCommand(adapterConfig);
-
-      const launchConfigData: LanguageSpecificLaunchConfig = { ...transformedLaunchConfig };
-
-      const stopOnEntryProvided = typeof dapLaunchArgs?.stopOnEntry === 'boolean';
-
-      // Let adapter policy override stopOnEntry default when user hasn't specified it.
-      // E.g., Go/Delve needs stopOnEntry=false to avoid "unknown goroutine" issues.
-      if (!stopOnEntryProvided) {
-        const adapterPolicy = this.selectPolicy(session.language);
-        const policyDefaults = adapterPolicy.getInitializationBehavior?.();
-        /* istanbul ignore next -- adapter-specific: Go/Delve stopOnEntry override */
-        if (typeof policyDefaults?.defaultStopOnEntry === 'boolean') {
-          launchConfigData.stopOnEntry = policyDefaults.defaultStopOnEntry;
-        }
-      }
-
-      this.logger.info(
-        `[SessionManager] Launch config stopOnEntry adjustments for ${sessionId}: base=${String(
-          transformedLaunchConfig.stopOnEntry
-        )}, final=${String(launchConfigData.stopOnEntry)}, userProvided=${String(
-          dapLaunchArgs?.stopOnEntry
-        )}`
-      );
-
-      const stopOnEntryFlag =
-        typeof launchConfigData?.stopOnEntry === 'boolean'
-          ? launchConfigData.stopOnEntry
-          : effectiveLaunchArgs.stopOnEntry;
-
-      const justMyCodeFlag =
-        typeof launchConfigData?.justMyCode === 'boolean'
-          ? launchConfigData.justMyCode
-          : effectiveLaunchArgs.justMyCode;
-
-      // Create ProxyConfig
-      const programFromLaunchConfig =
-        typeof launchConfigData?.program === 'string' && launchConfigData.program.length > 0
-          ? launchConfigData.program
-          : scriptPath;
-
-      const argsFromLaunchConfig = Array.isArray(launchConfigData?.args)
-        ? (launchConfigData!.args as unknown[]).filter((arg): arg is string => typeof arg === 'string')
-        : Array.isArray(scriptArgs)
-          ? [...scriptArgs]
-          : [];
-
-      const normalizedScriptArgs = argsFromLaunchConfig.length > 0 ? argsFromLaunchConfig : undefined;
-
-      if (initialBreakpoints.length) {
-        this.logger.info(
-          `[SessionManager] Initial breakpoints for ${sessionId}:`,
-          initialBreakpoints.map(bp => ({ file: bp.file, line: bp.line }))
-        );
-      }
-
-      const proxyConfig: ProxyConfig = {
-        sessionId,
-        language: session.language, // Add language from session
-        executablePath: resolvedExecutablePath,
-        adapterHost: '127.0.0.1',
-        adapterPort,
-        logDir: sessionLogDir,
-        scriptPath: programFromLaunchConfig,
-        scriptArgs: normalizedScriptArgs,
-        stopOnEntry: stopOnEntryFlag,
-        justMyCode: justMyCodeFlag,
-        initialBreakpoints,
-        initialFunctionBreakpoints,
-        dryRunSpawn: dryRunSpawn === true,
-        // ILogger doesn't declare level, but the injected logger is the winston
-        // instance whose level already resolves CLI --log-level and
-        // DEBUG_MCP_LOG_LEVEL (issue #403); mocks without it fall back to the
-        // worker's legacy default.
-        logLevel: (this.logger as { level?: string }).level,
-        breakOnExceptions,
-        launchConfig: launchConfigData,
-        adapterCommand, // Pass the adapter command
-        attachMode: isAttachMode,
-      };
-
-      // Create and start ProxyManager with the adapter
-      const proxyManager = this.proxyManagerFactory.create(adapter);
-      session.proxyManager = proxyManager;
-      adapterOwnedByProxy = true;
-
-      // Set up event handlers
-      this.setupProxyEventHandlers(session, proxyManager, effectiveLaunchArgs);
-
-      // Start the proxy
-      await proxyManager.start(proxyConfig);
-
-      return launchConfigData;
+      // Call transformLaunchConfig for launch operations
+      return await adapter.transformLaunchConfig(genericLaunchConfig as GenericLaunchConfig);
     } catch (error) {
-      // ProxyManager.cleanup() is the only caller of adapter.dispose(), so a
-      // throw before session.proxyManager took ownership — a rejected
-      // transform (issue #552), the MSVC sentinel, an unresolved executable —
-      // would otherwise strand the registry slot until "Maximum adapter
-      // instances reached". Same duck-typed guard as ProxyManager.cleanup().
-      if (!adapterOwnedByProxy && typeof adapter.dispose === 'function') {
-        await adapter.dispose().catch((disposeError: unknown) => {
-          this.logger.warn(
-            `[SessionManager] Failed to dispose adapter after launch setup error for session ${sessionId}: ${
-              disposeError instanceof Error ? disposeError.message : String(disposeError)
-            }`
-          );
-        });
-      }
+      this.logger.warn(
+        `[SessionManager] transform${isAttachMode ? 'Attach' : 'Launch'}Config failed for ${session.language}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      // A transform can perform required work (such as compiling a C++ source
+      // file) or reject invalid attach arguments. Forwarding the generic
+      // configuration after that failure starts the adapter with inputs known
+      // to be wrong and hides the actionable error (issue #552). A toolchain
+      // verdict recorded before the rejection (CPP/RUST_MSVC_BEHAVIOR=error
+      // rejects from inside the transform) still becomes the structured
+      // MSVC_TOOLCHAIN_DETECTED sentinel rather than a bare error.
+      this.applyToolchainValidation(session.id, adapter);
       throw error;
     }
+  }
+
+  /**
+   * Attach transforms may strip adapterConfig keys (issue #450) — record the
+   * drops so attachToProcess can warn the caller. Keys the transform kept but
+   * the adapter doesn't declare in supportedAttachKeys are forwarded to the
+   * debug adapter as-is, and recorded separately so the caller learns they
+   * weren't recognized (issue #466) — never deleted, so upstream debugger
+   * capabilities stay reachable without an mcp-debugger release. Both records
+   * are assigned unconditionally so a prior attach's record never leaks.
+   */
+  private recordAttachKeyDiff(
+    session: ManagedSession,
+    adapter: IDebugAdapter,
+    inputs: LaunchInputs,
+    transformedLaunchConfig: LanguageSpecificLaunchConfig
+  ): void {
+    if (!inputs.isAttachMode) {
+      return;
+    }
+    const sessionId = session.id;
+    const supportedKeys = adapter.supportedAttachKeys;
+    // A typo of a supported key is the likeliest caller mistake — annotate
+    // both buckets with an edit-distance suggestion when a list is declared.
+    const describeKey = (key: string): string => {
+      const suggestion = supportedKeys ? didYouMean(key, supportedKeys) : null;
+      return suggestion ? `${key} (did you mean ${suggestion}?)` : key;
+    };
+
+    const dropped: string[] = [];
+    const forwardedUnknown: string[] = [];
+    for (const key of inputs.adapterExtraKeys) {
+      if (!(key in transformedLaunchConfig)) {
+        dropped.push(describeKey(key));
+      } else if (supportedKeys && !supportedKeys.includes(key)) {
+        forwardedUnknown.push(describeKey(key));
+      }
+    }
+
+    if (dropped.length > 0) {
+      this.logger.warn(
+        `[SessionManager] ${session.language} attach transform dropped adapterConfig key(s) for session ${sessionId}: ${dropped.join(', ')}`
+      );
+    }
+    if (forwardedUnknown.length > 0) {
+      this.logger.warn(
+        `[SessionManager] ${session.language} attach forwarded unrecognized adapterConfig key(s) for session ${sessionId}: ${forwardedUnknown.join(', ')}`
+      );
+    }
+    session.attachDroppedConfigKeys = dropped.length > 0 ? dropped : undefined;
+    session.attachForwardedUnknownConfigKeys = forwardedUnknown.length > 0 ? forwardedUnknown : undefined;
+  }
+
+  /**
+   * Use the adapter to resolve the executable path. Direct-connect attach
+   * sessions (e.g. Ruby/rdbg, Python/debugpy) spawn no local process, so no
+   * toolchain lookup runs — a nominal, unverified name keeps the proxy init
+   * payload (which requires a non-empty string) satisfied (issue #331).
+   */
+  private async resolveAdapterExecutable(
+    session: ManagedSession,
+    adapter: IDebugAdapter,
+    inputs: LaunchInputs
+  ): Promise<string> {
+    const isDirectConnectAttach = inputs.isAttachMode && adapter.usesDirectConnectForAttach?.() === true;
+
+    if (isDirectConnectAttach) {
+      const resolvedExecutablePath =
+        session.executablePath || adapter.getDefaultExecutableName?.() || session.language;
+      this.logger.info(
+        `[SessionManager] Direct-connect attach for ${session.language}; skipping executable resolution`
+      );
+      return resolvedExecutablePath;
+    }
+
+    try {
+      const resolvedExecutablePath = await adapter.resolveExecutablePath(session.executablePath);
+      this.logger.info(`[SessionManager] Adapter resolved executable path: ${resolvedExecutablePath}`);
+      return resolvedExecutablePath;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `[SessionManager] Failed to resolve executable for ${session.language}:`,
+        msg
+      );
+
+      // Convert to appropriate error type based on language
+      if (session.language === 'python' && msg.includes('not found')) {
+        throw new PythonNotFoundError(session.executablePath || 'python');
+      }
+
+      // On launch, adapters with an attach mode may still work without the
+      // local toolchain — point the user at attach_to_process (issue #331)
+      const attachHint =
+        !inputs.isAttachMode && adapter.supportsAttach?.()
+          ? ` ${ErrorMessages.attachMayStillWork(session.language)}`
+          : '';
+
+      throw new DebugSessionCreationError(
+        `Failed to resolve ${session.language} executable: ${msg}${attachHint}`,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Assemble the adapter spawn command, the final launch configuration and the
+   * ProxyConfig the worker is started with.
+   */
+  private buildAdapterLaunchPlan(
+    session: ManagedSession,
+    adapter: IDebugAdapter,
+    inputs: LaunchInputs,
+    request: ProxyLaunchRequest,
+    transformedLaunchConfig: LanguageSpecificLaunchConfig,
+    resolvedExecutablePath: string
+  ): AdapterLaunchPlan {
+    const sessionId = session.id;
+    const { scriptPath, scriptArgs, dapLaunchArgs, dryRunSpawn, breakOnExceptions } = request;
+    const {
+      sessionLogDir,
+      adapterPort,
+      initialBreakpoints,
+      initialFunctionBreakpoints,
+      effectiveLaunchArgs,
+      isAttachMode
+    } = inputs;
+
+    // Build adapter command using the adapter. Direct-connect attach sessions
+    // (e.g. Ruby/rdbg) have no adapter process to spawn, so no command is built;
+    // the adapter policy connects straight to the attach host/port instead.
+    const adapterCommand =
+      isAttachMode && adapter.usesDirectConnectForAttach?.()
+        ? undefined
+        : adapter.buildAdapterCommand(inputs.adapterConfig);
+
+    const launchConfigData: LanguageSpecificLaunchConfig = { ...transformedLaunchConfig };
+
+    const stopOnEntryProvided = typeof dapLaunchArgs?.stopOnEntry === 'boolean';
+
+    // Let adapter policy override stopOnEntry default when user hasn't specified it.
+    // E.g., Go/Delve needs stopOnEntry=false to avoid "unknown goroutine" issues.
+    if (!stopOnEntryProvided) {
+      const adapterPolicy = this.selectPolicy(session.language);
+      const policyDefaults = adapterPolicy.getInitializationBehavior?.();
+      /* istanbul ignore next -- adapter-specific: Go/Delve stopOnEntry override */
+      if (typeof policyDefaults?.defaultStopOnEntry === 'boolean') {
+        launchConfigData.stopOnEntry = policyDefaults.defaultStopOnEntry;
+      }
+    }
+
+    this.logger.info(
+      `[SessionManager] Launch config stopOnEntry adjustments for ${sessionId}: base=${String(
+        transformedLaunchConfig.stopOnEntry
+      )}, final=${String(launchConfigData.stopOnEntry)}, userProvided=${String(
+        dapLaunchArgs?.stopOnEntry
+      )}`
+    );
+
+    const stopOnEntryFlag =
+      typeof launchConfigData?.stopOnEntry === 'boolean'
+        ? launchConfigData.stopOnEntry
+        : effectiveLaunchArgs.stopOnEntry;
+
+    const justMyCodeFlag =
+      typeof launchConfigData?.justMyCode === 'boolean'
+        ? launchConfigData.justMyCode
+        : effectiveLaunchArgs.justMyCode;
+
+    // Create ProxyConfig
+    const programFromLaunchConfig =
+      typeof launchConfigData?.program === 'string' && launchConfigData.program.length > 0
+        ? launchConfigData.program
+        : scriptPath;
+
+    const argsFromLaunchConfig = Array.isArray(launchConfigData?.args)
+      ? (launchConfigData!.args as unknown[]).filter((arg): arg is string => typeof arg === 'string')
+      : Array.isArray(scriptArgs)
+        ? [...scriptArgs]
+        : [];
+
+    const normalizedScriptArgs = argsFromLaunchConfig.length > 0 ? argsFromLaunchConfig : undefined;
+
+    if (initialBreakpoints.length) {
+      this.logger.info(
+        `[SessionManager] Initial breakpoints for ${sessionId}:`,
+        initialBreakpoints.map(bp => ({ file: bp.file, line: bp.line }))
+      );
+    }
+
+    const proxyConfig: ProxyConfig = {
+      sessionId,
+      language: session.language, // Add language from session
+      executablePath: resolvedExecutablePath,
+      adapterHost: '127.0.0.1',
+      adapterPort,
+      logDir: sessionLogDir,
+      scriptPath: programFromLaunchConfig,
+      scriptArgs: normalizedScriptArgs,
+      stopOnEntry: stopOnEntryFlag,
+      justMyCode: justMyCodeFlag,
+      initialBreakpoints,
+      initialFunctionBreakpoints,
+      dryRunSpawn: dryRunSpawn === true,
+      // ILogger doesn't declare level, but the injected logger is the winston
+      // instance whose level already resolves CLI --log-level and
+      // DEBUG_MCP_LOG_LEVEL (issue #403); mocks without it fall back to the
+      // worker's legacy default.
+      logLevel: (this.logger as { level?: string }).level,
+      breakOnExceptions,
+      launchConfig: launchConfigData,
+      adapterCommand, // Pass the adapter command
+      attachMode: isAttachMode,
+    };
+
+    return { launchConfig: launchConfigData, proxyConfig };
   }
 
   /**

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -113,7 +113,7 @@ export interface UnexposeSessionResult {
  * type is what lets the preparation split into steps without each step growing
  * its own six-argument signature.
  */
-export interface ProxyLaunchRequest {
+interface ProxyLaunchRequest {
   scriptPath: string;
   scriptArgs?: string[];
   dapLaunchArgs?: Partial<CustomLaunchRequestArguments>;
@@ -128,7 +128,7 @@ export interface ProxyLaunchRequest {
  * and then updated in place with the resolved executable path, exactly as the
  * single long method did.
  */
-export interface LaunchInputs {
+interface LaunchInputs {
   sessionLogDir: string;
   adapterPort: number;
   initialBreakpoints: NonNullable<ProxyConfig['initialBreakpoints']>;
@@ -141,7 +141,7 @@ export interface LaunchInputs {
 }
 
 /** The two products of adapter-side preparation: what to start, and what to return. */
-export interface AdapterLaunchPlan {
+interface AdapterLaunchPlan {
   launchConfig: LanguageSpecificLaunchConfig;
   proxyConfig: ProxyConfig;
 }
@@ -214,12 +214,15 @@ export abstract class SessionManagerOperations extends SessionManagerData {
 
     const inputs = await this.prepareLaunchInputs(session, request);
 
-    // The lease owns the adapter — and its registry slot — until a ProxyManager
-    // takes it, so every throw in the body lands in one `finally` that gives the
-    // slot back. Same behaviour as the `adapterOwnedByProxy` boolean it replaces
-    // (#557); the difference is that the boolean had to be assigned at one point
-    // and consulted from one catch, so the next throw site added outside that
-    // window would have silently reopened the leak.
+    // The lease owns the adapter until `transferTo` hands it to the ProxyManager:
+    // every throw before that point disposes it here, returning its registry
+    // slot. After the transfer the release is a no-op and the ProxyManager's
+    // teardown owns disposal — both callers' catches stop `session.proxyManager`,
+    // and `ProxyManager.cleanup()` disposes the adapter from there. Same
+    // behaviour as the `adapterOwnedByProxy` boolean it replaces (#557); the
+    // difference is that the boolean had to be assigned at one point and
+    // consulted from one catch, so the next throw site added outside that window
+    // would have silently reopened the leak.
     const lease = await AdapterLease.acquire(
       this.adapterRegistry,
       session.language,

--- a/tests/core/unit/session/launch/proxy-failure-diagnostics.test.ts
+++ b/tests/core/unit/session/launch/proxy-failure-diagnostics.test.ts
@@ -182,6 +182,57 @@ describe('logProxyFailure', () => {
     );
   });
 
+  it('survives an error object whose toString throws, rather than rejecting', async () => {
+    const logger = createLogger();
+    const fileSystem = createFileSystem();
+    // Both callers await this from inside a catch that is about to return
+    // {success:false}; a throw here would turn a reported failure into a
+    // rejection out of the tool call.
+    const hostile = {
+      get message(): string {
+        throw new Error('message getter exploded');
+      },
+      toString(): string {
+        throw new Error('toString exploded');
+      }
+    };
+
+    const diagnostics = await logProxyFailure(
+      { logger, fileSystem },
+      { id: 'sess-1', logDir: runDir },
+      hostile,
+      'attachToProcess'
+    );
+
+    // The pointers still reach the caller, and the log still names the failure.
+    expect(diagnostics).toEqual({ proxyLogPath });
+    expect(logger.error).toHaveBeenCalledWith(
+      '[SessionManager] Detailed error in attachToProcess for session sess-1:',
+      expect.objectContaining({
+        message: '<<error could not be described>>',
+        proxyLogPath,
+        diagnosticsUnavailable: expect.stringContaining('exploded')
+      })
+    );
+  });
+
+  it('survives a logger that throws, since there is nowhere left to report it', async () => {
+    const logger = createLogger();
+    const fileSystem = createFileSystem();
+    logger.error.mockImplementation(() => {
+      throw new Error('transport closed');
+    });
+
+    await expect(
+      logProxyFailure(
+        { logger, fileSystem },
+        { id: 'sess-1', logDir: runDir },
+        new Error('attach failed'),
+        'attachToProcess'
+      )
+    ).resolves.toEqual({ proxyLogPath });
+  });
+
   it('logs the proxy log tail but returns only the pointers', async () => {
     const logger = createLogger();
     const fileSystem = createFileSystem();

--- a/tests/core/unit/session/launch/proxy-failure-diagnostics.test.ts
+++ b/tests/core/unit/session/launch/proxy-failure-diagnostics.test.ts
@@ -14,23 +14,22 @@ import {
   logProxyFailure,
   readProxyLogTail
 } from '../../../../../src/session/launch/proxy-failure-diagnostics.js';
-import type { IFileSystem, ILogger } from '../../../../../src/interfaces/external-dependencies.js';
 import type { ProxyInitProgress } from '../../../../../src/utils/error-messages.js';
+import { createMockLogger } from '../../../../test-utils/helpers/test-dependencies.js';
+import { createMockFileSystem } from '../../../../unit/test-utils/mock-factories.js';
 
 const initProgress: ProxyInitProgress = { transportConnected: true, pendingCommand: 'initialize' };
 
 const runDir = path.join('/tmp', 'logs', 'sess-1', 'run-1');
 const proxyLogPath = path.join(runDir, 'proxy-sess-1.log');
 
-function createLogger() {
-  return { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } satisfies ILogger;
+/** A winston log file: every line newline-TERMINATED, so the text ends in a newline. */
+function logFile(lines: string[]): string {
+  return lines.map((line) => `${line}\n`).join('');
 }
 
-function createFileSystem() {
-  return {
-    pathExists: vi.fn<IFileSystem['pathExists']>(async () => true),
-    readFile: vi.fn<IFileSystem['readFile']>(async () => '')
-  };
+function enoent(): NodeJS.ErrnoException {
+  return Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
 }
 
 describe('collectProxyFailureDiagnostics', () => {
@@ -49,6 +48,21 @@ describe('collectProxyFailureDiagnostics', () => {
     ).toEqual({ proxyLogPath });
   });
 
+  it('keeps the session-derived pointer when the error refuses to be read', () => {
+    // The log path comes from the session and the init progress from the error;
+    // a hostile error must cost only the field that depends on it, or the tool
+    // result loses `data` entirely.
+    const hostile = {
+      get initProgress(): never {
+        throw new Error('initProgress getter exploded');
+      }
+    };
+
+    expect(collectProxyFailureDiagnostics({ id: 'sess-1', logDir: runDir }, hostile)).toEqual({
+      proxyLogPath
+    });
+  });
+
   it('invents nothing for a failure that happened before a log directory existed', () => {
     expect(
       collectProxyFailureDiagnostics({ id: 'sess-1', logDir: undefined }, new Error('bad config'))
@@ -61,42 +75,64 @@ describe('collectProxyFailureDiagnostics', () => {
 });
 
 describe('readProxyLogTail', () => {
-  it('returns only the last N lines, so a long log cannot swamp the record', async () => {
-    const fileSystem = createFileSystem();
+  it('returns only the last N content lines, so a long log cannot swamp the record', async () => {
+    const fileSystem = createMockFileSystem();
     const allLines = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`);
-    fileSystem.readFile.mockResolvedValue(allLines.join('\n'));
+    fileSystem.readFile.mockResolvedValue(logFile(allLines));
 
     const tail = await readProxyLogTail(fileSystem, proxyLogPath, 80);
 
-    expect(tail?.split('\n')).toHaveLength(80);
-    expect(tail).toContain('line 200');
-    expect(tail).not.toContain('line 120\n');
+    // 80 lines of CONTENT: the file's trailing newline is a terminator, not a line.
+    const tailLines = tail!.split('\n');
+    expect(tailLines).toHaveLength(80);
+    expect(tailLines[0]).toBe('line 121');
+    expect(tailLines[79]).toContain('line 200');
+    // The shared tailer labels what it dropped.
+    expect(tail).toContain('(last 80 of 200 lines)');
   });
 
   it('splits CRLF logs, so a Windows proxy log is not one giant line', async () => {
-    const fileSystem = createFileSystem();
-    fileSystem.readFile.mockResolvedValue('first\r\nsecond\r\nthird');
+    const fileSystem = createMockFileSystem();
+    fileSystem.readFile.mockResolvedValue('first\r\nsecond\r\nthird\r\n');
 
-    expect(await readProxyLogTail(fileSystem, proxyLogPath, 2)).toBe('second\nthird');
+    expect(await readProxyLogTail(fileSystem, proxyLogPath, 2)).toBe(
+      'second\nthird (last 2 of 3 lines)'
+    );
+  });
+
+  it('redacts secret-shaped lines instead of copying them into the server log', async () => {
+    const fileSystem = createMockFileSystem();
+    // The proxy log carries raw adapter argv and DAP output bodies, so the lines
+    // a failure makes interesting are exactly the ones that can hold a token.
+    fileSystem.readFile.mockResolvedValue(
+      logFile(['[Worker] spawning adapter', '[Worker] argv: --token=super-secret-value'])
+    );
+
+    const tail = await readProxyLogTail(fileSystem, proxyLogPath);
+
+    expect(tail).toContain('[Worker] spawning adapter');
+    expect(tail).not.toContain('super-secret-value');
+    expect(tail).toContain('[REDACTED');
   });
 
   it('reads nothing when there is no path to read', async () => {
-    const fileSystem = createFileSystem();
+    const fileSystem = createMockFileSystem();
 
     expect(await readProxyLogTail(fileSystem, undefined)).toBeUndefined();
-    expect(fileSystem.pathExists).not.toHaveBeenCalled();
-  });
-
-  it('reads nothing when the proxy never got as far as writing its log', async () => {
-    const fileSystem = createFileSystem();
-    fileSystem.pathExists.mockResolvedValue(false);
-
-    expect(await readProxyLogTail(fileSystem, proxyLogPath)).toBeUndefined();
     expect(fileSystem.readFile).not.toHaveBeenCalled();
   });
 
-  it('reports a read failure as the tail rather than throwing over the real error', async () => {
-    const fileSystem = createFileSystem();
+  it('reads nothing when the proxy never got as far as writing its log', async () => {
+    const fileSystem = createMockFileSystem();
+    // ENOENT is the answer an exists-check would have bought, one syscall later
+    // and with a rotation race in between.
+    fileSystem.readFile.mockRejectedValue(enoent());
+
+    expect(await readProxyLogTail(fileSystem, proxyLogPath)).toBeUndefined();
+  });
+
+  it('reports any other read failure as the tail rather than throwing over the real error', async () => {
+    const fileSystem = createMockFileSystem();
     fileSystem.readFile.mockRejectedValue(new Error('permission denied'));
 
     expect(await readProxyLogTail(fileSystem, proxyLogPath)).toBe(
@@ -149,8 +185,8 @@ describe('buildProxyFailureErrorDetails', () => {
 
 describe('logProxyFailure', () => {
   it('names the failing operation in the log line', async () => {
-    const logger = createLogger();
-    const fileSystem = createFileSystem();
+    const logger = createMockLogger();
+    const fileSystem = createMockFileSystem();
 
     await logProxyFailure(
       { logger, fileSystem },
@@ -166,8 +202,8 @@ describe('logProxyFailure', () => {
   });
 
   it('keeps the launch literal the existing suites pin', async () => {
-    const logger = createLogger();
-    const fileSystem = createFileSystem();
+    const logger = createMockLogger();
+    const fileSystem = createMockFileSystem();
 
     await logProxyFailure(
       { logger, fileSystem },
@@ -183,8 +219,8 @@ describe('logProxyFailure', () => {
   });
 
   it('survives an error object whose toString throws, rather than rejecting', async () => {
-    const logger = createLogger();
-    const fileSystem = createFileSystem();
+    const logger = createMockLogger();
+    const fileSystem = createMockFileSystem();
     // Both callers await this from inside a catch that is about to return
     // {success:false}; a throw here would turn a reported failure into a
     // rejection out of the tool call.
@@ -216,10 +252,39 @@ describe('logProxyFailure', () => {
     );
   });
 
+  it('survives an error whose initProgress getter throws, keeping the log path', async () => {
+    const logger = createMockLogger();
+    const fileSystem = createMockFileSystem();
+    const hostile = Object.defineProperty(new Error('proxy init timed out'), 'initProgress', {
+      get(): never {
+        throw new Error('initProgress getter exploded');
+      }
+    });
+
+    const diagnostics = await logProxyFailure(
+      { logger, fileSystem },
+      { id: 'sess-1', logDir: runDir },
+      hostile,
+      'attachToProcess'
+    );
+
+    // The hostile field costs itself and nothing else: the record is the full
+    // one, not the degraded fallback.
+    expect(diagnostics).toEqual({ proxyLogPath });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Detailed error in attachToProcess'),
+      expect.objectContaining({
+        message: 'proxy init timed out',
+        proxyLogPath,
+        initProgress: undefined
+      })
+    );
+  });
+
   it('survives a logger that throws, since there is nowhere left to report it', async () => {
-    const logger = createLogger();
-    const fileSystem = createFileSystem();
-    logger.error.mockImplementation(() => {
+    const logger = createMockLogger();
+    const fileSystem = createMockFileSystem();
+    vi.mocked(logger.error).mockImplementation(() => {
       throw new Error('transport closed');
     });
 
@@ -234,9 +299,9 @@ describe('logProxyFailure', () => {
   });
 
   it('logs the proxy log tail but returns only the pointers', async () => {
-    const logger = createLogger();
-    const fileSystem = createFileSystem();
-    fileSystem.readFile.mockResolvedValue('adapter said: could not open port');
+    const logger = createMockLogger();
+    const fileSystem = createMockFileSystem();
+    fileSystem.readFile.mockResolvedValue(logFile(['adapter said: could not open port']));
     const error = Object.assign(new Error('proxy init timed out'), { initProgress });
 
     const diagnostics = await logProxyFailure(

--- a/tests/core/unit/session/launch/proxy-failure-diagnostics.test.ts
+++ b/tests/core/unit/session/launch/proxy-failure-diagnostics.test.ts
@@ -1,0 +1,204 @@
+/**
+ * The proxy-failure diagnostics have two audiences and the split between them
+ * is the thing worth protecting: the tool result gets *pointers* (which init
+ * stage stalled, where the proxy log is), the server log gets the whole record
+ * including the log tail. Putting the tail in the result would bury the error
+ * for the agent reading it; leaving it out of the log is what made a failed
+ * attach undiagnosable before issue #561.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import path from 'path';
+import {
+  buildProxyFailureErrorDetails,
+  collectProxyFailureDiagnostics,
+  logProxyFailure,
+  readProxyLogTail
+} from '../../../../../src/session/launch/proxy-failure-diagnostics.js';
+import type { IFileSystem, ILogger } from '../../../../../src/interfaces/external-dependencies.js';
+import type { ProxyInitProgress } from '../../../../../src/utils/error-messages.js';
+
+const initProgress: ProxyInitProgress = { transportConnected: true, pendingCommand: 'initialize' };
+
+const runDir = path.join('/tmp', 'logs', 'sess-1', 'run-1');
+const proxyLogPath = path.join(runDir, 'proxy-sess-1.log');
+
+function createLogger() {
+  return { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } satisfies ILogger;
+}
+
+function createFileSystem() {
+  return {
+    pathExists: vi.fn<IFileSystem['pathExists']>(async () => true),
+    readFile: vi.fn<IFileSystem['readFile']>(async () => '')
+  };
+}
+
+describe('collectProxyFailureDiagnostics', () => {
+  it('carries the init progress the timeout error rode in on', () => {
+    const error = Object.assign(new Error('proxy init timed out'), { initProgress });
+
+    expect(collectProxyFailureDiagnostics({ id: 'sess-1', logDir: runDir }, error)).toEqual({
+      initProgress,
+      proxyLogPath
+    });
+  });
+
+  it('still points at the proxy log when the error carries no init progress', () => {
+    expect(
+      collectProxyFailureDiagnostics({ id: 'sess-1', logDir: runDir }, new Error('adapter exited'))
+    ).toEqual({ proxyLogPath });
+  });
+
+  it('invents nothing for a failure that happened before a log directory existed', () => {
+    expect(
+      collectProxyFailureDiagnostics({ id: 'sess-1', logDir: undefined }, new Error('bad config'))
+    ).toEqual({});
+  });
+
+  it('tolerates a thrown non-error', () => {
+    expect(collectProxyFailureDiagnostics({ id: 'sess-1', logDir: undefined }, 'boom')).toEqual({});
+  });
+});
+
+describe('readProxyLogTail', () => {
+  it('returns only the last N lines, so a long log cannot swamp the record', async () => {
+    const fileSystem = createFileSystem();
+    const allLines = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`);
+    fileSystem.readFile.mockResolvedValue(allLines.join('\n'));
+
+    const tail = await readProxyLogTail(fileSystem, proxyLogPath, 80);
+
+    expect(tail?.split('\n')).toHaveLength(80);
+    expect(tail).toContain('line 200');
+    expect(tail).not.toContain('line 120\n');
+  });
+
+  it('splits CRLF logs, so a Windows proxy log is not one giant line', async () => {
+    const fileSystem = createFileSystem();
+    fileSystem.readFile.mockResolvedValue('first\r\nsecond\r\nthird');
+
+    expect(await readProxyLogTail(fileSystem, proxyLogPath, 2)).toBe('second\nthird');
+  });
+
+  it('reads nothing when there is no path to read', async () => {
+    const fileSystem = createFileSystem();
+
+    expect(await readProxyLogTail(fileSystem, undefined)).toBeUndefined();
+    expect(fileSystem.pathExists).not.toHaveBeenCalled();
+  });
+
+  it('reads nothing when the proxy never got as far as writing its log', async () => {
+    const fileSystem = createFileSystem();
+    fileSystem.pathExists.mockResolvedValue(false);
+
+    expect(await readProxyLogTail(fileSystem, proxyLogPath)).toBeUndefined();
+    expect(fileSystem.readFile).not.toHaveBeenCalled();
+  });
+
+  it('reports a read failure as the tail rather than throwing over the real error', async () => {
+    const fileSystem = createFileSystem();
+    fileSystem.readFile.mockRejectedValue(new Error('permission denied'));
+
+    expect(await readProxyLogTail(fileSystem, proxyLogPath)).toBe(
+      '<<Failed to read proxy log: permission denied>>'
+    );
+  });
+});
+
+describe('buildProxyFailureErrorDetails', () => {
+  it('captures the identity of a system error, not just its message', () => {
+    const error = Object.assign(new Error('spawn ENOENT'), {
+      code: 'ENOENT',
+      errno: -4058,
+      syscall: 'spawn',
+      path: 'python'
+    });
+
+    const details = buildProxyFailureErrorDetails(error, { initProgress, proxyLogPath }, 'tail');
+
+    expect(details).toMatchObject({
+      type: 'Error',
+      message: 'spawn ENOENT',
+      code: 'ENOENT',
+      errno: -4058,
+      syscall: 'spawn',
+      path: 'python',
+      initProgress,
+      proxyLogPath,
+      proxyLogTail: 'tail'
+    });
+    expect(details.stack).toContain('spawn ENOENT');
+  });
+
+  it('says so rather than throwing when the error will not serialize', () => {
+    const circular: Record<string, unknown> = { message: 'cycle' };
+    circular.self = circular;
+
+    expect(buildProxyFailureErrorDetails(circular, {}, undefined).raw).toBe(
+      'Error not JSON serializable'
+    );
+  });
+
+  it('describes a thrown non-error without pretending it has a stack', () => {
+    const details = buildProxyFailureErrorDetails('boom', {}, undefined);
+
+    expect(details.message).toBe('boom');
+    expect(details.stack).toBe('No stack available');
+  });
+});
+
+describe('logProxyFailure', () => {
+  it('names the failing operation in the log line', async () => {
+    const logger = createLogger();
+    const fileSystem = createFileSystem();
+
+    await logProxyFailure(
+      { logger, fileSystem },
+      { id: 'sess-1', logDir: runDir },
+      new Error('attach failed'),
+      'attachToProcess'
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[SessionManager] Detailed error in attachToProcess for session sess-1:',
+      expect.objectContaining({ message: 'attach failed' })
+    );
+  });
+
+  it('keeps the launch literal the existing suites pin', async () => {
+    const logger = createLogger();
+    const fileSystem = createFileSystem();
+
+    await logProxyFailure(
+      { logger, fileSystem },
+      { id: 'sess-1', logDir: runDir },
+      new Error('launch failed'),
+      'startDebugging'
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Detailed error in startDebugging'),
+      expect.any(Object)
+    );
+  });
+
+  it('logs the proxy log tail but returns only the pointers', async () => {
+    const logger = createLogger();
+    const fileSystem = createFileSystem();
+    fileSystem.readFile.mockResolvedValue('adapter said: could not open port');
+    const error = Object.assign(new Error('proxy init timed out'), { initProgress });
+
+    const diagnostics = await logProxyFailure(
+      { logger, fileSystem },
+      { id: 'sess-1', logDir: runDir },
+      error,
+      'attachToProcess'
+    );
+
+    expect(diagnostics).toEqual({ initProgress, proxyLogPath });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ proxyLogTail: 'adapter said: could not open port' })
+    );
+  });
+});

--- a/tests/core/unit/session/session-manager-attach-diagnostics.test.ts
+++ b/tests/core/unit/session/session-manager-attach-diagnostics.test.ts
@@ -16,6 +16,7 @@ import path from 'path';
 import { SessionManager, SessionManagerConfig } from '../../../../src/session/session-manager.js';
 import { DebugLanguage, SessionState } from '@debugmcp/shared';
 import type { ProxyInitProgress } from '../../../../src/utils/error-messages.js';
+import { proxyLogFileName } from '../../../../src/proxy/proxy-log-path.js';
 import { createMockDependencies } from './session-manager-test-utils.js';
 
 const initProgress: ProxyInitProgress = { transportConnected: true, pendingCommand: 'initialize' };
@@ -83,7 +84,9 @@ describe('SessionManager - attach failure diagnostics (issue #561)', () => {
     const { session, result } = await attachAgainstADyingProxy('log content');
 
     const { proxyLogPath } = result.data as { proxyLogPath: string };
-    expect(path.basename(proxyLogPath)).toBe(`proxy-${session.id}.log`);
+    // Named by the same helper the proxy's own logger uses, so a rename cannot
+    // leave the diagnostics pointing at a file nothing writes.
+    expect(path.basename(proxyLogPath)).toBe(proxyLogFileName(session.id));
     expect(dependencies.mockFileSystem.readFile).toHaveBeenCalledWith(proxyLogPath, 'utf-8');
   });
 

--- a/tests/core/unit/session/session-manager-attach-diagnostics.test.ts
+++ b/tests/core/unit/session/session-manager-attach-diagnostics.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Issue #561: a failed `attach_to_process` now writes the same structured
+ * failure record a failed `start_debugging` writes.
+ *
+ * Before this, attach logged only `Failed to attach to process for session X`
+ * plus the bare error and returned the #551 pointers. When the proxy died
+ * during initialization, the adapter's own complaint lived only in the proxy
+ * log, and nothing told anyone to go read it — the exact failure mode the
+ * launch path had already been given a log tail for.
+ *
+ * The tail belongs in the log and nowhere else: `data` is what an agent reads
+ * back, and its shape is pinned by the #551 suites.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import { SessionManager, SessionManagerConfig } from '../../../../src/session/session-manager.js';
+import { DebugLanguage, SessionState } from '@debugmcp/shared';
+import type { ProxyInitProgress } from '../../../../src/utils/error-messages.js';
+import { createMockDependencies } from './session-manager-test-utils.js';
+
+const initProgress: ProxyInitProgress = { transportConnected: true, pendingCommand: 'initialize' };
+
+describe('SessionManager - attach failure diagnostics (issue #561)', () => {
+  let sessionManager: SessionManager;
+  let dependencies: ReturnType<typeof createMockDependencies>;
+
+  beforeEach(() => {
+    dependencies = createMockDependencies();
+    const config: SessionManagerConfig = { logDirBase: path.join('/tmp', 'attach-diagnostics') };
+    sessionManager = new SessionManager(config, dependencies);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    dependencies.mockProxyManager.reset();
+  });
+
+  /** Attach a session whose proxy dies during initialization. */
+  async function attachAgainstADyingProxy(proxyLogContent: string) {
+    const session = await sessionManager.createSession({ language: DebugLanguage.MOCK });
+    vi.mocked(dependencies.mockFileSystem.readFile).mockResolvedValue(proxyLogContent);
+    vi.spyOn(dependencies.mockProxyManager, 'start').mockRejectedValue(
+      Object.assign(new Error('Debug proxy initialization did not complete within 30s'), {
+        initProgress
+      })
+    );
+
+    const result = await sessionManager.attachToProcess(session.id, {
+      port: 5678,
+      host: '127.0.0.1'
+    });
+
+    return { session, result };
+  }
+
+  it('logs the same errorDetails record the launch path logs, tail included', async () => {
+    const { session, result } = await attachAgainstADyingProxy(
+      ['[Worker] connecting to 127.0.0.1:5678', 'ECONNREFUSED — nothing is listening'].join('\n')
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.state).toBe(SessionState.ERROR);
+    expect(dependencies.mockLogger.error).toHaveBeenCalledWith(
+      `[SessionManager] Detailed error in attachToProcess for session ${session.id}:`,
+      expect.objectContaining({
+        message: 'Debug proxy initialization did not complete within 30s',
+        initProgress,
+        proxyLogTail: expect.stringContaining('ECONNREFUSED — nothing is listening')
+      })
+    );
+  });
+
+  it('keeps the log tail out of the tool result, whose shape callers depend on', async () => {
+    const { result } = await attachAgainstADyingProxy('a very long proxy log');
+
+    expect(result.data).toEqual({
+      initProgress,
+      proxyLogPath: expect.stringContaining('proxy-')
+    });
+  });
+
+  it('points at the proxy log the proxy actually writes', async () => {
+    const { session, result } = await attachAgainstADyingProxy('log content');
+
+    const { proxyLogPath } = result.data as { proxyLogPath: string };
+    expect(path.basename(proxyLogPath)).toBe(`proxy-${session.id}.log`);
+    expect(dependencies.mockFileSystem.readFile).toHaveBeenCalledWith(proxyLogPath, 'utf-8');
+  });
+
+  it('still reports the failure when the proxy log cannot be read', async () => {
+    const session = await sessionManager.createSession({ language: DebugLanguage.MOCK });
+    vi.mocked(dependencies.mockFileSystem.readFile).mockRejectedValue(new Error('permission denied'));
+    vi.spyOn(dependencies.mockProxyManager, 'start').mockRejectedValue(new Error('adapter exited'));
+
+    const result = await sessionManager.attachToProcess(session.id, { port: 5678 });
+
+    expect(result.error).toContain('adapter exited');
+    expect(dependencies.mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Detailed error in attachToProcess'),
+      expect.objectContaining({
+        proxyLogTail: '<<Failed to read proxy log: permission denied>>'
+      })
+    );
+  });
+});

--- a/tests/unit/adapters/adapter-lease.test.ts
+++ b/tests/unit/adapters/adapter-lease.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `AdapterLease` replaces the `let adapterOwnedByProxy = false` flag that used
+ * to decide, from a single catch at the bottom of `startProxyManager`, whether
+ * a failed launch still owed the registry an `adapter.dispose()`.
+ *
+ * What these tests protect is the *slot accounting*: the registry allows ten
+ * concurrent adapters per language, so one un-disposed adapter per failed
+ * launch turns the eleventh attempt into "Maximum adapter instances (10)
+ * reached" instead of the real error. Each case is therefore stated as an
+ * ownership question — who disposes, and how many times.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { AdapterLease } from '../../../src/adapters/adapter-lease.js';
+import type { ILogger, IProxyManagerFactory } from '../../../src/interfaces/external-dependencies.js';
+import type { IProxyManager } from '../../../src/proxy/proxy-manager.js';
+import type { AdapterConfig, IAdapterRegistry } from '@debugmcp/shared';
+import { FakeDebugAdapter } from '../../test-utils/fakes/fake-debug-adapter.js';
+import { MockProxyManager } from '../../test-utils/mocks/mock-proxy-manager.js';
+
+const config: AdapterConfig = {
+  sessionId: 'sess-1',
+  executablePath: '',
+  adapterHost: '127.0.0.1',
+  adapterPort: 9000,
+  logDir: '/tmp/logs/sess-1',
+  scriptPath: 'script.py',
+  launchConfig: {}
+};
+
+function createLogger() {
+  return { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } satisfies ILogger;
+}
+
+function createRegistry(adapter: FakeDebugAdapter): Pick<IAdapterRegistry, 'create'> {
+  return { create: vi.fn(async () => adapter) };
+}
+
+function createFactory(proxyManager: IProxyManager = new MockProxyManager()): IProxyManagerFactory {
+  return { create: vi.fn(() => proxyManager) };
+}
+
+describe('AdapterLease', () => {
+  describe('acquire', () => {
+    it('creates the adapter through the registry and starts out holding it', async () => {
+      const adapter = new FakeDebugAdapter();
+      const registry = createRegistry(adapter);
+
+      const lease = await AdapterLease.acquire(registry, 'python', config, createLogger());
+
+      expect(registry.create).toHaveBeenCalledWith('python', config);
+      expect(lease.adapter).toBe(adapter);
+      expect(lease.isHeld).toBe(true);
+    });
+
+    it('propagates a registry failure without producing a lease', async () => {
+      const registry: Pick<IAdapterRegistry, 'create'> = {
+        create: vi.fn(async () => {
+          throw new Error('Maximum adapter instances (10) reached for language: cpp');
+        })
+      };
+
+      await expect(AdapterLease.acquire(registry, 'cpp', config, createLogger())).rejects.toThrow(
+        'Maximum adapter instances (10) reached'
+      );
+    });
+  });
+
+  describe('release', () => {
+    it('disposes the adapter exactly once and drops the lease', async () => {
+      const adapter = new FakeDebugAdapter();
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+
+      await lease.release();
+
+      expect(adapter.dispose).toHaveBeenCalledTimes(1);
+      expect(lease.isHeld).toBe(false);
+    });
+
+    it('is idempotent, so a redundant release cannot double-dispose', async () => {
+      const adapter = new FakeDebugAdapter();
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+
+      await lease.release();
+      await lease.release();
+
+      expect(adapter.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows a dispose failure with a warning, leaving the setup error to surface', async () => {
+      const adapter = new FakeDebugAdapter({
+        dispose: async () => {
+          throw new Error('handle already closed');
+        }
+      });
+      const logger = createLogger();
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, logger);
+
+      await expect(lease.release()).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[SessionManager] Failed to dispose adapter after launch setup error for session sess-1: handle already closed'
+      );
+    });
+
+    it('tolerates a partial adapter double that defines no dispose', async () => {
+      const adapter = new FakeDebugAdapter();
+      // The production guard is duck-typed because partial doubles (and any
+      // adapter predating the member) reach it; model exactly that shape.
+      delete (adapter as Partial<FakeDebugAdapter>).dispose;
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+
+      await expect(lease.release()).resolves.toBeUndefined();
+      expect(lease.isHeld).toBe(false);
+    });
+  });
+
+  describe('transferTo', () => {
+    it('hands the adapter to the proxy manager and stops owning it', async () => {
+      const adapter = new FakeDebugAdapter();
+      const proxyManager = new MockProxyManager();
+      const factory = createFactory(proxyManager);
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+
+      expect(lease.transferTo(factory)).toBe(proxyManager);
+
+      expect(factory.create).toHaveBeenCalledWith(adapter);
+      expect(lease.isHeld).toBe(false);
+    });
+
+    it('makes the trailing release a no-op, so the running proxy keeps its adapter', async () => {
+      const adapter = new FakeDebugAdapter();
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+
+      lease.transferTo(createFactory());
+      await lease.release();
+
+      expect(adapter.dispose).not.toHaveBeenCalled();
+    });
+
+    it('refuses a second transfer rather than handing one adapter to two owners', async () => {
+      const adapter = new FakeDebugAdapter();
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+
+      lease.transferTo(createFactory());
+
+      expect(() => lease.transferTo(createFactory())).toThrow(
+        'Adapter lease for session sess-1 was already transferred or released'
+      );
+    });
+
+    it('refuses a transfer after release, when the adapter is already disposed', async () => {
+      const adapter = new FakeDebugAdapter();
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+
+      await lease.release();
+
+      expect(() => lease.transferTo(createFactory())).toThrow(/already transferred or released/);
+    });
+
+    it('keeps the lease held when the factory throws, so the finally still disposes', async () => {
+      const adapter = new FakeDebugAdapter();
+      const factory: IProxyManagerFactory = {
+        create: vi.fn(() => {
+          throw new Error('Port allocation failed');
+        })
+      };
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+
+      expect(() => lease.transferTo(factory)).toThrow('Port allocation failed');
+      expect(lease.isHeld).toBe(true);
+
+      await lease.release();
+      expect(adapter.dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/adapters/adapter-lease.test.ts
+++ b/tests/unit/adapters/adapter-lease.test.ts
@@ -50,6 +50,7 @@ describe('AdapterLease', () => {
       expect(registry.create).toHaveBeenCalledWith('python', config);
       expect(lease.adapter).toBe(adapter);
       expect(lease.isHeld).toBe(true);
+      expect(lease.getState()).toBe('held');
     });
 
     it('propagates a registry failure without producing a lease', async () => {
@@ -101,6 +102,25 @@ describe('AdapterLease', () => {
       );
     });
 
+    it('swallows a dispose that throws synchronously, which a bare .catch() would miss', async () => {
+      const adapter = new FakeDebugAdapter();
+      // The interface declares `dispose(): Promise<void>`, so violating it takes
+      // a cast — and that violation IS the case under test: a synchronous throw
+      // means no promise ever exists, so `dispose().catch(...)` never runs, and
+      // from the caller's `finally` the throw would replace the setup error that
+      // sent us there.
+      adapter.dispose = vi.fn(() => {
+        throw new Error('adapter handle was already torn down');
+      }) as unknown as FakeDebugAdapter['dispose'];
+      const logger = createLogger();
+      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, logger);
+
+      await expect(lease.release()).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[SessionManager] Failed to dispose adapter after launch setup error for session sess-1: adapter handle was already torn down'
+      );
+    });
+
     it('tolerates a partial adapter double that defines no dispose', async () => {
       const adapter = new FakeDebugAdapter();
       // The production guard is duck-typed because partial doubles (and any
@@ -143,17 +163,24 @@ describe('AdapterLease', () => {
       lease.transferTo(createFactory());
 
       expect(() => lease.transferTo(createFactory())).toThrow(
-        'Adapter lease for session sess-1 was already transferred or released'
+        'Adapter lease for session sess-1 was already transferred'
       );
+      expect(lease.getState()).toBe('transferred');
     });
 
-    it('refuses a transfer after release, when the adapter is already disposed', async () => {
+    it('refuses a transfer after release, and says so — the adapter is disposed, not in use', async () => {
       const adapter = new FakeDebugAdapter();
       const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
 
       await lease.release();
 
-      expect(() => lease.transferTo(createFactory())).toThrow(/already transferred or released/);
+      // The two refusals must read differently: "transferred" sends you looking
+      // for a live adapter inside a running proxy, "released" tells you it is
+      // already disposed.
+      expect(() => lease.transferTo(createFactory())).toThrow(
+        'Adapter lease for session sess-1 was already released'
+      );
+      expect(lease.getState()).toBe('released');
     });
 
     it('keeps the lease held when the factory throws, so the finally still disposes', async () => {

--- a/tests/unit/adapters/adapter-lease.test.ts
+++ b/tests/unit/adapters/adapter-lease.test.ts
@@ -8,14 +8,19 @@
  * launch turns the eleventh attempt into "Maximum adapter instances (10)
  * reached" instead of the real error. Each case is therefore stated as an
  * ownership question — who disposes, and how many times.
+ *
+ * `release()` is the sole `finally` of `startProxyManager`, so a second theme
+ * runs through the release cases: it must never throw. Anything escaping it
+ * replaces the setup error the caller was about to report with a teardown one.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { AdapterLease } from '../../../src/adapters/adapter-lease.js';
-import type { ILogger, IProxyManagerFactory } from '../../../src/interfaces/external-dependencies.js';
-import type { IProxyManager } from '../../../src/proxy/proxy-manager.js';
-import type { AdapterConfig, IAdapterRegistry } from '@debugmcp/shared';
+import { MockProxyManagerFactory } from '../../../src/factories/proxy-manager-factory.js';
+import type { AdapterConfig, IAdapterRegistry, IDebugAdapter } from '@debugmcp/shared';
 import { FakeDebugAdapter } from '../../test-utils/fakes/fake-debug-adapter.js';
 import { MockProxyManager } from '../../test-utils/mocks/mock-proxy-manager.js';
+import { createMockAdapterRegistry } from '../../test-utils/mocks/mock-adapter-registry.js';
+import { createMockLogger } from '../../test-utils/helpers/test-dependencies.js';
 
 const config: AdapterConfig = {
   sessionId: 'sess-1',
@@ -27,59 +32,62 @@ const config: AdapterConfig = {
   launchConfig: {}
 };
 
-function createLogger() {
-  return { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } satisfies ILogger;
+/** A registry that hands back exactly this adapter, whatever language is asked for. */
+function registryFor(adapter: IDebugAdapter): IAdapterRegistry {
+  return createMockAdapterRegistry({ createAdapter: async () => adapter });
 }
 
-function createRegistry(adapter: FakeDebugAdapter): Pick<IAdapterRegistry, 'create'> {
-  return { create: vi.fn(async () => adapter) };
+/** A factory that hands back `proxyManager`, and records what it was given. */
+function factoryFor(proxyManager = new MockProxyManager()): MockProxyManagerFactory {
+  const factory = new MockProxyManagerFactory();
+  factory.createFn = () => proxyManager;
+  return factory;
 }
 
-function createFactory(proxyManager: IProxyManager = new MockProxyManager()): IProxyManagerFactory {
-  return { create: vi.fn(() => proxyManager) };
+async function leaseFor(adapter: IDebugAdapter, logger = createMockLogger()) {
+  return AdapterLease.acquire(registryFor(adapter), 'python', config, logger);
 }
 
 describe('AdapterLease', () => {
   describe('acquire', () => {
     it('creates the adapter through the registry and starts out holding it', async () => {
       const adapter = new FakeDebugAdapter();
-      const registry = createRegistry(adapter);
+      const registry = registryFor(adapter);
 
-      const lease = await AdapterLease.acquire(registry, 'python', config, createLogger());
+      const lease = await AdapterLease.acquire(registry, 'python', config, createMockLogger());
 
       expect(registry.create).toHaveBeenCalledWith('python', config);
       expect(lease.adapter).toBe(adapter);
-      expect(lease.isHeld).toBe(true);
       expect(lease.getState()).toBe('held');
     });
 
     it('propagates a registry failure without producing a lease', async () => {
-      const registry: Pick<IAdapterRegistry, 'create'> = {
-        create: vi.fn(async () => {
+      const registry = createMockAdapterRegistry({
+        createAdapter: async () => {
           throw new Error('Maximum adapter instances (10) reached for language: cpp');
-        })
-      };
+        }
+      });
 
-      await expect(AdapterLease.acquire(registry, 'cpp', config, createLogger())).rejects.toThrow(
-        'Maximum adapter instances (10) reached'
-      );
+      await expect(
+        AdapterLease.acquire(registry, 'cpp', config, createMockLogger())
+      ).rejects.toThrow('Maximum adapter instances (10) reached');
     });
   });
 
   describe('release', () => {
     it('disposes the adapter exactly once and drops the lease', async () => {
       const adapter = new FakeDebugAdapter();
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+      const lease = await leaseFor(adapter);
 
       await lease.release();
 
       expect(adapter.dispose).toHaveBeenCalledTimes(1);
-      expect(lease.isHeld).toBe(false);
+      expect(lease.getState()).toBe('released');
     });
 
     it('is idempotent, so a redundant release cannot double-dispose', async () => {
       const adapter = new FakeDebugAdapter();
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+      const lease = await leaseFor(adapter);
 
       await lease.release();
       await lease.release();
@@ -93,8 +101,8 @@ describe('AdapterLease', () => {
           throw new Error('handle already closed');
         }
       });
-      const logger = createLogger();
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, logger);
+      const logger = createMockLogger();
+      const lease = await leaseFor(adapter, logger);
 
       await expect(lease.release()).resolves.toBeUndefined();
       expect(logger.warn).toHaveBeenCalledWith(
@@ -112,8 +120,8 @@ describe('AdapterLease', () => {
       adapter.dispose = vi.fn(() => {
         throw new Error('adapter handle was already torn down');
       }) as unknown as FakeDebugAdapter['dispose'];
-      const logger = createLogger();
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, logger);
+      const logger = createMockLogger();
+      const lease = await leaseFor(adapter, logger);
 
       await expect(lease.release()).resolves.toBeUndefined();
       expect(logger.warn).toHaveBeenCalledWith(
@@ -121,15 +129,43 @@ describe('AdapterLease', () => {
       );
     });
 
+    it('swallows a logger that throws while reporting a failed dispose', async () => {
+      const adapter = new FakeDebugAdapter({
+        dispose: async () => {
+          throw new Error('handle already closed');
+        }
+      });
+      const logger = createMockLogger();
+      vi.mocked(logger.warn).mockImplementation(() => {
+        throw new Error('log transport closed');
+      });
+      const lease = await leaseFor(adapter, logger);
+
+      await expect(lease.release()).resolves.toBeUndefined();
+    });
+
     it('tolerates a partial adapter double that defines no dispose', async () => {
       const adapter = new FakeDebugAdapter();
       // The production guard is duck-typed because partial doubles (and any
       // adapter predating the member) reach it; model exactly that shape.
       delete (adapter as Partial<FakeDebugAdapter>).dispose;
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+      const lease = await leaseFor(adapter);
 
       await expect(lease.release()).resolves.toBeUndefined();
-      expect(lease.isHeld).toBe(false);
+      expect(lease.getState()).toBe('released');
+    });
+
+    it('tolerates a registry double that resolves no adapter at all', async () => {
+      // Deliberately a raw double rather than createMockAdapterRegistry: that
+      // helper now rejects a nullish adapter by design, and the property read
+      // on a nullish `adapter` is precisely what must not escape `release()`.
+      const registry: Pick<IAdapterRegistry, 'create'> = {
+        create: vi.fn(async () => undefined as unknown as IDebugAdapter)
+      };
+      const lease = await AdapterLease.acquire(registry, 'python', config, createMockLogger());
+
+      await expect(lease.release()).resolves.toBeUndefined();
+      expect(lease.getState()).toBe('released');
     });
   });
 
@@ -137,20 +173,21 @@ describe('AdapterLease', () => {
     it('hands the adapter to the proxy manager and stops owning it', async () => {
       const adapter = new FakeDebugAdapter();
       const proxyManager = new MockProxyManager();
-      const factory = createFactory(proxyManager);
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+      const factory = factoryFor(proxyManager);
+      const lease = await leaseFor(adapter);
 
       expect(lease.transferTo(factory)).toBe(proxyManager);
 
-      expect(factory.create).toHaveBeenCalledWith(adapter);
-      expect(lease.isHeld).toBe(false);
+      expect(factory.lastAdapter).toBe(adapter);
+      expect(factory.createdManagers).toEqual([proxyManager]);
+      expect(lease.getState()).toBe('transferred');
     });
 
     it('makes the trailing release a no-op, so the running proxy keeps its adapter', async () => {
       const adapter = new FakeDebugAdapter();
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+      const lease = await leaseFor(adapter);
 
-      lease.transferTo(createFactory());
+      lease.transferTo(factoryFor());
       await lease.release();
 
       expect(adapter.dispose).not.toHaveBeenCalled();
@@ -158,11 +195,11 @@ describe('AdapterLease', () => {
 
     it('refuses a second transfer rather than handing one adapter to two owners', async () => {
       const adapter = new FakeDebugAdapter();
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+      const lease = await leaseFor(adapter);
 
-      lease.transferTo(createFactory());
+      lease.transferTo(factoryFor());
 
-      expect(() => lease.transferTo(createFactory())).toThrow(
+      expect(() => lease.transferTo(factoryFor())).toThrow(
         'Adapter lease for session sess-1 was already transferred'
       );
       expect(lease.getState()).toBe('transferred');
@@ -170,14 +207,14 @@ describe('AdapterLease', () => {
 
     it('refuses a transfer after release, and says so — the adapter is disposed, not in use', async () => {
       const adapter = new FakeDebugAdapter();
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+      const lease = await leaseFor(adapter);
 
       await lease.release();
 
       // The two refusals must read differently: "transferred" sends you looking
       // for a live adapter inside a running proxy, "released" tells you it is
       // already disposed.
-      expect(() => lease.transferTo(createFactory())).toThrow(
+      expect(() => lease.transferTo(factoryFor())).toThrow(
         'Adapter lease for session sess-1 was already released'
       );
       expect(lease.getState()).toBe('released');
@@ -185,15 +222,14 @@ describe('AdapterLease', () => {
 
     it('keeps the lease held when the factory throws, so the finally still disposes', async () => {
       const adapter = new FakeDebugAdapter();
-      const factory: IProxyManagerFactory = {
-        create: vi.fn(() => {
-          throw new Error('Port allocation failed');
-        })
+      const factory = new MockProxyManagerFactory();
+      factory.createFn = () => {
+        throw new Error('Port allocation failed');
       };
-      const lease = await AdapterLease.acquire(createRegistry(adapter), 'python', config, createLogger());
+      const lease = await leaseFor(adapter);
 
       expect(() => lease.transferTo(factory)).toThrow('Port allocation failed');
-      expect(lease.isHeld).toBe(true);
+      expect(lease.getState()).toBe('held');
 
       await lease.release();
       expect(adapter.dispose).toHaveBeenCalledTimes(1);

--- a/tests/unit/proxy/proxy-log-path.test.ts
+++ b/tests/unit/proxy/proxy-log-path.test.ts
@@ -1,0 +1,37 @@
+/**
+ * The proxy log path is written by the worker and *read back* by the session
+ * layer's failure diagnostics, so the two halves must agree byte for byte.
+ * These tests pin the composition rule rather than a literal string: the name
+ * is `proxy-<sessionId>.log`, and the full path is that name joined onto the
+ * run directory with the host separator (a hand-built `${dir}/${name}` was the
+ * Windows hazard this module removes).
+ */
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { proxyLogFileName, proxyLogPathFor } from '../../../src/proxy/proxy-log-path.js';
+
+describe('proxy log path', () => {
+  it('names the file after the session', () => {
+    expect(proxyLogFileName('abc-123')).toBe('proxy-abc-123.log');
+  });
+
+  it('joins the file name onto the run directory with the host separator', () => {
+    const logDir = path.join('/tmp', 'logs', 'abc-123', 'run-1');
+
+    expect(proxyLogPathFor(logDir, 'abc-123')).toBe(
+      path.join(logDir, 'proxy-abc-123.log')
+    );
+  });
+
+  it('composes from the file name, so renaming the file moves both halves', () => {
+    const logDir = path.join('/var', 'log', 'mcp');
+
+    expect(proxyLogPathFor(logDir, 'sess')).toBe(path.join(logDir, proxyLogFileName('sess')));
+  });
+
+  it('normalizes a trailing separator instead of doubling it', () => {
+    expect(proxyLogPathFor(`${path.join('/tmp', 'logs')}${path.sep}`, 's1')).toBe(
+      path.join('/tmp', 'logs', 'proxy-s1.log')
+    );
+  });
+});

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -1024,7 +1024,6 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
     it('captures proxy log tail when initialization throws', async () => {
       mockSession.logDir = '/tmp/session-logs';
-      mockDependencies.fileSystem.pathExists.mockResolvedValueOnce(true);
       mockDependencies.fileSystem.readFile.mockResolvedValueOnce('first line\nsecond line\nthird line');
 
       vi.spyOn(operations as any, 'startProxyManager').mockRejectedValue(new Error('Proxy failed to initialize'));
@@ -1033,10 +1032,12 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Proxy failed to initialize');
-      expect(mockDependencies.fileSystem.pathExists).toHaveBeenCalledWith(
-        path.join('/tmp/session-logs', 'proxy-test-session.log')
+      // The tail is read straight through — no exists-then-read pair, which
+      // raced the proxy still writing (and rotating) this very file.
+      expect(mockDependencies.fileSystem.readFile).toHaveBeenCalledWith(
+        path.join('/tmp/session-logs', 'proxy-test-session.log'),
+        'utf-8'
       );
-      expect(mockDependencies.fileSystem.readFile).toHaveBeenCalled();
       expect(mockProxyManager.stop).toHaveBeenCalled();
       expect(mockSession.proxyManager).toBeUndefined();
       expect(mockLogger.error).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Closes #561. Third PR of the structural-refactor series (after #563 and the `FakeDebugAdapter` PR, on which this branch is stacked).

**User-visible (#561):** a failed `attach_to_process` now logs the same structured `errorDetails` record a failed `start_debugging` logs — error type/code/syscall, the `initProgress` stage, and the last 80 lines of the proxy log as `proxyLogTail` — under `Detailed error in attachToProcess for session <id>:`. The tool result is unchanged (`data.initProgress` / `data.proxyLogPath` only; the tail goes to the log, never into the response).

**Internal restructuring, behaviour-preserving:**

- **`src/adapters/adapter-lease.ts`** — `AdapterLease.acquire(registry, …)` → `lease.transferTo(proxyManagerFactory)` → `lease.release()`. Since #557 the adapter-slot leak on a throw between `adapterRegistry.create()` and `ProxyManager` ownership has been closed by an `adapterOwnedByProxy` flag guarding a catch; the lease makes that ownership an object with a three-state lifecycle (`held → transferred | released`) inside a `try/finally`, so every throw site in the preparation window — present and future — releases by construction instead of by convention. `release()` is total (sync throws and rejections from `dispose()` are swallowed with the existing warn text). No behaviour change on any path; the pinned dispose-once and log-literal tests are untouched.
- `startProxyManager` (still the same protected method with the same signature — the ~55 test spies keep working) now reads as `prepareLaunchInputs → acquire → prepareAdapterLaunch (transform → attach-key diff → toolchain verdict → resolve executable → build command → build ProxyConfig, side-effect order verbatim) → transfer → start`, with typed `ProxyLaunchRequest` / `LaunchInputs` / `AdapterLaunchPlan` intermediates.
- **`src/proxy/proxy-log-path.ts`** — the `proxy-<sessionId>.log` name was built in three places (`dap-proxy-dependencies.ts`, `dap-proxy-worker.ts`, the diagnostics collector); one `proxyLogPathFor(logDir, sessionId)` now.
- **`src/session/launch/proxy-failure-diagnostics.ts`** — `collectProxyFailureDiagnostics`, `readProxyLogTail`, `buildProxyFailureErrorDetails`, and a total `logProxyFailure(deps, session, error, operation)` shared by both catches (a pathological error object or a throwing logger degrades to a minimal record instead of rejecting out of `attachToProcess`/`startDebugging`).

New tests: `adapter-lease.test.ts` (built on `FakeDebugAdapter`: release disposes once, transfer-then-release no-op, double transfer / transfer-after-release messages, factory throw leaves the lease held, sync-throwing and rejecting `dispose`, adapter without `dispose`), `proxy-log-path.test.ts`, `proxy-failure-diagnostics.test.ts`, and `session-manager-attach-diagnostics.test.ts` (drives the real `attachToProcess` and pins the literal, the tail in the log, and the tail absent from `data`).

## Test plan

- [x] `pnpm run typecheck` → 0; `pnpm run typecheck:all` → exit 0 (baseline unchanged at 751/92; new test files type-clean)
- [x] `npm run test:unit` → 240 files / 4552 tests; integration 28 passed / 5 skipped; `npm run lint`; `pnpm changelog:check`
- [x] Live dogfood on the built branch via the dev proxy: python launch (breakpoint hit, stack, continue), C++ source launch (compile + stopOnEntry + output), python attach (continue/pause/stack/detach), **12 consecutive failed-compile C++ launches on one session** all returning the compile error and never `Maximum adapter instances (10) reached`, then a valid launch on that same session succeeding; `attach_to_process(port: 1)` producing `Detailed error in attachToProcess` + `proxyLogTail` in the server log and `data.proxyLogPath` in the tool result
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eq9fRrPuacc6ScMEkEGX9T
