### PR TITLE
refactor(server): extract the tool layer from src/server.ts into src/server/ (mechanical, snapshot-fenced)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,9 +199,10 @@ The codebase follows a **layered architecture with dependency injection** and **
 
 ### Core Components
 
-1. **MCP Server Layer** (`src/server.ts`, `src/index.ts`)
+1. **MCP Server Layer** (`src/server.ts`, `src/server/`, `src/index.ts`)
    - Entry point for MCP protocol communication
-   - Handles tool registration and routing
+   - `src/server.ts` is the composition root (`DebugMcpServer`: dependencies, lifecycle, session validation, breakpoint gating, the public facade methods); it implements `ToolContext` and passes itself to the handlers
+   - `src/server/` holds the tool schemas (`tool-schemas.ts`), argument coercion (`tool-arguments.ts`), the tools/call dispatch wrapper (`tool-dispatch.ts` over `handlers/index.ts`), one handler module per tool family (`handlers/*.ts`), and the resource (`output-resources.ts`) and prompt (`prompts.ts`) handlers
    - Supports STDIO and Streamable HTTP transport modes (legacy SSE deprecated)
    - Dynamically discovers available language adapters
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -51,10 +51,11 @@ graph TB
 
 ## Component Responsibilities
 
-### 1. MCP Server Layer (`src/server.ts`, `src/index.ts`)
+### 1. MCP Server Layer (`src/server.ts`, `src/server/`, `src/index.ts`)
 - **Purpose**: Entry point for MCP protocol communication
 - **Key Files**: 
-  - `src/server.ts` - Main server implementation
+  - `src/server.ts` - `DebugMcpServer`, the composition root: dependencies, lifecycle, session validation, breakpoint gating and the public facade methods; implements `ToolContext`
+  - `src/server/` - tool schemas (`tool-schemas.ts`), argument coercion (`tool-arguments.ts`), the tools/call dispatch wrapper (`tool-dispatch.ts` over `handlers/index.ts`), one handler module per tool family (`handlers/*.ts`), and the resource (`output-resources.ts`) and prompt (`prompts.ts`) handlers
   - `src/index.ts` - CLI entry point with subcommands (stdio, http, sse [deprecated], check-rust-binary)
 - **Responsibilities**:
   - Handle MCP tool registration and routing

--- a/src/server.ts
+++ b/src/server.ts
@@ -778,7 +778,7 @@ export class DebugMcpServer implements ToolContext {
     this.sessionManager = new SessionManager(sessionManagerConfig, dependencies);
     this.outputResources = new OutputResourceNotifier(this.server, this.logger);
 
-    this.registerTools();
+    registerToolHandlers(this.server, this);
     registerResourceHandlers(this.server, this.sessionManager, this.outputResources);
     registerPromptHandlers(this.server, this.environment);
     this.sessionManager.on('output-captured', this.outputResources.handleOutputCaptured);
@@ -807,10 +807,6 @@ export class DebugMcpServer implements ToolContext {
       : '';
     return new McpError(McpErrorCode.InvalidParams,
       `${label} not found: '${originalPath}'\nLooked for: '${fileCheck.effectivePath}'${fileCheck.errorMessage ? `\nError: ${fileCheck.errorMessage}` : ''}${containerHint}`);
-  }
-
-  private registerTools(): void {
-    registerToolHandlers(this.server, this);
   }
 
   /** @internal test seam; removed in PR 6 */

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,6 +85,14 @@ import {
   removeBreakpointTool,
   clearBreakpointsTool
 } from './server/handlers/breakpoint-tools.js';
+import {
+  stepTool,
+  continueExecutionTool,
+  pauseExecutionTool,
+  listThreadsTool,
+  handlePause,
+  handleListThreads
+} from './server/handlers/execution-tools.js';
 
 export { coerceToolArguments };
 export type { SetBreakpointRequest };
@@ -933,118 +941,19 @@ export class DebugMcpServer implements ToolContext {
             case 'step_over':
             case 'step_into':
             case 'step_out': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-
-              try {
-                let stepResult: { success: boolean; state: string; error?: string; data?: unknown; };
-                if (toolName === 'step_over') {
-                  stepResult = await this.stepOver(args.sessionId);
-                } else if (toolName === 'step_into') {
-                  stepResult = await this.stepInto(args.sessionId);
-                } else {
-                  stepResult = await this.stepOut(args.sessionId);
-                }
-
-                // Build response with location and line context if available
-                const stepType = toolName.replace('step_', '').replace('_', ' ');
-                const resultData = stepResult.data as { message?: string; location?: { file: string; line: number; column?: number }; pending?: boolean } | undefined;
-                const response: Record<string, unknown> = {
-                  success: stepResult.success,
-                  message: `Stepped ${stepType}`,
-                  state: stepResult.state
-                };
-
-                // A pending step means the program is still executing (e.g. stepping
-                // over a long-running call); report that truthfully instead of "Stepped".
-                if (resultData?.pending) {
-                  response.pending = true;
-                  if (resultData.message) {
-                    response.message = resultData.message;
-                  }
-                }
-
-                // Extract location from result data
-                const location = resultData?.location;
-
-                if (location) {
-                  response.location = location;
-
-                  // Try to get line context
-                  try {
-                    const lineContext = await this.lineReader.getLineContext(
-                      location.file,
-                      location.line,
-                      { contextLines: 2 }
-                    );
-
-                    if (lineContext) {
-                      response.context = {
-                        lineContent: lineContext.lineContent,
-                        surrounding: lineContext.surrounding
-                      };
-                    }
-                  } catch (contextError) {
-                    // Log but don't fail if we can't get context
-                    this.logger.debug('Could not get line context for step result', {
-                      file: location.file,
-                      line: location.line,
-                      error: contextError
-                    });
-                  }
-                }
-
-                result = { content: [{ type: 'text', text: JSON.stringify(response) }] };
-              } catch (error) {
-                // Handle validation errors specifically
-                if (error instanceof SessionTerminatedError ||
-                    error instanceof SessionNotFoundError ||
-                    error instanceof ProxyNotRunningError) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else if (error instanceof Error) {
-                  // Handle other expected errors (like "Failed to step over")
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else {
-                  // Re-throw unexpected errors
-                  throw error;
-                }
-              }
+              result = await stepTool(this, args, toolName);
               break;
             }
             case 'continue_execution': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-              
-              try {
-                const continueResult = await this.continueExecution(args.sessionId);
-                result = { content: [{ type: 'text', text: JSON.stringify({ success: continueResult, message: continueResult ? 'Continued execution' : 'Failed to continue execution' }) }] };
-              } catch (error) {
-                // Handle validation errors specifically
-                if (error instanceof SessionTerminatedError ||
-                    error instanceof SessionNotFoundError ||
-                    error instanceof ProxyNotRunningError) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else if (error instanceof Error) {
-                  // Handle other expected errors
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else {
-                  // Re-throw unexpected errors
-                  throw error;
-                }
-              }
+              result = await continueExecutionTool(this, args, toolName);
               break;
             }
             case 'pause_execution': {
-              result = await this.handlePause(args as { sessionId: string; threadId?: number });
+              result = await pauseExecutionTool(this, args, toolName);
               break;
             }
             case 'list_threads': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-              result = await this.handleListThreads(args as { sessionId: string });
+              result = await listThreadsTool(this, args, toolName);
               break;
             }
             case 'get_variables': {
@@ -1286,21 +1195,9 @@ export class DebugMcpServer implements ToolContext {
     }) }] };
   }
 
-  private async handlePause(args: { sessionId: string; threadId?: number }): Promise<ServerResult> {
-    try {
-      this.validateSession(args.sessionId);
-      const result = await this.sessionManager.pause(args.sessionId, args.threadId);
-      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
-    } catch (error) {
-      this.logger.error('Failed to pause execution', { error });
-      if (error instanceof SessionTerminatedError ||
-          error instanceof SessionNotFoundError ||
-          error instanceof ProxyNotRunningError) {
-        return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-      }
-      if (error instanceof McpError) throw error;
-      throw new McpError(McpErrorCode.InternalError, `Failed to pause execution: ${(error as Error).message}`);
-    }
+  /** @internal test seam; removed in PR 6 */
+  private async handlePause(args: { sessionId: string; threadId?: number }): Promise<ToolResult> {
+    return handlePause(this, args);
   }
 
   private async handleExposeSession(sessionId: string): Promise<ServerResult> {
@@ -1376,21 +1273,9 @@ export class DebugMcpServer implements ToolContext {
     }
   }
 
-  private async handleListThreads(args: { sessionId: string }): Promise<ServerResult> {
-    try {
-      this.validateSession(args.sessionId);
-      const threads = await this.sessionManager.listThreads(args.sessionId);
-      return { content: [{ type: 'text', text: JSON.stringify({ success: true, threads }) }] };
-    } catch (error) {
-      this.logger.error('Failed to list threads', { error });
-      if (error instanceof SessionTerminatedError ||
-          error instanceof SessionNotFoundError ||
-          error instanceof ProxyNotRunningError) {
-        return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-      }
-      if (error instanceof McpError) throw error;
-      throw new McpError(McpErrorCode.InternalError, `Failed to list threads: ${(error as Error).message}`);
-    }
+  /** @internal test seam; removed in PR 6 */
+  private async handleListThreads(args: { sessionId: string }): Promise<ToolResult> {
+    return handleListThreads(this, args);
   }
 
   private async handleEvaluateExpression(args: { sessionId: string, expression: string, frameId?: number, timeout?: number }): Promise<ServerResult> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,9 +51,7 @@ import {
 } from './utils/language-availability.js';
 import { isContainerMode, getWorkspaceRoot } from './utils/container-path-utils.js';
 import {
-  BP_ADDRESSING_ENV_KEY,
   getBpAddressingMode,
-  supportsExpectedContent,
   supportsStatementAnchors,
   supportsLoudSnapping
 } from './utils/bp-addressing.js';
@@ -81,6 +79,12 @@ import {
   detachFromProcessTool,
   redefineClassesTool
 } from './server/handlers/debuggee-tools.js';
+import {
+  setBreakpointTool,
+  listBreakpointsTool,
+  removeBreakpointTool,
+  clearBreakpointsTool
+} from './server/handlers/breakpoint-tools.js';
 
 export { coerceToolArguments };
 export type { SetBreakpointRequest };
@@ -877,357 +881,19 @@ export class DebugMcpServer implements ToolContext {
               break;
             }
             case 'set_breakpoint': {
-              const isFunctionBp = args.function !== undefined;
-              if (!args.sessionId || (!isFunctionBp && (!args.file || (args.line === undefined && args.statement === undefined)))) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
-              }
-
-              // Addressing-mode gating (issue #271): reject params outside the
-              // configured mode even though the schema omits them — a client
-              // replaying a cached schema must not slip features into a
-              // restricted server. Checked on the raw args so unknown params
-              // are caught too.
-              const bpMode = getBpAddressingMode(this.environment);
-              if (args.expectedContent !== undefined && !supportsExpectedContent(bpMode)) {
-                throw new McpError(
-                  McpErrorCode.InvalidParams,
-                  `expectedContent is disabled (${BP_ADDRESSING_ENV_KEY}=${bpMode}). Use plain line addressing.`
-                );
-              }
-              if ((args.statement !== undefined || args.nearLine !== undefined) && !supportsStatementAnchors(bpMode)) {
-                throw new McpError(
-                  McpErrorCode.InvalidParams,
-                  `statement addressing is disabled (${BP_ADDRESSING_ENV_KEY}=${bpMode}). Use line addressing.`
-                );
-              }
-              if (isFunctionBp && !supportsStatementAnchors(bpMode)) {
-                throw new McpError(
-                  McpErrorCode.InvalidParams,
-                  `function breakpoints are disabled (${BP_ADDRESSING_ENV_KEY}=${bpMode}). Use line addressing.`
-                );
-              }
-
-              if (isFunctionBp) {
-                // Function breakpoints are session-global symbols — no file,
-                // no line, no content anchor, no logpoint, no suspend policy
-                // (DAP FunctionBreakpoint supports name + condition only).
-                if (args.file !== undefined) {
-                  throw new McpError(McpErrorCode.InvalidParams,
-                    'Function breakpoints are not file-scoped; omit file. The adapter resolves the symbol name across the whole program.');
-                }
-                if (args.line !== undefined || args.statement !== undefined ||
-                    args.expectedContent !== undefined || args.nearLine !== undefined) {
-                  throw new McpError(McpErrorCode.InvalidParams,
-                    'Provide function alone (optionally with condition) — it cannot be combined with line, statement, expectedContent, or nearLine.');
-                }
-                if (args.logMessage !== undefined) {
-                  throw new McpError(McpErrorCode.InvalidParams,
-                    'logMessage is not supported on function breakpoints (DAP has no logpoint form for them); use a line or statement breakpoint.');
-                }
-                if (args.suspendPolicy !== undefined) {
-                  throw new McpError(McpErrorCode.InvalidParams,
-                    'suspendPolicy is not supported on function breakpoints.');
-                }
-
-                try {
-                  const fnGate = this.validateFunctionBreakpointSupport(args.sessionId);
-                  // Policy-certain rewrite (issue #467): a name the adapter can
-                  // never bind as given (go bare 'main') is corrected instead
-                  // of stored as a permanently-dead breakpoint; the warning
-                  // says the rewrite happened.
-                  const normalized = this.normalizeFunctionBreakpointName(args.sessionId, args.function!);
-                  const effectiveName = normalized?.name ?? args.function!;
-                  // Per-adapter name advisory (issues #303/#308): warn at set
-                  // time about names the adapter is known to mis-resolve
-                  // (rust bare 'main' -> CRT entry) or never bind (go bare
-                  // identifiers). Advisory only — the breakpoint is still set.
-                  const nameHint = normalized
-                    ? undefined
-                    : this.getFunctionBreakpointNameHint(args.sessionId, effectiveName);
-                  const { breakpoint, warning: syncWarning } = await this.setFunctionBreakpoint(
-                    args.sessionId, effectiveName, args.condition
-                  );
-
-                  this.logger.info('debug:breakpoint', {
-                    event: 'set',
-                    sessionId: args.sessionId,
-                    sessionName: this.getSessionName(args.sessionId),
-                    breakpointId: breakpoint.id,
-                    functionName: breakpoint.functionName,
-                    verified: breakpoint.verified,
-                    timestamp: Date.now()
-                  });
-
-                  const warnings = [breakpoint.message, fnGate.warning, normalized?.note, nameHint, syncWarning].filter(Boolean);
-                  result = { content: [{ type: 'text', text: JSON.stringify({
-                    success: true,
-                    breakpointId: breakpoint.id,
-                    ...(normalized ? { requestedName: args.function } : {}),
-                    functionName: breakpoint.functionName,
-                    condition: breakpoint.condition,
-                    verified: breakpoint.verified,
-                    boundFile: breakpoint.boundFile,
-                    boundLine: breakpoint.boundLine,
-                    message: breakpoint.message || `Function breakpoint set on ${breakpoint.functionName}`,
-                    warning: warnings.length > 0 ? warnings.join('; ') : undefined
-                  }) }] };
-                } catch (error) {
-                  result = this.handleBreakpointToolError(error);
-                }
-                break;
-              }
-
-              try {
-                // Logpoint gating (issue #235): hard error for known-unsupported
-                // adapters; a warning when support is unknown pre-launch.
-                const logPointGate = args.logMessage !== undefined
-                  ? this.validateLogPointSupport(args.sessionId)
-                  : {};
-
-                const { breakpoint, warning: syncWarning } = await this.setBreakpoint({
-                  sessionId: args.sessionId,
-                  // Non-function path: the entry guard above ensures file is set
-                  file: args.file!,
-                  line: args.line,
-                  expectedContent: args.expectedContent,
-                  statement: args.statement,
-                  nearLine: args.nearLine,
-                  condition: args.condition,
-                  suspendPolicy: args.suspendPolicy,
-                  logMessage: args.logMessage
-                });
-
-                // Log breakpoint event
-                this.logger.info('debug:breakpoint', {
-                  event: 'set',
-                  sessionId: args.sessionId,
-                  sessionName: this.getSessionName(args.sessionId),
-                  breakpointId: breakpoint.id,
-                  file: breakpoint.file,
-                  line: breakpoint.line,
-                  verified: breakpoint.verified,
-                  timestamp: Date.now()
-                });
-                
-                // Try to get line context for the breakpoint
-                let context;
-                try {
-                  const lineContext = await this.lineReader.getLineContext(
-                    breakpoint.file,
-                    breakpoint.line,
-                    { contextLines: 2 }
-                  );
-                  
-                  if (lineContext) {
-                    context = {
-                      lineContent: lineContext.lineContent,
-                      surrounding: lineContext.surrounding
-                    };
-                  }
-                } catch (contextError) {
-                  // Log but don't fail if we can't get context
-                  this.logger.debug('Could not get line context for breakpoint', { 
-                    file: breakpoint.file, 
-                    line: breakpoint.line, 
-                    error: contextError 
-                  });
-                }
-                
-                // Loud snapping (issue #271): if the adapter bound the
-                // breakpoint to a different line than requested, say so
-                // prominently instead of silently reporting the moved line.
-                const snapped =
-                  breakpoint.requestedLine !== undefined &&
-                  breakpoint.line !== breakpoint.requestedLine;
-                const snapWarning = snapped
-                  ? `Breakpoint moved by the debugger: requested line ${breakpoint.requestedLine}, bound to line ${breakpoint.line}${
-                      context ? `: \`${context.lineContent.trim()}\`` : ''
-                    }`
-                  : undefined;
-
-                const warnings = [breakpoint.message, logPointGate.warning, syncWarning, snapWarning].filter(Boolean);
-                result = { content: [{ type: 'text', text: JSON.stringify({
-                  success: true,
-                  breakpointId: breakpoint.id,
-                  file: breakpoint.file,
-                  line: breakpoint.line,
-                  requestedLine: breakpoint.requestedLine,
-                  anchor: breakpoint.anchor,
-                  content: context?.lineContent,
-                  verified: breakpoint.verified,
-                  logMessage: breakpoint.logMessage,
-                  message: snapWarning || breakpoint.message || `${breakpoint.logMessage !== undefined ? 'Logpoint' : 'Breakpoint'} set at ${breakpoint.file}:${breakpoint.line}`,
-                  // Warn on adapter validation messages, sync failures, snaps,
-                  // and unknown logpoint support
-                  warning: warnings.length > 0 ? warnings.join('; ') : undefined,
-                  // Include context if available
-                  context: context || undefined
-                }) }] };
-                const contentEntry = Array.isArray(result.content) ? result.content[0] : undefined;
-                const textContent = contentEntry && typeof (contentEntry as { text?: unknown }).text === 'string'
-                  ? (contentEntry as { text: string }).text
-                  : undefined;
-                let parsedResponse: Record<string, unknown> | null = null;
-                if (typeof textContent === 'string') {
-                  try {
-                    parsedResponse = JSON.parse(textContent) as Record<string, unknown>;
-                  } catch {
-                    parsedResponse = null;
-                  }
-                }
-                this.logger.info('tool:set_breakpoint:result', {
-                  sessionId: args.sessionId,
-                  response: parsedResponse
-                });
-              } catch (error) {
-                // Handle session state errors specifically
-                if (error instanceof McpError && 
-                    (error.message.includes('terminated') || 
-                     error.message.includes('closed') || 
-                     (error.message.includes('not found') && error.message.includes('Session')))) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else {
-                  // Re-throw all other errors (including file validation errors)
-                  throw error;
-                }
-              }
+              result = await setBreakpointTool(this, args, toolName);
               break;
             }
             case 'list_breakpoints': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameter: sessionId');
-              }
-              try {
-                const breakpoints = this.listBreakpoints(args.sessionId, args.file);
-                // Function breakpoints are session-global, so a file filter
-                // deliberately excludes them (issue #271 phase 3).
-                const functionBreakpoints = args.file === undefined
-                  ? this.sessionManager.listFunctionBreakpoints(args.sessionId)
-                  : [];
-                result = { content: [{ type: 'text', text: JSON.stringify({
-                  success: true,
-                  breakpoints,
-                  count: breakpoints.length,
-                  ...(args.file === undefined
-                    ? { functionBreakpoints, functionCount: functionBreakpoints.length }
-                    : {})
-                }) }] };
-              } catch (error) {
-                result = this.handleBreakpointToolError(error);
-              }
+              result = await listBreakpointsTool(this, args, toolName);
               break;
             }
             case 'remove_breakpoint': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameter: sessionId');
-              }
-              if (!args.breakpointId && args.function === undefined && (!args.file || args.line === undefined)) {
-                throw new McpError(
-                  McpErrorCode.InvalidParams,
-                  'Provide breakpointId, function, or file and line together'
-                );
-              }
-              try {
-                let removed: Array<Breakpoint | FunctionBreakpoint>;
-                let warning: string | undefined;
-                // Function-addressed removal discloses names the way
-                // set_breakpoint does: `functionName` is always the effective
-                // name, `requestedName` appears only when a policy rewrite
-                // changed it (issue #550).
-                let functionDisclosure: { functionName: string; requestedName?: string } | undefined;
-                if (!args.breakpointId && args.function !== undefined) {
-                  const requestedName = args.function;
-                  // Use the same policy-certain rewrite as set_breakpoint so
-                  // the name the caller supplied can remove the normalized
-                  // record that was stored (issue #550). The literal name is
-                  // matched too — a record stored un-rewritten (policy lookup
-                  // failure, or set through another path) stays removable.
-                  const normalized = this.normalizeFunctionBreakpointName(args.sessionId, requestedName);
-                  const effectiveName = normalized?.name ?? requestedName;
-                  functionDisclosure = {
-                    functionName: effectiveName,
-                    ...(normalized ? { requestedName } : {})
-                  };
-                  const matches = this.sessionManager
-                    .listFunctionBreakpoints(args.sessionId)
-                    .filter((bp) => bp.functionName === effectiveName || bp.functionName === requestedName);
-                  removed = [];
-                  const warnings: string[] = [];
-                  for (const bp of matches) {
-                    const res = await this.removeBreakpoint(args.sessionId, bp.id);
-                    if (res.removed) removed.push(res.removed);
-                    if (res.warning) warnings.push(res.warning);
-                  }
-                  if (removed.length === 0) {
-                    // Same per-adapter name advisory set_breakpoint gives
-                    // (issues #303/#308), so a bare Go name that never matched
-                    // learns the package-qualified form it should use.
-                    const nameHint = normalized
-                      ? undefined
-                      : this.getFunctionBreakpointNameHint(args.sessionId, effectiveName);
-                    if (nameHint) warnings.push(nameHint);
-                    result = { content: [{ type: 'text', text: JSON.stringify({
-                      success: false,
-                      error: normalized
-                        ? `No function breakpoint found for ${requestedName} (normalized to ${effectiveName})`
-                        : `No function breakpoint found for ${requestedName}`,
-                      ...functionDisclosure,
-                      warning: warnings.length > 0 ? warnings.join('; ') : undefined
-                    }) }] };
-                    break;
-                  }
-                  warning = warnings.length > 0 ? warnings.join('; ') : undefined;
-                } else if (args.breakpointId) {
-                  const res = await this.removeBreakpoint(args.sessionId, args.breakpointId);
-                  removed = res.removed ? [res.removed] : [];
-                  warning = res.warning;
-                  if (removed.length === 0) {
-                    result = { content: [{ type: 'text', text: JSON.stringify({
-                      success: false,
-                      error: `No breakpoint found with id ${args.breakpointId}`
-                    }) }] };
-                    break;
-                  }
-                } else {
-                  const res = await this.removeBreakpointsByLocation(args.sessionId, args.file!, args.line!);
-                  removed = res.removed;
-                  warning = res.warning;
-                  if (removed.length === 0) {
-                    result = { content: [{ type: 'text', text: JSON.stringify({
-                      success: false,
-                      error: `No breakpoint found at ${args.file}:${args.line}`
-                    }) }] };
-                    break;
-                  }
-                }
-                result = { content: [{ type: 'text', text: JSON.stringify({
-                  success: true,
-                  removed,
-                  message: `Removed ${removed.length} breakpoint(s)`,
-                  ...(functionDisclosure ?? {}),
-                  warning
-                }) }] };
-              } catch (error) {
-                result = this.handleBreakpointToolError(error);
-              }
+              result = await removeBreakpointTool(this, args, toolName);
               break;
             }
             case 'clear_breakpoints': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameter: sessionId');
-              }
-              try {
-                const res = await this.clearBreakpoints(args.sessionId, args.file);
-                result = { content: [{ type: 'text', text: JSON.stringify({
-                  success: true,
-                  cleared: res.cleared,
-                  files: res.files,
-                  message: `Cleared ${res.cleared} breakpoint(s)`,
-                  warning: res.warning
-                }) }] };
-              } catch (error) {
-                result = this.handleBreakpointToolError(error);
-              }
+              result = await clearBreakpointsTool(this, args, toolName);
               break;
             }
             case 'start_debugging': {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,10 @@
 
 /**
  * Debug MCP Server - Main Server Implementation
+ *
+ * Tool schemas, argument coercion, dispatch and the per-tool handlers live in
+ * the sibling directory src/server/ (NodeNext resolves ./server.js and
+ * ./server/x.js without conflict).
  */
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
@@ -64,6 +68,11 @@ import {
 import { isRedactionEnabled } from './utils/redaction-mode.js';
 import { getVariableAccessMode, requiresExplicitNames } from './utils/variable-access.js';
 import { assertLineContent, resolveStatement, stripTrailingComment } from './utils/breakpoint-resolver.js';
+import { coerceToolArguments, ToolArguments } from './server/tool-arguments.js';
+import { extractPayloadSuccess, sanitizeRequest } from './server/tool-result.js';
+import { buildToolDefinitions } from './server/tool-schemas.js';
+
+export { coerceToolArguments };
 
 const DEFAULT_LANGUAGES = Object.freeze([DebugLanguage.PYTHON, DebugLanguage.MOCK] as const);
 
@@ -111,57 +120,6 @@ interface AvailableLanguage {
 }
 
 /**
- * Tool arguments interface
- */
-interface ToolArguments {
-  sessionId?: string;
-  language?: string;
-  name?: string;
-  executablePath?: string;  // Language-agnostic executable path
-  file?: string;
-  line?: number;
-  condition?: string;
-  logMessage?: string;
-  expectedContent?: string;
-  statement?: string;
-  nearLine?: number;
-  function?: string;
-  breakpointId?: string;
-  scriptPath?: string;
-  args?: string[];
-  dapLaunchArgs?: Partial<DebugProtocol.LaunchRequestArguments>;
-  dryRunSpawn?: boolean;
-  breakOnExceptions?: string;
-  adapterLaunchConfig?: Record<string, unknown>;
-  scope?: number;
-  frameId?: number;
-  expression?: string;
-  linesContext?: number;
-  includeInternals?: boolean;
-  includeSpecial?: boolean;
-  names?: string[];
-  // Attach-related parameters
-  port?: number;
-  host?: string;
-  processId?: number | string;
-  timeout?: number;
-  verifyTimeout?: number;
-  sourcePaths?: string[];
-  stopOnEntry?: boolean;
-  justMyCode?: boolean;
-  adapterConfig?: Record<string, unknown>;
-  terminateProcess?: boolean;
-  suspendPolicy?: 'all' | 'thread';
-  threadId?: number;
-  // redefine_classes parameters
-  classesDir?: string;
-  sinceTimestamp?: number;
-  // get_output parameters
-  since?: number;
-  limit?: number;
-}
-
-/**
  * Request shape for DebugMcpServer.setBreakpoint (issue #271).
  */
 export interface SetBreakpointRequest {
@@ -178,68 +136,6 @@ export interface SetBreakpointRequest {
   condition?: string;
   logMessage?: string;
   suspendPolicy?: 'all' | 'thread';
-}
-
-/**
- * Schema-driven type coercion for MCP tool arguments.
- *
- * Works around a known Claude Code bug (anthropics/claude-code#11359) where
- * SSE-transport tool arguments arrive as strings instead of their declared
- * JSON-Schema types.  Called once per request on the fresh args object — no
- * shared state is mutated.
- */
-const TOOL_ARG_EXPECTED_TYPES: Record<string, 'number' | 'boolean' | 'object' | 'array'> = {
-  // numbers
-  line: 'number', linesContext: 'number', scope: 'number',
-  frameId: 'number', port: 'number', timeout: 'number', threadId: 'number',
-  verifyTimeout: 'number', since: 'number', limit: 'number',
-  sinceTimestamp: 'number', nearLine: 'number',
-  // booleans
-  includeInternals: 'boolean', includeSpecial: 'boolean',
-  stopOnEntry: 'boolean', justMyCode: 'boolean',
-  dryRunSpawn: 'boolean', terminateProcess: 'boolean',
-  // objects
-  dapLaunchArgs: 'object', adapterLaunchConfig: 'object', adapterConfig: 'object',
-  // arrays
-  args: 'array', sourcePaths: 'array', names: 'array',
-};
-
-export function coerceToolArguments(args: Record<string, unknown>): Record<string, unknown> {
-  for (const [key, expectedType] of Object.entries(TOOL_ARG_EXPECTED_TYPES)) {
-    const val = args[key];
-    if (val === undefined) continue;
-
-    // Handle "null" string → undefined for optional params
-    if (val === 'null') { args[key] = undefined; continue; }
-
-    if (typeof val !== 'string') continue; // already correct type
-
-    switch (expectedType) {
-      case 'number': {
-        if (val !== '') {
-          const n = Number(val);
-          if (!Number.isNaN(n)) args[key] = n;
-        }
-        break;
-      }
-      case 'boolean':
-        if (val === 'true') args[key] = true;
-        else if (val === 'false') args[key] = false;
-        break;
-      case 'object':
-      case 'array':
-        try {
-          const parsed = JSON.parse(val);
-          if (expectedType === 'object' && typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-            args[key] = parsed;
-          } else if (expectedType === 'array' && Array.isArray(parsed)) {
-            args[key] = parsed;
-          }
-        } catch { /* leave as-is, downstream validation will catch */ }
-        break;
-    }
-  }
-  return args;
 }
 
 /**
@@ -1032,44 +928,6 @@ export class DebugMcpServer {
   }
 
   /**
-   * Sanitize request data for logging (remove sensitive information)
-   */
-  private sanitizeRequest(args: Record<string, unknown>): Record<string, unknown> {
-    const sanitized = { ...args };
-    // Remove absolute paths from executablePath
-    if (sanitized.executablePath && typeof sanitized.executablePath === 'string' && path.isAbsolute(sanitized.executablePath)) {
-      sanitized.executablePath = '<absolute-path>';
-    }
-    // Truncate long arrays
-    if (sanitized.args && Array.isArray(sanitized.args) && sanitized.args.length > 5) {
-      sanitized.args = [...sanitized.args.slice(0, 5), `... +${sanitized.args.length - 5} more`];
-    }
-    return sanitized;
-  }
-
-  /**
-   * Derive the success flag for the tool:response log line from the tool's own
-   * payload. Handlers report failures as { success: false } inside the JSON
-   * text content without throwing; the log line must agree with the payload
-   * rather than meaning merely "the handler didn't throw" (issue #397).
-   */
-  private extractPayloadSuccess(result: ServerResult): boolean {
-    try {
-      const content = (result as { content?: Array<{ type?: string; text?: string }> }).content;
-      const first = content?.[0];
-      if (first?.type === 'text' && typeof first.text === 'string') {
-        const payload = JSON.parse(first.text) as unknown;
-        if (payload && typeof payload === 'object' && typeof (payload as { success?: unknown }).success === 'boolean') {
-          return (payload as { success: boolean }).success;
-        }
-      }
-    } catch {
-      // Non-JSON payloads carry no success flag; treat handler completion as success.
-    }
-    return true;
-  }
-
-  /**
    * Get session name for logging
    */
   private getSessionName(sessionId: string): string {
@@ -1079,16 +937,6 @@ export class DebugMcpServer {
     } catch {
       return 'Unknown Session';
     }
-  }
-
-  private getPathDescription(parameterName: string): string {
-    if (isContainerMode(this.environment)) {
-      return `Path to the ${parameterName}. Use paths relative to the project root (e.g., examples/python/script.py). The server resolves these against the workspace mount.`;
-    }
-    if (parameterName === 'script') {
-      return `Path to the script to debug. Use absolute paths or paths relative to your current working directory`;
-    }
-    return `Path to the ${parameterName}. Use absolute paths or paths relative to your current working directory`;
   }
 
   private fileNotFoundError(label: string, originalPath: string, fileCheck: FileExistenceResult): McpError {
@@ -1106,130 +954,7 @@ export class DebugMcpServer {
       // Get supported languages dynamically - deferred until request time
       const supportedLanguages = await this.getSupportedLanguagesAsync();
       
-      // Generate dynamic descriptions for path parameters
-      const fileDescription = this.getPathDescription('source file');
-      const scriptPathDescription = this.getPathDescription('script');
-
-      // Addressing-mode-gated set_breakpoint params (issue #271): a server
-      // restricted to line mode must not advertise content-addressing at all.
-      const bpMode = getBpAddressingMode(this.environment);
-      const setBreakpointExtraProps: Record<string, unknown> = {};
-      let setBreakpointRequired = ['sessionId', 'file', 'line'];
-      if (supportsExpectedContent(bpMode)) {
-        setBreakpointExtraProps.expectedContent = {
-          type: 'string',
-          description: 'Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior'
-        };
-      }
-      if (supportsStatementAnchors(bpMode)) {
-        setBreakpointExtraProps.statement = {
-          type: 'string',
-          description: 'Address by content instead of line number: the text of the target line, like an Edit-tool match — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored; an exact whole-line match always wins over substring matches). Preferred over line — it can only land on a line containing your text (an inexact or multi-candidate match adds a warning to the response) and survives file edits across restart_debugging. If the text appears on multiple lines, the error lists every match; add nearLine to pick one. Provide statement OR line, not both'
-        };
-        setBreakpointExtraProps.nearLine = {
-          type: 'number',
-          description: 'With statement only: when the statement text appears on multiple lines, bind to the match closest to this line'
-        };
-        setBreakpointExtraProps.function = {
-          type: 'string',
-          description: 'Address by symbol name instead of file location: break on entry to this function/method (DAP function breakpoint). No file or line needed — names survive edits better than both. Composes with condition only. Supported by Python, Go, Rust, .NET, Java, and JavaScript adapters. JavaScript names are dotted runtime paths (e.g. "handler" or "obj.method") bound to the current function value: top-level function declarations of the main module bind at launch; functions in modules loaded later bind at the next pause'
-        };
-        setBreakpointRequired = ['sessionId'];
-      }
-
-      // Least-privilege gating (issue #237): in explicit mode the names
-      // filter is required, and the schema must say so.
-      const varAccessExplicit = requiresExplicitNames(getVariableAccessMode(this.environment));
-      const namesProp = {
-        type: 'array',
-        items: { type: 'string' },
-        description: 'Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response\'s notFound.' +
-          (varAccessExplicit ? ' Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled.' : '')
-      };
-      const getVariablesRequired = varAccessExplicit ? ['sessionId', 'scope', 'names'] : ['sessionId', 'scope'];
-      const getLocalVariablesRequired = varAccessExplicit ? ['sessionId', 'names'] : ['sessionId'];
-
-      return {
-        tools: [
-          { name: 'create_debug_session', description: 'Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode', inputSchema: { type: 'object', properties: { language: { type: 'string', enum: supportedLanguages, description: 'Programming language for debugging' }, name: { type: 'string', description: 'Optional session name' }, executablePath: {type: 'string', description: 'Path to language executable (optional, will auto-detect if not provided)'}, host: { type: 'string', description: 'Host to attach to for remote debugging (optional, triggers attach mode)' }, port: { type: 'number', description: 'Debug port to attach to for remote debugging (optional, triggers attach mode)' }, timeout: { type: 'number', description: 'Connection timeout in milliseconds for attach mode (default: 30000)' }, verifyTimeout: { type: 'number', description: 'Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)' }, adapterConfig: { type: 'object', description: 'Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)', additionalProperties: true } }, required: ['language'] } },
-          { name: 'list_supported_languages', description: 'List all supported debugging languages with metadata', inputSchema: { type: 'object', properties: {} } },
-          { name: 'list_debug_sessions', description: 'List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. "breakpoint" vs "exception")', inputSchema: { type: 'object', properties: {} } },
-          { name: 'set_breakpoint', description: 'Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. "com.example.MyClass" or "com.example.Outer$Inner") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths.' }, line: { type: 'number', description: 'Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior' }, ...setBreakpointExtraProps, condition: { type: 'string', description: 'Optional expression: only break (or log) when it evaluates truthy' }, logMessage: { type: 'string', description: 'Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. "order={orderId} total={total}"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby' }, suspendPolicy: { type: 'string', enum: ['all', 'thread'], description: 'Suspend policy when breakpoint is hit: "all" suspends all threads (default), "thread" only suspends the event thread. Only supported by the Java/JDI adapter.' } }, required: setBreakpointRequired } },
-          { name: 'list_breakpoints', description: 'List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Optional: only list breakpoints in this file' } }, required: ['sessionId'] } },
-          { name: 'remove_breakpoint', description: 'Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, breakpointId: { type: 'string', description: 'Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line' }, function: { type: 'string', description: 'Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go "main" matches the stored "main.main"); the response reports the effective name as functionName and, when rewritten, the original as requestedName' }, file: { type: 'string', description: 'Alternative addressing: source file path (use together with line)' }, line: { type: 'number', description: 'Alternative addressing: line number (use together with file)' } }, required: ['sessionId'] } },
-          { name: 'clear_breakpoints', description: 'Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Optional: only clear breakpoints in this file' } }, required: ['sessionId'] } },
-          { name: 'start_debugging', description: 'Start debugging a script', inputSchema: {
-              type: 'object', 
-              properties: { 
-                sessionId: { type: 'string' }, 
-                scriptPath: { type: 'string', description: scriptPathDescription }, 
-                args: { type: 'array', items: { type: 'string' } }, 
-                dapLaunchArgs: { 
-                  type: 'object', 
-                  properties: { 
-                    stopOnEntry: { type: 'boolean' },
-                    justMyCode: { type: 'boolean' } 
-                  },
-                  additionalProperties: true
-                },
-                dryRunSpawn: { type: 'boolean' },
-                breakOnExceptions: { type: 'string', enum: ['uncaught', 'all', 'none'], description: 'Break when exceptions are thrown: "uncaught" pauses at uncaught exceptions at the crash site instead of terminating the session; "all" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to "uncaught" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays "none"); pass "none" to opt out and let crashing scripts run to termination' },
-                adapterLaunchConfig: {
-                  type: 'object',
-                  description: 'Optional adapter-specific launch configuration overrides',
-                  additionalProperties: true
-                }
-              },
-              required: ['sessionId', 'scriptPath']
-            }
-          },
-          { name: 'restart_debugging', description: 'Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'attach_to_process', description: 'Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down', inputSchema: {
-              type: 'object',
-              properties: {
-                sessionId: { type: 'string', description: 'Debug session ID' },
-                port: { type: 'number', description: 'Debug port to attach to' },
-                host: { type: 'string', description: 'Host to attach to (default: localhost)' },
-                processId: { type: ['number', 'string'], description: 'Process ID (for local attach, language-specific)' },
-                timeout: { type: 'number', description: 'Connection timeout in milliseconds (default: 30000)' },
-                verifyTimeout: { type: 'number', description: 'How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable' },
-                sourcePaths: { type: 'array', items: { type: 'string' }, description: 'Source paths for code mapping' },
-                stopOnEntry: { type: 'boolean', description: 'Stop on entry after attaching' },
-                justMyCode: { type: 'boolean', description: 'Only debug user code (skip library code)' },
-                breakOnExceptions: { type: 'string', enum: ['uncaught', 'all', 'none'], description: 'Break when exceptions are thrown: "uncaught" pauses at uncaught exceptions at the crash site; "all" also pauses on caught/raised exceptions (language-dependent). Default "none" — attach sessions never apply a language default (unlike launch)' },
-                adapterConfig: { type: 'object', description: 'Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like "settings set target.exec-search-paths /proc/<pid>/root"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)', additionalProperties: true }
-              },
-              required: ['sessionId']
-            }
-          },
-          { name: 'detach_from_process', description: 'Detach from the debugged process without terminating it', inputSchema: {
-              type: 'object',
-              properties: {
-                sessionId: { type: 'string', description: 'Debug session ID' },
-                terminateProcess: { type: 'boolean', description: 'Whether to terminate the process on detach (default: false)' }
-              },
-              required: ['sessionId']
-            }
-          },
-          { name: 'expose_session', description: 'Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as "mirrorToken" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'unexpose_session', description: 'Close a session\'s DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'close_debug_session', description: 'Close a debugging session', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'step_over', description: 'Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state "running" and pending:true — the session becomes "paused" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'step_into', description: 'Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state "running" and pending:true — the session becomes "paused" when the step completes', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'step_out', description: 'Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state "running" and pending:true — the session becomes "paused" when the step completes', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'continue_execution', description: 'Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes "paused" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. "breakpoint" vs "exception"). Use get_output to read the program\'s stdout/stderr', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'pause_execution', description: 'Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports "paused" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, threadId: { type: 'number', description: 'Thread ID to pause. If omitted or 0, pauses all threads.' } }, required: ['sessionId'] } },
-          { name: 'list_threads', description: 'List all threads in the debugged process', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
-          { name: 'get_variables', description: 'Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, scope: { type: 'number', description: "The variablesReference number from a StackFrame or Variable" }, names: namesProp }, required: getVariablesRequired } },
-          { name: 'get_local_variables', description: 'Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeSpecial: { type: 'boolean', description: 'Include special/internal variables like this, __proto__, __builtins__, etc. Default: false' }, names: namesProp }, required: getLocalVariablesRequired } },
-          { name: 'get_stack_trace', description: 'Get stack trace. The response includes stopReason — why the session is paused (e.g. "breakpoint" vs "exception"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeInternals: { type: 'boolean', description: 'Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output.' }, threadId: { type: 'number', description: 'Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread' } }, required: ['sessionId'] } },
-          { name: 'get_scopes', description: 'Get scopes for a stack frame', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, frameId: { type: 'number', description: "The ID of the stack frame from a stackTrace response" } }, required: ['sessionId', 'frameId'] } },
-          { name: 'evaluate_expression', description: 'Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, expression: { type: 'string' }, frameId: { type: 'number', description: 'Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically' }, timeout: { type: 'number', description: 'Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout' } }, required: ['sessionId', 'expression'] } },
-          { name: 'get_source_context', description: 'Get source context around a specific line in a file', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: fileDescription }, line: { type: 'number', description: 'Line number to get context for' }, linesContext: { type: 'number', description: 'Number of lines before and after to include (default: 5)' } }, required: ['sessionId', 'file', 'line'] } },
-          { name: 'get_output', description: 'Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, since: { type: 'number', description: 'Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer' }, limit: { type: 'number', description: 'Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available' } }, required: ['sessionId'] } },
-          { name: 'redefine_classes', description: 'Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, classesDir: { type: 'string', description: 'Absolute path to compiled classes directory (e.g. build/classes/java/main/)' }, sinceTimestamp: { type: 'number', description: 'Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files.' }, timeout: { type: 'number', description: 'Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once' } }, required: ['sessionId', 'classesDir'] } },
-        ],
-      };
+      return { tools: buildToolDefinitions({ supportedLanguages, environment: this.environment }) };
     });
 
     this.server.setRequestHandler(
@@ -1243,7 +968,7 @@ export class DebugMcpServer {
           tool: toolName,
           sessionId: args.sessionId,
           sessionName: args.sessionId ? this.getSessionName(args.sessionId) : undefined,
-          request: this.sanitizeRequest(args as Record<string, unknown>),
+          request: sanitizeRequest(args as Record<string, unknown>),
           timestamp: Date.now()
         });
 
@@ -2274,7 +1999,7 @@ export class DebugMcpServer {
             tool: toolName,
             sessionId: args.sessionId,
             sessionName: args.sessionId ? this.getSessionName(args.sessionId) : undefined,
-            success: this.extractPayloadSuccess(result),
+            success: extractPayloadSuccess(result),
             timestamp: Date.now()
           });
           

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import {
 } from './errors/debug-errors.js';
 import { SessionManager, SessionManagerConfig } from './session/session-manager.js';
 import { StackTraceResult } from './session/session-manager-data.js';
-import { buildTruncationNotice, VariableTruncationSummary } from './session/variable-caps.js';
+import { VariableTruncationSummary } from './session/variable-caps.js';
 import { createProductionDependencies } from './container/dependencies.js';
 import { ContainerConfig } from './container/types.js';
 import {
@@ -33,7 +33,6 @@ import {
     Breakpoint,
     FunctionBreakpoint,
     SessionLifecycleState,
-    SessionState,
     IEnvironment,
     ILogger,
     ExceptionBreakMode,
@@ -93,6 +92,17 @@ import {
   handlePause,
   handleListThreads
 } from './server/handlers/execution-tools.js';
+import {
+  getVariablesTool,
+  getStackTraceTool,
+  getScopesTool,
+  evaluateExpressionTool,
+  getSourceContextTool,
+  getLocalVariablesTool,
+  handleEvaluateExpression,
+  handleGetSourceContext,
+  handleGetLocalVariables
+} from './server/handlers/inspection-tools.js';
 
 export { coerceToolArguments };
 export type { SetBreakpointRequest };
@@ -957,136 +967,27 @@ export class DebugMcpServer implements ToolContext {
               break;
             }
             case 'get_variables': {
-              if (!args.sessionId || args.scope === undefined) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
-              }
-              this.enforceExplicitNames('get_variables', args.names);
-
-              try {
-                const { variables, truncation } = await this.getVariablesDetailed(args.sessionId, args.scope, args.names);
-
-                // Log variable inspection (truncate large values)
-                const truncatedVars = variables.map(v => ({
-                  name: v.name,
-                  type: v.type,
-                  value: v.value.length > 200 ? v.value.substring(0, 200) + '... (truncated)' : v.value
-                }));
-                
-                this.logger.info('debug:variables', {
-                  sessionId: args.sessionId,
-                  sessionName: this.getSessionName(args.sessionId),
-                  variablesReference: args.scope,
-                  variableCount: variables.length,
-                  variables: truncatedVars.slice(0, 10), // Log first 10 variables
-                  timestamp: Date.now()
-                });
-                
-                const redaction = this.redactionSummary(variables);
-                const notFound = args.names
-                  ? args.names.filter(name => !variables.some(v => v.name === name))
-                  : undefined;
-                const truncationInfo = truncation
-                  ? { ...truncation, notice: buildTruncationNotice(truncation, variables) }
-                  : undefined;
-                result = { content: [{ type: 'text', text: JSON.stringify({ success: true, variables, count: variables.length, variablesReference: args.scope, ...(notFound !== undefined ? { notFound } : {}), ...(redaction ? { redaction } : {}), ...(truncationInfo ? { truncation: truncationInfo } : {}) }) }] };
-              } catch (error) {
-                // Handle validation errors specifically
-                if (error instanceof SessionTerminatedError ||
-                    error instanceof SessionNotFoundError ||
-                    error instanceof ProxyNotRunningError) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else {
-                  // Re-throw unexpected errors
-                  throw error;
-                }
-              }
+              result = await getVariablesTool(this, args, toolName);
               break;
             }
             case 'get_stack_trace': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-              
-              try {
-                // Default to false for cleaner output
-                const includeInternals = args.includeInternals ?? false;
-                const stackTrace = await this.getStackTrace(args.sessionId, includeInternals, args.threadId);
-                const lastStop = this.sessionManager.getSession(args.sessionId)?.lastStop;
-                const payload: Record<string, unknown> = {
-                  success: true,
-                  stackFrames: stackTrace.frames,
-                  count: stackTrace.frames.length,
-                  ...(typeof stackTrace.threadId === 'number' ? { threadId: stackTrace.threadId } : {}),
-                  includeInternals,
-                  stopReason: lastStop?.reason,
-                  lastStop
-                };
-                // Anything the result needs explaining (not paused, stack came
-                // from a different thread, all threads frameless) plus the
-                // issue #346 hidden-frames disclosure share the note field.
-                const notes: string[] = [];
-                if (stackTrace.note) {
-                  notes.push(stackTrace.note);
-                }
-                if (stackTrace.hiddenFrameCount > 0) {
-                  payload.hiddenFrames = stackTrace.hiddenFrameCount;
-                  notes.push(stackTrace.allFramesInternal
-                    ? `All ${stackTrace.totalFrameCount} frames are internal/runtime frames; showing the top internal frame so scopes and evaluate still work. Pass includeInternals: true to see the full stack.`
-                    : `${stackTrace.hiddenFrameCount} internal frame(s) hidden — pass includeInternals: true to see them.`);
-                }
-                if (notes.length > 0) {
-                  payload.note = notes.join(' ');
-                }
-                result = { content: [{ type: 'text', text: JSON.stringify(payload) }] };
-              } catch (error) {
-                // Handle validation errors specifically
-                if (error instanceof SessionTerminatedError ||
-                    error instanceof SessionNotFoundError ||
-                    error instanceof ProxyNotRunningError) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else if (error instanceof Error && !(error instanceof McpError)) {
-                  // DAP-level failures (e.g. "Child session not ready ...")
-                  // must surface as errors, not as an empty-but-successful
-                  // stack trace (issue #124).
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else {
-                  // Re-throw unexpected errors
-                  throw error;
-                }
-              }
+              result = await getStackTraceTool(this, args, toolName);
               break;
             }
             case 'get_scopes': {
-              if (!args.sessionId || args.frameId === undefined) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
-              }
-              
-              try {
-                const scopes = await this.getScopes(args.sessionId, args.frameId);
-                result = { content: [{ type: 'text', text: JSON.stringify({ success: true, scopes }) }] };
-              } catch (error) {
-                // Handle validation errors specifically
-                if (error instanceof SessionTerminatedError ||
-                    error instanceof SessionNotFoundError ||
-                    error instanceof ProxyNotRunningError) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-                } else {
-                  // Re-throw unexpected errors
-                  throw error;
-                }
-              }
+              result = await getScopesTool(this, args, toolName);
               break;
             }
             case 'evaluate_expression': {
-              result = await this.handleEvaluateExpression(args as { sessionId: string; expression: string; frameId?: number; timeout?: number });
+              result = await evaluateExpressionTool(this, args, toolName);
               break;
             }
             case 'get_source_context': {
-              result = await this.handleGetSourceContext(args as { sessionId: string; file: string; line: number; linesContext?: number });
+              result = await getSourceContextTool(this, args, toolName);
               break;
             }
             case 'get_local_variables': {
-              result = await this.handleGetLocalVariables(args as { sessionId: string; includeSpecial?: boolean; names?: string[] });
+              result = await getLocalVariablesTool(this, args, toolName);
               break;
             }
             case 'get_output': {
@@ -1278,277 +1179,19 @@ export class DebugMcpServer implements ToolContext {
     return handleListThreads(this, args);
   }
 
-  private async handleEvaluateExpression(args: { sessionId: string, expression: string, frameId?: number, timeout?: number }): Promise<ServerResult> {
-    try {
-      // Validate session
-      this.validateSession(args.sessionId);
-
-      // Check expression length (sanity check)
-      if (args.expression.length > 10240) {
-        throw new McpError(McpErrorCode.InvalidParams, 'Expression too long (max 10KB)');
-      }
-
-      // Call SessionManager's evaluateExpression method (no context is passed here;
-      // the adapter policy chooses the DAP evaluate context)
-      const result = await this.sessionManager.evaluateExpression(
-        args.sessionId,
-        args.expression,
-        args.frameId,
-        // Context is chosen by the adapter policy inside SessionManager
-        args.timeout
-      );
-      
-      // Log for audit trail
-      this.logger.info('tool:evaluate_expression', {
-        sessionId: args.sessionId,
-        sessionName: this.getSessionName(args.sessionId),
-        expression: args.expression.substring(0, 100), // Truncate for logging
-        success: result.success,
-        hasResult: !!result.result,
-        timestamp: Date.now()
-      });
-      
-      // Return formatted response
-      return { 
-        content: [{ 
-          type: 'text', 
-          text: JSON.stringify(result) 
-        }] 
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      
-      // Log the error
-      this.logger.error('tool:evaluate_expression:error', {
-        sessionId: args.sessionId,
-        expression: args.expression.substring(0, 100),
-        error: errorMessage,
-        timestamp: Date.now()
-      });
-      
-      // Handle session state errors specifically
-      if (error instanceof McpError && 
-          (error.message.includes('terminated') || 
-           error.message.includes('closed') || 
-           error.message.includes('not found') ||
-           error.message.includes('not paused'))) {
-        return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-      } else if (error instanceof McpError) {
-        throw error;
-      } else {
-        // Wrap unexpected errors
-        throw new McpError(McpErrorCode.InternalError, `Failed to evaluate expression: ${errorMessage}`);
-      }
-    }
+  /** @internal test seam; removed in PR 6 */
+  private async handleEvaluateExpression(args: { sessionId: string, expression: string, frameId?: number, timeout?: number }): Promise<ToolResult> {
+    return handleEvaluateExpression(this, args);
   }
 
-  private async handleGetSourceContext(args: { sessionId: string, file: string, line: number, linesContext?: number }): Promise<ServerResult> {
-    try {
-      // Validate session
-      this.validateSession(args.sessionId);
-      
-      // Check file exists for immediate feedback
-      const fileCheck = await this.fileChecker.checkExists(args.file);
-      if (!fileCheck.exists) {
-        throw this.fileNotFoundError('Source file', args.file, fileCheck);
-      }
-      
-      this.logger.info(`Source context requested for session: ${args.sessionId}, file: ${fileCheck.effectivePath}, line: ${args.line}`);
-      
-      // Get line context using the line reader
-      const contextLines = args.linesContext ?? 5; // Default to 5 lines of context
-      const lineContext = await this.lineReader.getLineContext(
-        fileCheck.effectivePath,
-        args.line,
-        { contextLines }
-      );
-      
-      if (!lineContext) {
-        // File might be binary or unreadable
-        return { 
-          content: [{ 
-            type: 'text', 
-            text: JSON.stringify({ 
-              success: false, 
-              error: 'Could not read source context. File may be binary or inaccessible.',
-              file: args.file,
-              line: args.line
-            }) 
-          }] 
-        };
-      }
-      
-      // Log source context request
-      this.logger.info('debug:source_context', {
-        sessionId: args.sessionId,
-        sessionName: this.getSessionName(args.sessionId),
-        file: args.file,
-        line: args.line,
-        contextLines: contextLines,
-        timestamp: Date.now()
-      });
-      
-      return { 
-        content: [{ 
-          type: 'text', 
-          text: JSON.stringify({ 
-            success: true,
-            file: args.file,
-            line: args.line,
-            lineContent: lineContext.lineContent,
-            surrounding: lineContext.surrounding,
-            contextLines: contextLines
-          }) 
-        }] 
-      };
-    } catch (error) {
-      this.logger.error('Failed to get source context', { error });
-      if (error instanceof SessionTerminatedError ||
-          error instanceof SessionNotFoundError ||
-          error instanceof ProxyNotRunningError) {
-        return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-      }
-      if (error instanceof McpError) throw error;
-      throw new McpError(McpErrorCode.InternalError, `Failed to get source context: ${(error as Error).message}`);
-    }
+  /** @internal test seam; removed in PR 6 */
+  private async handleGetSourceContext(args: { sessionId: string, file: string, line: number, linesContext?: number }): Promise<ToolResult> {
+    return handleGetSourceContext(this, args);
   }
 
-  private async handleGetLocalVariables(args: { sessionId: string; includeSpecial?: boolean; names?: string[] }): Promise<ServerResult> {
-    this.enforceExplicitNames('get_local_variables', args.names);
-    try {
-      // Validate session
-      this.validateSession(args.sessionId);
-
-      // Get local variables using the new convenience method
-      const result = await this.getLocalVariables(
-        args.sessionId,
-        args.includeSpecial ?? false,
-        args.names
-      );
-      
-      // Log for debugging
-      this.logger.info('tool:get_local_variables', {
-        sessionId: args.sessionId,
-        sessionName: this.getSessionName(args.sessionId),
-        includeSpecial: args.includeSpecial ?? false,
-        variableCount: result.variables.length,
-        frame: result.frame,
-        scopeName: result.scopeName,
-        timestamp: Date.now()
-      });
-      
-      // Format response
-      const response: Record<string, unknown> = {
-        success: true,
-        variables: result.variables,
-        count: result.variables.length
-      };
-
-      const redaction = this.redactionSummary(result.variables);
-      if (redaction) {
-        response.redaction = redaction;
-      }
-
-      // Size-guard advisory (issues #356/#359): say explicitly that data was
-      // cut and how to fetch the rest, instead of silently dropping it.
-      if (result.truncation) {
-        response.truncation = {
-          ...result.truncation,
-          notice: buildTruncationNotice(result.truncation, result.variables)
-        };
-      }
-
-      if (args.names) {
-        response.notFound = args.names.filter(
-          name => !result.variables.some(v => v.name === name)
-        );
-      }
-
-      // Include frame information if available
-      if (result.frame) {
-        response.frame = result.frame;
-      }
-
-      // Include scope name if available
-      if (result.scopeName) {
-        response.scopeName = result.scopeName;
-      }
-
-      // The tool walked down past an empty runtime/stdlib top frame — say so,
-      // since `frame` no longer names the top of the stack (issue #468).
-      if (result.anchorNote) {
-        response.note = result.anchorNote;
-      }
-
-      // Surface adapter warnings embedded in the scope name — e.g. Delve
-      // reports "Locals (warning: optimized function)" when the debuggee was
-      // built with optimizations, which typically means missing variables.
-      const warningMatch = result.scopeName?.match(/\(warning:[^)]*\)/i);
-      if (warningMatch) {
-        response.warning =
-          `The debug adapter reported the locals scope as "${result.scopeName}". ` +
-          'This usually means the target was compiled with optimizations, so variables may be missing or unreadable. ' +
-          'For Go, rebuild the binary with -gcflags="all=-N -l" (exec mode) or launch the .go source directly (debug mode).';
-      }
-
-      // Add helpful messages for edge cases
-      if (result.variables.length === 0) {
-        if (!result.frame) {
-          // Distinguish "not paused" from "paused but the anchored thread has
-          // no frames" — the latter used to claim the debugger may not be
-          // paused while list_debug_sessions said paused (issue #465).
-          const sessionState = this.sessionManager.getSession(args.sessionId)?.state;
-          response.message = sessionState === SessionState.PAUSED
-            ? 'The session is paused, but the anchored thread reported no stack frames. ' +
-              'Try get_stack_trace with a threadId from list_threads, or continue_execution ' +
-              'followed by pause_execution to re-anchor on a reportable thread.'
-            : 'No stack frames available. The debugger may not be paused.';
-        } else if (!result.scopeName) {
-          response.message = 'No local scope found in the current frame.';
-        } else {
-          response.message = `The ${result.scopeName} scope is empty.`;
-        }
-      }
-      
-      return { 
-        content: [{ 
-          type: 'text', 
-          text: JSON.stringify(response) 
-        }] 
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      
-      // Log the error
-      this.logger.error('tool:get_local_variables:error', {
-        sessionId: args.sessionId,
-        error: errorMessage,
-        timestamp: Date.now()
-      });
-      
-      // Handle session state errors specifically
-      if (error instanceof McpError &&
-          (error.message.includes('terminated') ||
-           error.message.includes('closed') ||
-           error.message.includes('not found') ||
-           error.message.includes('not paused'))) {
-        // A terminated session is a normal end state (e.g. a step_out ran the
-        // program to completion) — explain that instead of implying misuse.
-        const message = error.message.includes('terminated')
-          ? 'The program has terminated, so no frames or variables exist. Use restart_debugging to run it again.'
-          : 'Cannot get local variables. The session must be paused at a breakpoint.';
-        return { content: [{ type: 'text', text: JSON.stringify({
-          success: false,
-          error: error.message,
-          message
-        }) }] };
-      } else if (error instanceof McpError) {
-        throw error;
-      } else {
-        // Wrap unexpected errors
-        throw new McpError(McpErrorCode.InternalError, `Failed to get local variables: ${errorMessage}`);
-      }
-    }
+  /** @internal test seam; removed in PR 6 */
+  private async handleGetLocalVariables(args: { sessionId: string; includeSpecial?: boolean; names?: string[] }): Promise<ToolResult> {
+    return handleGetLocalVariables(this, args);
   }
 
   private async handleListSupportedLanguages(): Promise<ServerResult> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -779,6 +779,11 @@ export class DebugMcpServer implements ToolContext {
     this.outputResources = new OutputResourceNotifier(this.server, this.logger);
 
     registerToolHandlers(this.server, this);
+    // Tool handlers read every dependency live through `ctx` (=== this) at call
+    // time; the resource and prompt layers capture `sessionManager` and
+    // `environment` here instead. Both fields are readonly, so production never
+    // observes the difference — but a test that swaps `sessionManager` after
+    // construction sees the swap in tool handlers only, not in resource handlers.
     registerResourceHandlers(this.server, this.sessionManager, this.outputResources);
     registerPromptHandlers(this.server, this.environment);
     this.sessionManager.on('output-captured', this.outputResources.handleOutputCaptured);

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,6 +103,7 @@ import {
   handleGetSourceContext,
   handleGetLocalVariables
 } from './server/handlers/inspection-tools.js';
+import { getOutputTool } from './server/handlers/output-tools.js';
 
 export { coerceToolArguments };
 export type { SetBreakpointRequest };
@@ -991,7 +992,7 @@ export class DebugMcpServer implements ToolContext {
               break;
             }
             case 'get_output': {
-              result = await this.handleGetOutput(args as { sessionId: string; since?: number; limit?: number });
+              result = await getOutputTool(this, args, toolName);
               break;
             }
             case 'list_supported_languages': {
@@ -1069,31 +1070,6 @@ export class DebugMcpServer implements ToolContext {
   public redactionSummary(items: Array<{ redacted?: boolean }>): { masked: number; notice: string } | undefined {
     const masked = items.filter(item => item.redacted).length;
     return masked > 0 ? { masked, notice: REDACTION_NOTICE } : undefined;
-  }
-
-  private async handleGetOutput(args: { sessionId: string; since?: number; limit?: number }): Promise<ServerResult> {
-    // Deliberately no validateSession(): that rejects TERMINATED sessions, but
-    // reading output after the program finished is the primary use case.
-    // Output stays readable until close_debug_session removes the session.
-    const session = this.sessionManager.getSession(args.sessionId);
-    if (!session) {
-      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: `Session not found: ${args.sessionId}` }) }] };
-    }
-    const since = Math.max(0, args.since ?? 0);
-    const limit = Math.min(Math.max(1, args.limit ?? 100), 1000);
-    const read = session.outputBuffer
-      ? session.outputBuffer.read(since, limit)
-      : { entries: [], nextSince: since, hasMore: false, dropped: 0 }; // session created but never launched
-    const redaction = this.redactionSummary(read.entries);
-    return { content: [{ type: 'text', text: JSON.stringify({
-      success: true,
-      sessionId: args.sessionId,
-      entries: read.entries,
-      nextSince: read.nextSince,
-      hasMore: read.hasMore,
-      dropped: read.dropped,
-      ...(redaction ? { redaction } : {})
-    }) }] };
   }
 
   /** @internal test seam; removed in PR 6 */

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,6 +74,13 @@ import {
   closeDebugSessionTool,
   handleListDebugSessions
 } from './server/handlers/session-tools.js';
+import {
+  startDebuggingTool,
+  restartDebuggingTool,
+  attachToProcessTool,
+  detachFromProcessTool,
+  redefineClassesTool
+} from './server/handlers/debuggee-tools.js';
 
 export { coerceToolArguments };
 export type { SetBreakpointRequest };
@@ -1224,205 +1231,19 @@ export class DebugMcpServer implements ToolContext {
               break;
             }
             case 'start_debugging': {
-              if (!args.sessionId || !args.scriptPath) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
-              }
-              
-              try {
-                if (args.adapterLaunchConfig !== undefined) {
-                  const cfg = args.adapterLaunchConfig;
-                  if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
-                    throw new McpError(McpErrorCode.InvalidParams, 'adapterLaunchConfig must be an object when provided');
-                  }
-                }
-
-                const intake = this.normalizeStartDebuggingArgs(args.dapLaunchArgs, args.breakOnExceptions);
-                const debugResult = await this.startDebugging(
-                  args.sessionId,
-                  args.scriptPath,
-                  args.args,
-                  intake.dapLaunchArgs,
-                  args.dryRunSpawn,
-                  args.adapterLaunchConfig,
-                  this.validateBreakOnExceptions(intake.breakOnExceptions)
-                );
-                const responsePayload: Record<string, unknown> = {
-                  success: debugResult.success,
-                  state: debugResult.state,
-                  message: debugResult.error ? debugResult.error : (debugResult.data as Record<string, unknown>)?.message || `Operation status for ${args.scriptPath}`,
-                };
-                if (debugResult.data) {
-                  responsePayload.data = debugResult.data;
-                }
-                // Top-level warning join (set_breakpoint pattern): intake
-                // normalization notes (issue #305) plus any session-manager
-                // warning (unbound function breakpoints, issue #308).
-                const dataWarning = (debugResult.data as { warning?: string } | undefined)?.warning;
-                const startWarnings = [...intake.warnings, dataWarning].filter(Boolean);
-                if (debugResult.success && startWarnings.length > 0) {
-                  responsePayload.warning = startWarnings.join('; ');
-                }
-                result = { content: [{ type: 'text', text: JSON.stringify(responsePayload) }] };
-              } catch (error) {
-                // Handle session state errors specifically
-                if (error instanceof McpError && 
-                    (error.message.includes('terminated') || 
-                     error.message.includes('closed') || 
-                     (error.message.includes('not found') && error.message.includes('Session')))) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message, state: 'stopped' }) }] };
-                } else {
-                  // Re-throw all other errors (including file validation errors)
-                  throw error;
-                }
-              }
+              result = await startDebuggingTool(this, args, toolName);
               break;
             }
             case 'restart_debugging': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameter: sessionId');
-              }
-              try {
-                const debugResult = await this.restartDebugging(args.sessionId);
-                const responsePayload: Record<string, unknown> = {
-                  success: debugResult.success,
-                  state: debugResult.state,
-                  message: debugResult.error
-                    ? debugResult.error
-                    : (debugResult.data as Record<string, unknown>)?.message || 'Debugging restarted',
-                };
-                if (debugResult.error) {
-                  responsePayload.error = debugResult.error;
-                }
-                if (debugResult.data) {
-                  responsePayload.data = debugResult.data;
-                  // Surface the merged restart warning (stale anchors and/or
-                  // unbound function breakpoints) at the top level too —
-                  // same discoverability as set_breakpoint/start_debugging.
-                  const restartWarning = (debugResult.data as { warning?: string }).warning;
-                  if (debugResult.success && restartWarning) {
-                    responsePayload.warning = restartWarning;
-                  }
-                }
-                result = { content: [{ type: 'text', text: JSON.stringify(responsePayload) }] };
-              } catch (error) {
-                result = this.handleBreakpointToolError(error);
-              }
+              result = await restartDebuggingTool(this, args, toolName);
               break;
             }
             case 'attach_to_process': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-
-              try {
-                if (args.adapterConfig !== undefined) {
-                  const cfg = args.adapterConfig;
-                  if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
-                    throw new McpError(McpErrorCode.InvalidParams, 'adapterConfig must be an object when provided');
-                  }
-                }
-
-                this.logger.info('Attach to process requested', {
-                  sessionId: args.sessionId,
-                  port: args.port,
-                  host: args.host,
-                  processId: args.processId
-                });
-
-                const attachResult = await this.sessionManager.attachToProcess(args.sessionId, {
-                  port: args.port,
-                  host: args.host,
-                  processId: args.processId,
-                  timeout: args.timeout,
-                  verifyTimeout: args.verifyTimeout,
-                  sourcePaths: args.sourcePaths,
-                  stopOnEntry: args.stopOnEntry,
-                  justMyCode: args.justMyCode,
-                  breakOnExceptions: this.validateBreakOnExceptions(args.breakOnExceptions),
-                  adapterConfig: args.adapterConfig
-                });
-
-                const responsePayload: Record<string, unknown> = {
-                  success: attachResult.success,
-                  state: attachResult.state,
-                  message: attachResult.error ||
-                    (attachResult.data as Record<string, unknown>)?.message ||
-                    'Attach operation completed'
-                };
-
-                if (attachResult.data) {
-                  responsePayload.data = attachResult.data;
-                  // Surface the dropped-adapterConfig-keys warning (issue
-                  // #450) at the top level too — same discoverability as
-                  // set_breakpoint/start_debugging/restart_debugging.
-                  const attachWarning = (attachResult.data as { warning?: string }).warning;
-                  if (attachResult.success && attachWarning) {
-                    responsePayload.warning = attachWarning;
-                  }
-                }
-
-                result = { content: [{ type: 'text', text: JSON.stringify(responsePayload) }] };
-              } catch (error) {
-                // Handle session state errors specifically
-                if (error instanceof McpError &&
-                    (error.message.includes('terminated') ||
-                     error.message.includes('closed') ||
-                     (error.message.includes('not found') && error.message.includes('Session')))) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({
-                    success: false,
-                    error: error.message,
-                    state: 'stopped'
-                  }) }] };
-                } else {
-                  throw error;
-                }
-              }
+              result = await attachToProcessTool(this, args, toolName);
               break;
             }
             case 'detach_from_process': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-
-              try {
-                this.logger.info('Detach from process requested', {
-                  sessionId: args.sessionId,
-                  terminateProcess: args.terminateProcess
-                });
-
-                const detachResult = await this.sessionManager.detachFromProcess(
-                  args.sessionId,
-                  args.terminateProcess ?? false
-                );
-
-                const responsePayload: Record<string, unknown> = {
-                  success: detachResult.success,
-                  state: detachResult.state,
-                  message: detachResult.error ||
-                    (detachResult.data as Record<string, unknown>)?.message ||
-                    'Detach operation completed'
-                };
-
-                if (detachResult.data) {
-                  responsePayload.data = detachResult.data;
-                }
-
-                result = { content: [{ type: 'text', text: JSON.stringify(responsePayload) }] };
-              } catch (error) {
-                // Handle session state errors specifically
-                if (error instanceof McpError &&
-                    (error.message.includes('terminated') ||
-                     error.message.includes('closed') ||
-                     (error.message.includes('not found') && error.message.includes('Session')))) {
-                  result = { content: [{ type: 'text', text: JSON.stringify({
-                    success: false,
-                    error: error.message,
-                    state: 'stopped'
-                  }) }] };
-                } else {
-                  throw error;
-                }
-              }
+              result = await detachFromProcessTool(this, args, toolName);
               break;
             }
             case 'expose_session': {
@@ -1702,15 +1523,7 @@ export class DebugMcpServer implements ToolContext {
               break;
             }
             case 'redefine_classes': {
-              const redefineResult = await this.sessionManager.redefineClasses(
-                args.sessionId as string,
-                args.classesDir as string,
-                (args.sinceTimestamp as number) || 0,
-                args.timeout
-              );
-              result = {
-                content: [{ type: 'text' as const, text: JSON.stringify(redefineResult, null, 2) }],
-              };
+              result = await redefineClassesTool(this, args, toolName);
               break;
             }
             default:

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,17 +10,11 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
-  ListResourcesRequestSchema,
-  ReadResourceRequestSchema,
-  SubscribeRequestSchema,
-  UnsubscribeRequestSchema,
-  ListPromptsRequestSchema,
-  GetPromptRequestSchema,
   ErrorCode as McpErrorCode,
   McpError,
   ServerResult,
 } from '@modelcontextprotocol/sdk/types.js';
-import { buildServerInstructions, buildDebuggingWorkflowPrompt } from './skill-content.js';
+import { buildServerInstructions } from './skill-content.js';
 import {
   SessionNotFoundError,
   SessionTerminatedError,
@@ -71,6 +65,8 @@ import { assertLineContent, resolveStatement, stripTrailingComment } from './uti
 import { coerceToolArguments, ToolArguments } from './server/tool-arguments.js';
 import { extractPayloadSuccess, sanitizeRequest } from './server/tool-result.js';
 import { buildToolDefinitions } from './server/tool-schemas.js';
+import { OutputResourceNotifier, registerResourceHandlers } from './server/output-resources.js';
+import { registerPromptHandlers } from './server/prompts.js';
 
 export { coerceToolArguments };
 
@@ -152,15 +148,8 @@ export class DebugMcpServer {
   private environment: IEnvironment;
 
   // Debuggee-output resource subscriptions (issue #218).
-  // URIs subscribed via resources/subscribe; updated-pings are debounced so
-  // notification volume is independent of debuggee output volume.
-  private static readonly OUTPUT_UPDATE_DEBOUNCE_MS = 150;
-  private subscribedUris = new Set<string>();
-  private outputUpdateTimers = new Map<string, NodeJS.Timeout>();
+  private outputResources: OutputResourceNotifier;
   private validationCache = new ValidationResultCache();
-  private handleOutputCaptured = (sessionId: string): void => {
-    this.scheduleOutputResourceUpdated(sessionId);
-  };
 
   // Get supported languages from adapter registry
   private async getSupportedLanguagesAsync(): Promise<string[]> {
@@ -917,11 +906,12 @@ export class DebugMcpServer {
     };
     
     this.sessionManager = new SessionManager(sessionManagerConfig, dependencies);
+    this.outputResources = new OutputResourceNotifier(this.server, this.logger);
 
     this.registerTools();
-    this.registerResources();
-    this.registerPrompts();
-    this.sessionManager.on('output-captured', this.handleOutputCaptured);
+    registerResourceHandlers(this.server, this.sessionManager, this.outputResources);
+    registerPromptHandlers(this.server, this.environment);
+    this.sessionManager.on('output-captured', this.outputResources.handleOutputCaptured);
     this.server.onerror = (error) => {
       this.logger.error('Server error', { error });
     };
@@ -1055,7 +1045,7 @@ export class DebugMcpServer {
               });
 
               // A new output resource is now listable (issue #218)
-              this.notifyResourceListChanged();
+              this.outputResources.notifyListChanged();
 
               // Check if attach mode is requested (host/port provided)
               const isAttachMode = args.port !== undefined;
@@ -1711,10 +1701,8 @@ export class DebugMcpServer {
                 });
 
                 // The session's output resource is gone (issue #218)
-                const outputUri = this.outputResourceUri(args.sessionId);
-                this.subscribedUris.delete(outputUri);
-                this.clearOutputUpdateTimer(outputUri);
-                this.notifyResourceListChanged();
+                this.outputResources.forgetSession(args.sessionId);
+                this.outputResources.notifyListChanged();
               }
               
               result = { content: [{ type: 'text', text: JSON.stringify({ success: closed, message: closed ? `Closed debug session: ${args.sessionId}` : `Failed to close debug session: ${args.sessionId}` }) }] };
@@ -2021,142 +2009,6 @@ export class DebugMcpServer {
         }
       }
     );
-  }
-
-  // ===== Debuggee-output resources (issue #218) =====
-
-  private outputResourceUri(sessionId: string): string {
-    return `debug://sessions/${sessionId}/output`;
-  }
-
-  /** Returns the sessionId encoded in a debug output resource URI, or undefined. */
-  private parseOutputResourceUri(uri: string): string | undefined {
-    const match = /^debug:\/\/sessions\/([^/]+)\/output$/.exec(uri);
-    return match?.[1];
-  }
-
-  /**
-   * Registers MCP resource handlers. Each debug session exposes its captured
-   * debuggee output as debug://sessions/{id}/output — a verbatim console
-   * transcript (all categories interleaved, in arrival order). Clients may
-   * subscribe to receive coalesced resources/updated pings as output arrives;
-   * structured/cursor access is available via the get_output tool.
-   */
-  private registerResources(): void {
-    this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
-      const sessions = this.sessionManager.getAllSessions();
-      return {
-        resources: sessions.map(session => ({
-          uri: this.outputResourceUri(session.id),
-          name: `Debuggee output — ${session.name}`,
-          description: `stdout/stderr/console output captured for ${session.language} debug session '${session.name}'`,
-          mimeType: 'text/plain'
-        }))
-      };
-    });
-
-    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-      const uri = request.params.uri;
-      const sessionId = this.parseOutputResourceUri(uri);
-      const session = sessionId ? this.sessionManager.getSession(sessionId) : undefined;
-      if (!session) {
-        throw new McpError(McpErrorCode.InvalidParams, `Unknown resource: ${uri}`);
-      }
-      return {
-        contents: [{
-          uri,
-          mimeType: 'text/plain',
-          // Empty until the first launch creates the buffer
-          text: session.outputBuffer?.renderText() ?? ''
-        }]
-      };
-    });
-
-    this.server.setRequestHandler(SubscribeRequestSchema, async (request) => {
-      const uri = request.params.uri;
-      const sessionId = this.parseOutputResourceUri(uri);
-      if (!sessionId || !this.sessionManager.getSession(sessionId)) {
-        throw new McpError(McpErrorCode.InvalidParams, `Unknown resource: ${uri}`);
-      }
-      this.subscribedUris.add(uri);
-      return {};
-    });
-
-    this.server.setRequestHandler(UnsubscribeRequestSchema, async (request) => {
-      const uri = request.params.uri;
-      this.subscribedUris.delete(uri);
-      this.clearOutputUpdateTimer(uri);
-      return {};
-    });
-  }
-
-  /**
-   * Registers MCP prompt handlers. The single `debugging-workflow` prompt
-   * serves the condensed debugging skill in-band so any connected agent can
-   * pull workflow guidance without a separate skill install (the full skill
-   * with per-language references ships in skills/debugging/).
-   */
-  private registerPrompts(): void {
-    const promptDescriptor = {
-      name: 'debugging-workflow',
-      description:
-        'How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks.'
-    };
-
-    this.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
-      prompts: [promptDescriptor]
-    }));
-
-    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-      if (request.params.name !== promptDescriptor.name) {
-        throw new McpError(McpErrorCode.InvalidParams, `Unknown prompt: ${request.params.name}`);
-      }
-      return {
-        description: promptDescriptor.description,
-        messages: [
-          {
-            role: 'user' as const,
-            content: { type: 'text' as const, text: buildDebuggingWorkflowPrompt(getBpAddressingMode(this.environment)) }
-          }
-        ]
-      };
-    });
-  }
-
-  /**
-   * Throttled resources/updated ping for a session's output resource: the
-   * first captured event after a quiet period arms a timer; everything that
-   * arrives inside the window rides the same ping.
-   */
-  private scheduleOutputResourceUpdated(sessionId: string): void {
-    const uri = this.outputResourceUri(sessionId);
-    if (!this.subscribedUris.has(uri) || this.outputUpdateTimers.has(uri)) {
-      return;
-    }
-    const timer = setTimeout(() => {
-      this.outputUpdateTimers.delete(uri);
-      this.server.sendResourceUpdated({ uri }).catch((error: unknown) => {
-        // Not connected yet / transport gone — nothing to notify, not an error.
-        this.logger.debug(`[Server] Failed to send resources/updated for ${uri}`, { error });
-      });
-    }, DebugMcpServer.OUTPUT_UPDATE_DEBOUNCE_MS);
-    timer.unref?.();
-    this.outputUpdateTimers.set(uri, timer);
-  }
-
-  private clearOutputUpdateTimer(uri: string): void {
-    const timer = this.outputUpdateTimers.get(uri);
-    if (timer) {
-      clearTimeout(timer);
-      this.outputUpdateTimers.delete(uri);
-    }
-  }
-
-  /** Fire-and-forget resources/list_changed (sessions appeared/disappeared). */
-  private notifyResourceListChanged(): void {
-    this.server.sendResourceListChanged().catch((error: unknown) => {
-      this.logger.debug('[Server] Failed to send resources/list_changed', { error });
-    });
   }
 
   private async handleListDebugSessions(): Promise<ServerResult> {
@@ -2720,11 +2572,8 @@ export class DebugMcpServer {
     // Tear down output-resource bookkeeping (issue #218): pending debounce
     // timers and the SessionManager listener must not outlive the server
     // (the test suite runs with a strict leak guard).
-    for (const uri of this.outputUpdateTimers.keys()) {
-      this.clearOutputUpdateTimer(uri);
-    }
-    this.subscribedUris.clear();
-    this.sessionManager.removeListener('output-captured', this.handleOutputCaptured);
+    this.outputResources.dispose();
+    this.sessionManager.removeListener('output-captured', this.outputResources.handleOutputCaptured);
     this.logger.info('Debug MCP Server stopped');
     // Last: detach this server's logger from the shared file transport so
     // per-session servers in HTTP mode don't accumulate on it (issue #404).

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import {
     SessionLifecycleState,
     SessionState,
     IEnvironment,
+    ILogger,
     ExceptionBreakMode,
     REDACTION_NOTICE
 } from '@debugmcp/shared';
@@ -68,8 +69,11 @@ import { buildToolDefinitions } from './server/tool-schemas.js';
 import { OutputResourceNotifier, registerResourceHandlers } from './server/output-resources.js';
 import { registerPromptHandlers } from './server/prompts.js';
 import { discoverSupportedLanguages, buildLanguageMetadata, LanguageMetadata } from './server/language-discovery.js';
+import type { ToolContext, SetBreakpointRequest } from './server/tool-context.js';
+import type { ToolResult } from './server/tool-result.js';
 
 export { coerceToolArguments };
+export type { SetBreakpointRequest };
 
 /**
  * Configuration options for the Debug MCP Server
@@ -93,40 +97,28 @@ interface AvailableLanguage {
 }
 
 /**
- * Request shape for DebugMcpServer.setBreakpoint (issue #271).
- */
-export interface SetBreakpointRequest {
-  sessionId: string;
-  file: string;
-  /** 1-based target line (required unless statement is given) */
-  line?: number;
-  /** Assert the target line's trimmed content before setting (assert/content modes) */
-  expectedContent?: string;
-  /** Content anchor: whole-line trimmed-equality match (content mode) */
-  statement?: string;
-  /** Disambiguates a multi-match statement to the closest occurrence */
-  nearLine?: number;
-  condition?: string;
-  logMessage?: string;
-  suspendPolicy?: 'all' | 'thread';
-}
-
-/**
  * Main Debug MCP Server class
  */
-export class DebugMcpServer {
+export class DebugMcpServer implements ToolContext {
   public server: Server;
-  private sessionManager: SessionManager;
-  private logger;
+  /** @internal ToolContext dependency; read live by the tool handlers. */
+  public readonly sessionManager: SessionManager;
+  /** @internal ToolContext dependency; read live by the tool handlers. */
+  public readonly logger: ILogger;
   /** Detaches this server's logger from the shared file transport on stop() (issue #404). */
   private readonly disposeLogger?: () => void;
-  private fileChecker: SimpleFileChecker;
-  private lineReader: LineReader;
-  private environment: IEnvironment;
+  /** @internal ToolContext dependency; read live by the tool handlers. */
+  public readonly fileChecker: SimpleFileChecker;
+  /** @internal ToolContext dependency; read live by the tool handlers. */
+  public readonly lineReader: LineReader;
+  /** @internal ToolContext dependency; read live by the tool handlers. */
+  public readonly environment: IEnvironment;
 
   // Debuggee-output resource subscriptions (issue #218).
-  private outputResources: OutputResourceNotifier;
-  private validationCache = new ValidationResultCache();
+  /** @internal ToolContext dependency; read live by the tool handlers. */
+  public readonly outputResources: OutputResourceNotifier;
+  /** @internal ToolContext dependency; read live by the tool handlers. */
+  public readonly validationCache = new ValidationResultCache();
 
   /** @internal Language discovery is a ToolContext service; see src/server/language-discovery.ts. */
   public async getSupportedLanguagesAsync(): Promise<string[]> {
@@ -140,8 +132,9 @@ export class DebugMcpServer {
 
   /**
    * Validate session exists and is not terminated
+   * @internal ToolContext service.
    */
-  private validateSession(sessionId: string): void {
+  public validateSession(sessionId: string): void {
     const session = this.sessionManager.getSession(sessionId);
     if (!session) {
       // Typed subclass of McpError (same code/message) so per-tool catch blocks
@@ -160,8 +153,9 @@ export class DebugMcpServer {
    * supportsLogPoints is false — is a hard error; known-supported passes;
    * unknown support passes with a warning and is re-checked against the
    * adapter's real capabilities at launch (drift warning).
+   * @internal ToolContext service.
    */
-  private validateLogPointSupport(sessionId: string): { warning?: string } {
+  public validateLogPointSupport(sessionId: string): { warning?: string } {
     const session = this.sessionManager.getSession(sessionId);
     const liveCaps = session?.adapterCapabilities;
     const policy = this.sessionManager.getSessionPolicy(sessionId);
@@ -191,8 +185,9 @@ export class DebugMcpServer {
    * verdict is checked FIRST. The policy encodes what the adapter and our
    * plumbing can actually deliver, so an explicit policy false must beat
    * whatever the live capabilities claim.
+   * @internal ToolContext service.
    */
-  private validateFunctionBreakpointSupport(sessionId: string): { warning?: string } {
+  public validateFunctionBreakpointSupport(sessionId: string): { warning?: string } {
     const session = this.sessionManager.getSession(sessionId);
     const liveCaps = session?.adapterCapabilities;
     const policy = this.sessionManager.getSessionPolicy(sessionId);
@@ -225,8 +220,9 @@ export class DebugMcpServer {
   /**
    * Per-adapter function-breakpoint name advisory (issues #303/#308).
    * Swallows policy-lookup failures — a hint must never break the set path.
+   * @internal ToolContext service.
    */
-  private getFunctionBreakpointNameHint(sessionId: string, functionName: string): string | undefined {
+  public getFunctionBreakpointNameHint(sessionId: string, functionName: string): string | undefined {
     try {
       return this.sessionManager.getSessionPolicy(sessionId).functionBreakpointNameHint?.(functionName);
     } catch {
@@ -237,8 +233,9 @@ export class DebugMcpServer {
   /**
    * Policy-certain function-breakpoint name rewrite (issue #467). Swallows
    * policy-lookup failures — normalization must never break the set path.
+   * @internal ToolContext service.
    */
-  private normalizeFunctionBreakpointName(
+  public normalizeFunctionBreakpointName(
     sessionId: string,
     functionName: string
   ): { name: string; note: string } | undefined {
@@ -253,8 +250,9 @@ export class DebugMcpServer {
    * Shared catch for the breakpoint management tools: session-lifecycle
    * failures become {success: false} results (same contract as
    * set_breakpoint's catch); everything else re-throws.
+   * @internal ToolContext service.
    */
-  private handleBreakpointToolError(error: unknown): { content: [{ type: 'text'; text: string }] } {
+  public handleBreakpointToolError(error: unknown): ToolResult {
     if (error instanceof McpError &&
         (error.message.includes('terminated') ||
          error.message.includes('closed') ||
@@ -264,7 +262,8 @@ export class DebugMcpServer {
     throw error;
   }
 
-  private validateBreakOnExceptions(value: string | undefined): ExceptionBreakMode | undefined {
+  /** @internal ToolContext service. */
+  public validateBreakOnExceptions(value: string | undefined): ExceptionBreakMode | undefined {
     if (value === undefined) {
       return undefined;
     }
@@ -303,8 +302,9 @@ export class DebugMcpServer {
    * - Other never-valid nested keys are stripped with a warning.
    * Fixing at intake also cures restart_debugging replay, which snapshots the
    * post-intake values into session.lastLaunch downstream.
+   * @internal ToolContext service.
    */
-  private normalizeStartDebuggingArgs(
+  public normalizeStartDebuggingArgs(
     dapLaunchArgs: Partial<DebugProtocol.LaunchRequestArguments> | undefined,
     topLevelBreakOnExceptions: string | undefined
   ): {
@@ -809,8 +809,9 @@ export class DebugMcpServer {
 
   /**
    * Get session name for logging
+   * @internal ToolContext service.
    */
-  private getSessionName(sessionId: string): string {
+  public getSessionName(sessionId: string): string {
     try {
       const session = this.sessionManager.getSession(sessionId);
       return session?.name || 'Unknown Session';
@@ -819,7 +820,8 @@ export class DebugMcpServer {
     }
   }
 
-  private fileNotFoundError(label: string, originalPath: string, fileCheck: FileExistenceResult): McpError {
+  /** @internal ToolContext service. */
+  public fileNotFoundError(label: string, originalPath: string, fileCheck: FileExistenceResult): McpError {
     const containerHint = isContainerMode(this.environment)
       ? `\nHint: Ensure the Docker volume mount maps your project root to ${getWorkspaceRoot(this.environment)} (e.g., -v /path/to/project:${getWorkspaceRoot(this.environment)})`
       : '';
@@ -1938,8 +1940,9 @@ export class DebugMcpServer {
    * Least-privilege enforcement (issue #237): in explicit mode, bulk scope
    * dumps are disabled — the tools require a non-empty names filter, and the
    * error teaches the correct call shape.
+   * @internal ToolContext service.
    */
-  private enforceExplicitNames(toolName: string, names: string[] | undefined): void {
+  public enforceExplicitNames(toolName: string, names: string[] | undefined): void {
     if (!requiresExplicitNames(getVariableAccessMode(this.environment))) {
       return;
     }
@@ -1957,8 +1960,9 @@ export class DebugMcpServer {
    * Top-level `redaction` notice object for tool results (issue #237):
    * present when any returned item carries the session layer's `redacted`
    * flag, so the agent learns why values changed and how to opt out.
+   * @internal ToolContext service.
    */
-  private redactionSummary(items: Array<{ redacted?: boolean }>): { masked: number; notice: string } | undefined {
+  public redactionSummary(items: Array<{ redacted?: boolean }>): { masked: number; notice: string } | undefined {
     const masked = items.filter(item => item.redacted).length;
     return masked > 0 ? { masked, notice: REDACTION_NOTICE } : undefined;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,6 +104,7 @@ import {
   handleGetLocalVariables
 } from './server/handlers/inspection-tools.js';
 import { getOutputTool } from './server/handlers/output-tools.js';
+import { exposeSessionTool, unexposeSessionTool } from './server/handlers/mirror-tools.js';
 
 export { coerceToolArguments };
 export type { SetBreakpointRequest };
@@ -932,17 +933,11 @@ export class DebugMcpServer implements ToolContext {
               break;
             }
             case 'expose_session': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-              result = await this.handleExposeSession(args.sessionId);
+              result = await exposeSessionTool(this, args, toolName);
               break;
             }
             case 'unexpose_session': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-              result = await this.handleUnexposeSession(args.sessionId);
+              result = await unexposeSessionTool(this, args, toolName);
               break;
             }
             case 'close_debug_session': {
@@ -1075,79 +1070,6 @@ export class DebugMcpServer implements ToolContext {
   /** @internal test seam; removed in PR 6 */
   private async handlePause(args: { sessionId: string; threadId?: number }): Promise<ToolResult> {
     return handlePause(this, args);
-  }
-
-  private async handleExposeSession(sessionId: string): Promise<ServerResult> {
-    try {
-      this.validateSession(sessionId);
-      const result = await this.sessionManager.exposeSession(sessionId);
-      if (!result.success) {
-        return { content: [{ type: 'text', text: JSON.stringify({
-          success: false,
-          state: result.state,
-          error: result.error
-        }) }] };
-      }
-      let message =
-        `Session exposed for IDE attach at ${result.host}:${result.port}. ` +
-        `VS Code: add a launch.json config {"name": "Mirror: agent debug session", ` +
-        `"type": "<your language's debug type, e.g. python>", "request": "attach", ` +
-        `"debugServer": ${result.port}, "mirrorToken": "${result.token}"} and start it. ` +
-        `The mirror is inspect-only; execution control stays with this session. ` +
-        `Full guidance: docs/tool-reference.md#expose_session.`;
-      if (isContainerMode(this.environment)) {
-        message +=
-          ' Note: this server runs inside a container — the mirror listens on the ' +
-          "container's loopback and is not reachable from your host IDE without extra " +
-          'networking (e.g. docker run --network host on Linux, or a socat/ssh forward ' +
-          'into the container).';
-      }
-      return { content: [{ type: 'text', text: JSON.stringify({
-        success: true,
-        state: result.state,
-        host: result.host,
-        port: result.port,
-        token: result.token,
-        message
-      }) }] };
-    } catch (error) {
-      this.logger.error('Failed to expose session', { error });
-      if (error instanceof SessionTerminatedError ||
-          error instanceof SessionNotFoundError ||
-          error instanceof ProxyNotRunningError) {
-        return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-      }
-      if (error instanceof McpError) throw error;
-      throw new McpError(McpErrorCode.InternalError, `Failed to expose session: ${(error as Error).message}`);
-    }
-  }
-
-  private async handleUnexposeSession(sessionId: string): Promise<ServerResult> {
-    try {
-      this.validateSession(sessionId);
-      const result = await this.sessionManager.unexposeSession(sessionId);
-      const message = !result.success
-        ? undefined
-        : result.wasExposed
-          ? `Mirror endpoint closed${typeof result.closedClients === 'number' ? ` (${result.closedClients} client${result.closedClients === 1 ? '' : 's'} disconnected)` : ''}`
-          : 'Session was not exposed — nothing to close';
-      return { content: [{ type: 'text', text: JSON.stringify({
-        success: result.success,
-        state: result.state,
-        ...(result.wasExposed !== undefined ? { wasExposed: result.wasExposed } : {}),
-        ...(message ? { message } : {}),
-        ...(result.error ? { error: result.error } : {})
-      }) }] };
-    } catch (error) {
-      this.logger.error('Failed to unexpose session', { error });
-      if (error instanceof SessionTerminatedError ||
-          error instanceof SessionNotFoundError ||
-          error instanceof ProxyNotRunningError) {
-        return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
-      }
-      if (error instanceof McpError) throw error;
-      throw new McpError(McpErrorCode.InternalError, `Failed to unexpose session: ${(error as Error).message}`);
-    }
   }
 
   /** @internal test seam; removed in PR 6 */

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,11 +8,8 @@
  */
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
   ErrorCode as McpErrorCode,
   McpError,
-  ServerResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { buildServerInstructions } from './skill-content.js';
 import {
@@ -53,57 +50,22 @@ import {
 import { isRedactionEnabled } from './utils/redaction-mode.js';
 import { getVariableAccessMode, requiresExplicitNames } from './utils/variable-access.js';
 import { assertLineContent, resolveStatement, stripTrailingComment } from './utils/breakpoint-resolver.js';
-import { coerceToolArguments, ToolArguments } from './server/tool-arguments.js';
-import { extractPayloadSuccess, sanitizeRequest } from './server/tool-result.js';
-import { buildToolDefinitions } from './server/tool-schemas.js';
 import { OutputResourceNotifier, registerResourceHandlers } from './server/output-resources.js';
 import { registerPromptHandlers } from './server/prompts.js';
 import { discoverSupportedLanguages, buildLanguageMetadata, LanguageMetadata } from './server/language-discovery.js';
 import type { ToolContext, SetBreakpointRequest } from './server/tool-context.js';
 import type { ToolResult } from './server/tool-result.js';
+import { handleListDebugSessions } from './server/handlers/session-tools.js';
+import { handlePause, handleListThreads } from './server/handlers/execution-tools.js';
 import {
-  createDebugSessionTool,
-  listDebugSessionsTool,
-  closeDebugSessionTool,
-  handleListDebugSessions
-} from './server/handlers/session-tools.js';
-import {
-  startDebuggingTool,
-  restartDebuggingTool,
-  attachToProcessTool,
-  detachFromProcessTool,
-  redefineClassesTool
-} from './server/handlers/debuggee-tools.js';
-import {
-  setBreakpointTool,
-  listBreakpointsTool,
-  removeBreakpointTool,
-  clearBreakpointsTool
-} from './server/handlers/breakpoint-tools.js';
-import {
-  stepTool,
-  continueExecutionTool,
-  pauseExecutionTool,
-  listThreadsTool,
-  handlePause,
-  handleListThreads
-} from './server/handlers/execution-tools.js';
-import {
-  getVariablesTool,
-  getStackTraceTool,
-  getScopesTool,
-  evaluateExpressionTool,
-  getSourceContextTool,
-  getLocalVariablesTool,
   handleEvaluateExpression,
   handleGetSourceContext,
   handleGetLocalVariables
 } from './server/handlers/inspection-tools.js';
-import { getOutputTool } from './server/handlers/output-tools.js';
-import { exposeSessionTool, unexposeSessionTool } from './server/handlers/mirror-tools.js';
-import { listSupportedLanguagesTool, handleListSupportedLanguages } from './server/handlers/language-tools.js';
+import { handleListSupportedLanguages } from './server/handlers/language-tools.js';
+import { registerToolHandlers } from './server/tool-dispatch.js';
 
-export { coerceToolArguments };
+export { coerceToolArguments } from './server/tool-arguments.js';
 export type { SetBreakpointRequest };
 
 /**
@@ -848,171 +810,7 @@ export class DebugMcpServer implements ToolContext {
   }
 
   private registerTools(): void {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      this.logger.debug('Handling ListToolsRequest');
-      
-      // Get supported languages dynamically - deferred until request time
-      const supportedLanguages = await this.getSupportedLanguagesAsync();
-      
-      return { tools: buildToolDefinitions({ supportedLanguages, environment: this.environment }) };
-    });
-
-    this.server.setRequestHandler(
-      CallToolRequestSchema,
-      async (request): Promise<ServerResult> => {
-        const toolName = request.params.name;
-        const args = coerceToolArguments((request.params.arguments ?? {}) as Record<string, unknown>) as ToolArguments;
-
-        // Log tool call with structured logging
-        this.logger.info('tool:call', {
-          tool: toolName,
-          sessionId: args.sessionId,
-          sessionName: args.sessionId ? this.getSessionName(args.sessionId) : undefined,
-          request: sanitizeRequest(args as Record<string, unknown>),
-          timestamp: Date.now()
-        });
-
-        try {
-          let result: ServerResult;
-          
-          switch (toolName) {
-            case 'create_debug_session': {
-              result = await createDebugSessionTool(this, args, toolName);
-              break;
-            }
-            case 'list_debug_sessions': {
-              result = await listDebugSessionsTool(this, args, toolName);
-              break;
-            }
-            case 'set_breakpoint': {
-              result = await setBreakpointTool(this, args, toolName);
-              break;
-            }
-            case 'list_breakpoints': {
-              result = await listBreakpointsTool(this, args, toolName);
-              break;
-            }
-            case 'remove_breakpoint': {
-              result = await removeBreakpointTool(this, args, toolName);
-              break;
-            }
-            case 'clear_breakpoints': {
-              result = await clearBreakpointsTool(this, args, toolName);
-              break;
-            }
-            case 'start_debugging': {
-              result = await startDebuggingTool(this, args, toolName);
-              break;
-            }
-            case 'restart_debugging': {
-              result = await restartDebuggingTool(this, args, toolName);
-              break;
-            }
-            case 'attach_to_process': {
-              result = await attachToProcessTool(this, args, toolName);
-              break;
-            }
-            case 'detach_from_process': {
-              result = await detachFromProcessTool(this, args, toolName);
-              break;
-            }
-            case 'expose_session': {
-              result = await exposeSessionTool(this, args, toolName);
-              break;
-            }
-            case 'unexpose_session': {
-              result = await unexposeSessionTool(this, args, toolName);
-              break;
-            }
-            case 'close_debug_session': {
-              result = await closeDebugSessionTool(this, args, toolName);
-              break;
-            }
-            case 'step_over':
-            case 'step_into':
-            case 'step_out': {
-              result = await stepTool(this, args, toolName);
-              break;
-            }
-            case 'continue_execution': {
-              result = await continueExecutionTool(this, args, toolName);
-              break;
-            }
-            case 'pause_execution': {
-              result = await pauseExecutionTool(this, args, toolName);
-              break;
-            }
-            case 'list_threads': {
-              result = await listThreadsTool(this, args, toolName);
-              break;
-            }
-            case 'get_variables': {
-              result = await getVariablesTool(this, args, toolName);
-              break;
-            }
-            case 'get_stack_trace': {
-              result = await getStackTraceTool(this, args, toolName);
-              break;
-            }
-            case 'get_scopes': {
-              result = await getScopesTool(this, args, toolName);
-              break;
-            }
-            case 'evaluate_expression': {
-              result = await evaluateExpressionTool(this, args, toolName);
-              break;
-            }
-            case 'get_source_context': {
-              result = await getSourceContextTool(this, args, toolName);
-              break;
-            }
-            case 'get_local_variables': {
-              result = await getLocalVariablesTool(this, args, toolName);
-              break;
-            }
-            case 'get_output': {
-              result = await getOutputTool(this, args, toolName);
-              break;
-            }
-            case 'list_supported_languages': {
-              result = await listSupportedLanguagesTool(this, args, toolName);
-              break;
-            }
-            case 'redefine_classes': {
-              result = await redefineClassesTool(this, args, toolName);
-              break;
-            }
-            default:
-              throw new McpError(McpErrorCode.MethodNotFound, `Unknown tool: ${toolName}`);
-          }
-          
-          // Log tool response; success mirrors the payload's own success flag (issue #397)
-          this.logger.info('tool:response', {
-            tool: toolName,
-            sessionId: args.sessionId,
-            sessionName: args.sessionId ? this.getSessionName(args.sessionId) : undefined,
-            success: extractPayloadSuccess(result),
-            timestamp: Date.now()
-          });
-          
-          return result;
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          
-          // Log tool error
-          this.logger.error('tool:error', {
-            tool: toolName,
-            sessionId: args.sessionId,
-            sessionName: args.sessionId ? this.getSessionName(args.sessionId) : undefined,
-            error: errorMessage,
-            timestamp: Date.now()
-          });
-          
-          if (error instanceof McpError) throw error;
-          throw new McpError(McpErrorCode.InternalError, `Failed to execute tool ${toolName}: ${errorMessage}`);
-        }
-      }
-    );
+    registerToolHandlers(this.server, this);
   }
 
   /** @internal test seam; removed in PR 6 */

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,21 +67,9 @@ import { extractPayloadSuccess, sanitizeRequest } from './server/tool-result.js'
 import { buildToolDefinitions } from './server/tool-schemas.js';
 import { OutputResourceNotifier, registerResourceHandlers } from './server/output-resources.js';
 import { registerPromptHandlers } from './server/prompts.js';
+import { discoverSupportedLanguages, buildLanguageMetadata, LanguageMetadata } from './server/language-discovery.js';
 
 export { coerceToolArguments };
-
-const DEFAULT_LANGUAGES = Object.freeze([DebugLanguage.PYTHON, DebugLanguage.MOCK] as const);
-
-function getDefaultLanguages(): string[] {
-  return [...DEFAULT_LANGUAGES];
-}
-
-function ensureLanguage(
-  languages: readonly string[],
-  language: string
-): string[] {
-  return languages.includes(language) ? [...languages] : [...languages, language];
-}
 
 /**
  * Configuration options for the Debug MCP Server
@@ -89,17 +77,6 @@ function ensureLanguage(
 export interface DebugMcpServerOptions {
   logLevel?: string;
   logFile?: string;
-}
-
-/**
- * Language metadata for supported languages
- */
-interface LanguageMetadata {
-  id: string;
-  displayName: string;
-  version: string;
-  requiresExecutable: boolean;
-  defaultExecutable?: string;
 }
 
 /**
@@ -151,101 +128,14 @@ export class DebugMcpServer {
   private outputResources: OutputResourceNotifier;
   private validationCache = new ValidationResultCache();
 
-  // Get supported languages from adapter registry
-  private async getSupportedLanguagesAsync(): Promise<string[]> {
-    const disabled = getDisabledLanguages();
-    const filter = (langs: readonly string[]) => this.filterDisabledLanguages(langs, disabled);
-    const adapterRegistry = this.getAdapterRegistry();
-    // Guard against undefined registry in certain test environments
-    if (!adapterRegistry) {
-      return filter(getDefaultLanguages());
-    }
-    // Prefer dynamic discovery. listLanguages is on IAdapterRegistry (issue
-    // #435 part 4); the runtime guard stays for partial registry doubles.
-    const maybeList = adapterRegistry.listLanguages;
-    if (typeof maybeList === 'function') {
-      try {
-        const langs = await maybeList.call(adapterRegistry);
-        if (Array.isArray(langs) && langs.length > 0) {
-          const normalized =
-            process.env.MCP_CONTAINER === 'true' ? ensureLanguage(langs, DebugLanguage.PYTHON) : langs;
-          return filter(normalized);
-        }
-      } catch (e) {
-        this.logger.warn('Dynamic adapter language discovery failed, falling back to registered languages', { error: (e as Error)?.message });
-      }
-    }
-    // Fallback to already-registered factories (may be empty until first use)
-    const langs = adapterRegistry.getSupportedLanguages?.() || [];
-    if (langs.length > 0) {
-      // In container runtime, ensure python is advertised even if not yet registered (preload may be async)
-      if (process.env.MCP_CONTAINER === 'true') {
-        return filter(ensureLanguage(langs, DebugLanguage.PYTHON));
-      }
-      return filter(langs);
-    }
-    // Final fallback to known defaults for UX (ensure python listed in container)
-    if (process.env.MCP_CONTAINER === 'true') {
-      return filter(ensureLanguage(getDefaultLanguages(), DebugLanguage.PYTHON));
-    }
-    return filter(getDefaultLanguages());
+  /** @internal Language discovery is a ToolContext service; see src/server/language-discovery.ts. */
+  public async getSupportedLanguagesAsync(): Promise<string[]> {
+    return discoverSupportedLanguages(this.getAdapterRegistry(), this.logger);
   }
 
-  // Get language metadata for all supported languages
-  private async getLanguageMetadata(): Promise<LanguageMetadata[]> {
-    const languages = await this.getSupportedLanguagesAsync();
-
-    // Hardcoded metadata fallback; adapters could provide this via registry in the future
-    return languages.map((lang: string) => {
-      switch (lang) {
-        case DebugLanguage.PYTHON:
-          return {
-            id: DebugLanguage.PYTHON,
-            displayName: 'Python',
-            version: '1.0.0',
-            requiresExecutable: true,
-            defaultExecutable: 'python'
-          };
-        case DebugLanguage.RUBY:
-          return {
-            id: DebugLanguage.RUBY,
-            displayName: 'Ruby',
-            version: '1.0.0',
-            requiresExecutable: true,
-            defaultExecutable: 'ruby'
-          };
-        case DebugLanguage.MOCK:
-          return {
-            id: DebugLanguage.MOCK,
-            displayName: 'Mock',
-            version: '1.0.0',
-            requiresExecutable: false
-          };
-        case DebugLanguage.JAVASCRIPT:
-          return {
-            id: DebugLanguage.JAVASCRIPT,
-            displayName: 'JavaScript/TypeScript',
-            version: '1.0.0',
-            requiresExecutable: true,
-            defaultExecutable: 'node'
-          };
-        case DebugLanguage.CPP:
-          return {
-            id: DebugLanguage.CPP,
-            displayName: 'C/C++',
-            version: '1.0.0',
-            requiresExecutable: true,
-            defaultExecutable: 'g++'
-          };
-        default:
-          return {
-            id: lang,
-            displayName: lang.charAt(0).toUpperCase() + lang.slice(1),
-            version: '1.0.0',
-            requiresExecutable: true
-          };
-      }
-    });
+  /** @internal Language metadata is a ToolContext service; see src/server/language-discovery.ts. */
+  public async getLanguageMetadata(): Promise<LanguageMetadata[]> {
+    return buildLanguageMetadata(await this.getSupportedLanguagesAsync());
   }
 
   /**
@@ -2586,16 +2476,5 @@ export class DebugMcpServer {
    */
   public getAdapterRegistry() {
     return this.sessionManager.adapterRegistry;
-  }
-
-  private filterDisabledLanguages(
-    languages: readonly string[],
-    disabled?: Set<string>,
-  ): string[] {
-    const disabledSet = disabled ?? getDisabledLanguages();
-    if (!disabledSet.size) {
-      return [...languages];
-    }
-    return languages.filter((lang) => !disabledSet.has(lang));
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,12 +42,8 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import path from 'path';
 import { SimpleFileChecker, createSimpleFileChecker, FileExistenceResult } from './utils/simple-file-checker.js';
 import { LineReader, createLineReader } from './utils/line-reader.js';
-import { getDisabledLanguages, isLanguageDisabled } from './utils/language-config.js';
-import {
-  probeLanguageEntry,
-  ValidationResultCache,
-  LanguageModes
-} from './utils/language-availability.js';
+import { isLanguageDisabled } from './utils/language-config.js';
+import { ValidationResultCache } from './utils/language-availability.js';
 import { isContainerMode, getWorkspaceRoot } from './utils/container-path-utils.js';
 import {
   getBpAddressingMode,
@@ -105,6 +101,7 @@ import {
 } from './server/handlers/inspection-tools.js';
 import { getOutputTool } from './server/handlers/output-tools.js';
 import { exposeSessionTool, unexposeSessionTool } from './server/handlers/mirror-tools.js';
+import { listSupportedLanguagesTool, handleListSupportedLanguages } from './server/handlers/language-tools.js';
 
 export { coerceToolArguments };
 export type { SetBreakpointRequest };
@@ -115,19 +112,6 @@ export type { SetBreakpointRequest };
 export interface DebugMcpServerOptions {
   logLevel?: string;
   logFile?: string;
-}
-
-/**
- * Entry in the list_supported_languages 'available' array.
- * 'installed' keeps its historical meaning (adapter package loadable);
- * 'modes' carries per-mode availability with reasons (issue #331).
- */
-interface AvailableLanguage {
-  language: string;
-  package: string;
-  installed: boolean;
-  description?: string;
-  modes: LanguageModes;
 }
 
 /**
@@ -991,7 +975,7 @@ export class DebugMcpServer implements ToolContext {
               break;
             }
             case 'list_supported_languages': {
-              result = await this.handleListSupportedLanguages();
+              result = await listSupportedLanguagesTool(this, args, toolName);
               break;
             }
             case 'redefine_classes': {
@@ -1092,84 +1076,9 @@ export class DebugMcpServer implements ToolContext {
     return handleGetLocalVariables(this, args);
   }
 
-  private async handleListSupportedLanguages(): Promise<ServerResult> {
-    try {
-      const adapterRegistry = this.getAdapterRegistry();
-      // Get installed languages via dynamic registry if available
-      const installed = await this.getSupportedLanguagesAsync();
-
-      // Also surface known adapters with install status if available from registry
-      let baseEntries: Array<{ language: string; package: string; installed: boolean; description?: string; attach: 'none' | 'direct-connect' | 'spawn' }> =
-        installed.map(lang => ({
-          language: lang,
-          package: `@debugmcp/adapter-${lang}`,
-          installed: true,
-          attach: 'none' as const
-        }));
-
-      // listAvailableAdapters/getFactory are on IAdapterRegistry (issue #435
-      // part 4); the runtime guards stay for partial registry doubles.
-      if (adapterRegistry && typeof adapterRegistry.listAvailableAdapters === 'function') {
-        try {
-          const meta = await adapterRegistry.listAvailableAdapters();
-          baseEntries = meta.map(m => ({
-            language: m.name,
-            package: m.packageName,
-            installed: m.installed,
-            description: m.description,
-            attach: m.attach ?? 'none'
-          }));
-        } catch (e) {
-          this.logger.warn('Failed to query detailed adapter metadata; returning installed list only', { error: (e as Error)?.message });
-        }
-      }
-
-      // Shared per-entry probe (issue #435): doctor consumes the same
-      // function, so the two views cannot drift apart. Probes run in
-      // parallel — on a cold cache each may import an adapter package and
-      // spawn a toolchain check, and this call should pay the max, not the
-      // sum (the doctor path already runs them concurrently).
-      const disabledSet = getDisabledLanguages();
-      const available: AvailableLanguage[] = await Promise.all(
-        baseEntries.map(async (entry) => {
-          const probe = await probeLanguageEntry(
-            {
-              language: entry.language,
-              packageName: entry.package,
-              installed: entry.installed,
-              attach: entry.attach
-            },
-            {
-              registry: adapterRegistry,
-              disabledSet,
-              runValidate: (language, validate) => this.validationCache.get(language, validate),
-              logger: this.logger
-            }
-          );
-          return {
-            language: entry.language,
-            package: entry.package,
-            installed: entry.installed,
-            description: entry.description,
-            modes: probe.modes
-          };
-        })
-      );
-
-      // Also build simple metadata array for backward compatibility with previous payload shape
-      const languageMetadata = await this.getLanguageMetadata();
-
-      return { content: [{ type: 'text', text: JSON.stringify({
-        success: true,
-        installed,
-        available,
-        languages: languageMetadata, // backward-compatible field with display info
-        count: installed.length
-      }) }] };
-    } catch (error) {
-      this.logger.error('Failed to list supported languages', { error });
-      throw new McpError(McpErrorCode.InternalError, `Failed to list supported languages: ${(error as Error).message}`);
-    }
+  /** @internal test seam; removed in PR 6 */
+  private async handleListSupportedLanguages(): Promise<ToolResult> {
+    return handleListSupportedLanguages(this);
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,6 @@ import { buildServerInstructions } from './skill-content.js';
 import {
   SessionNotFoundError,
   SessionTerminatedError,
-  UnsupportedLanguageError,
   UnsupportedFeatureError,
   ProxyNotRunningError
 } from './errors/debug-errors.js';
@@ -45,10 +44,8 @@ import path from 'path';
 import { SimpleFileChecker, createSimpleFileChecker, FileExistenceResult } from './utils/simple-file-checker.js';
 import { LineReader, createLineReader } from './utils/line-reader.js';
 import { getDisabledLanguages, isLanguageDisabled } from './utils/language-config.js';
-import { ErrorMessages } from './utils/error-messages.js';
 import {
   probeLanguageEntry,
-  checkLaunchToolchain,
   ValidationResultCache,
   LanguageModes
 } from './utils/language-availability.js';
@@ -71,6 +68,12 @@ import { registerPromptHandlers } from './server/prompts.js';
 import { discoverSupportedLanguages, buildLanguageMetadata, LanguageMetadata } from './server/language-discovery.js';
 import type { ToolContext, SetBreakpointRequest } from './server/tool-context.js';
 import type { ToolResult } from './server/tool-result.js';
+import {
+  createDebugSessionTool,
+  listDebugSessionsTool,
+  closeDebugSessionTool,
+  handleListDebugSessions
+} from './server/handlers/session-tools.js';
 
 export { coerceToolArguments };
 export type { SetBreakpointRequest };
@@ -859,151 +862,11 @@ export class DebugMcpServer implements ToolContext {
           
           switch (toolName) {
             case 'create_debug_session': {
-              // Validate before creating the session so a bad argument does
-              // not leave an orphan session behind (issue #336).
-              if (args.adapterConfig !== undefined) {
-                const cfg = args.adapterConfig;
-                if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
-                  throw new McpError(McpErrorCode.InvalidParams, 'adapterConfig must be an object when provided');
-                }
-              }
-
-              // Ensure requested language is among dynamically supported ones
-              const supported = await this.getSupportedLanguagesAsync();
-              const lang = (args.language || DebugLanguage.PYTHON) as DebugLanguage;
-              const requested = lang as unknown as string;
-              const isContainer = process.env.MCP_CONTAINER === 'true';
-              const allowInContainer = isContainer && requested === DebugLanguage.PYTHON;
-              if (!allowInContainer && !supported.includes(lang)) {
-                throw new UnsupportedLanguageError(lang, supported);
-              }
-
-              // Fail fast when the adapter can't do ANYTHING here (issue
-              // #360). A failed launch-toolchain probe alone must not block
-              // session creation: the caller may intend to attach (with or
-              // without a port at create time), and direct-connect attach
-              // needs no local toolchain — e.g. ruby attach works in the
-              // container image without a launch toolchain. Launch itself is
-              // still gated at start_debugging.
-              {
-                const launchGate = await checkLaunchToolchain(
-                  requested,
-                  this.getAdapterRegistry(),
-                  this.validationCache,
-                  this.logger
-                );
-                if (!launchGate.available) {
-                  const registry = this.getAdapterRegistry();
-                  const attachMechanism = await (async () => {
-                    try {
-                      const factory = typeof registry?.getFactory === 'function'
-                        ? await registry.getFactory(requested)
-                        : undefined;
-                      return factory?.getMetadata?.().modes?.attach ?? 'none';
-                    } catch {
-                      return 'none';
-                    }
-                  })();
-                  // 'direct-connect' attach runs inside the debuggee — usable
-                  // even when the local toolchain probe failed. 'spawn' attach
-                  // shares the failing toolchain; 'none' has no attach at all.
-                  if (attachMechanism !== 'direct-connect') {
-                    result = { content: [{ type: 'text', text: JSON.stringify({
-                      success: false,
-                      error: ErrorMessages.launchUnavailable(requested, launchGate.reason)
-                    }) }] };
-                    break;
-                  }
-                  this.logger.warn(
-                    `[Server] create_debug_session(${requested}): launch toolchain unavailable (${launchGate.reason}); ` +
-                      `allowing session creation because direct-connect attach remains usable.`
-                  );
-                }
-              }
-
-              const sessionInfo = await this.createDebugSession({
-                language: lang,
-                name: args.name,
-                executablePath: args.executablePath
-              });
-
-              // Log session creation
-              this.logger.info('session:created', {
-                sessionId: sessionInfo.id,
-                sessionName: sessionInfo.name,
-                language: sessionInfo.language,
-                executablePath: args.executablePath,
-                timestamp: Date.now()
-              });
-
-              // A new output resource is now listable (issue #218)
-              this.outputResources.notifyListChanged();
-
-              // Check if attach mode is requested (host/port provided)
-              const isAttachMode = args.port !== undefined;
-
-              if (isAttachMode) {
-                // Attach mode: immediately attach to the running process
-                this.logger.info('session:attach-mode', {
-                  sessionId: sessionInfo.id,
-                  host: args.host || 'localhost',
-                  port: args.port,
-                  timestamp: Date.now()
-                });
-
-                try {
-                  const attachResult = await this.sessionManager.attachToProcess(sessionInfo.id, {
-                    port: args.port as number,
-                    host: (args.host as string) || 'localhost',
-                    timeout: (args.timeout as number) || 30000,
-                    stopOnEntry: args.stopOnEntry,
-                    verifyTimeout: args.verifyTimeout,
-                    adapterConfig: args.adapterConfig,
-                  });
-
-                  // Forward the attach payload the same way attach_to_process
-                  // does: structured failure diagnostics (initProgress /
-                  // proxyLogPath, issue #551) and the dropped-adapterConfig
-                  // warning (issue #450) must reach this entry point too.
-                  const attachData = attachResult.data as { warning?: string } | undefined;
-                  const attachWarning = attachResult.success ? attachData?.warning : undefined;
-                  result = { content: [{ type: 'text', text: JSON.stringify({
-                    success: attachResult.success,
-                    sessionId: sessionInfo.id,
-                    state: attachResult.state,
-                    message: attachResult.success
-                      ? `Created and attached ${sessionInfo.language} debug session: ${sessionInfo.name}`
-                      : `Created session but attach failed: ${attachResult.error || 'Unknown error'}`,
-                    ...(attachData ? { data: attachData } : {}),
-                    ...(attachWarning ? { warning: attachWarning } : {})
-                  }) }] };
-                } catch (error) {
-                  this.logger.error('session:attach-failed', {
-                    sessionId: sessionInfo.id,
-                    error: error instanceof Error ? error.message : String(error),
-                    timestamp: Date.now()
-                  });
-
-                  result = { content: [{ type: 'text', text: JSON.stringify({
-                    success: false,
-                    sessionId: sessionInfo.id,
-                    state: 'error',
-                    message: `Created session but failed to attach: ${error instanceof Error ? error.message : String(error)}`
-                  }) }] };
-                }
-              } else {
-                // Launch mode: just create the session
-                result = { content: [{ type: 'text', text: JSON.stringify({
-                  success: true,
-                  sessionId: sessionInfo.id,
-                  message: `Created ${sessionInfo.language} debug session: ${sessionInfo.name}`
-                }) }] };
-              }
-
+              result = await createDebugSessionTool(this, args, toolName);
               break;
             }
             case 'list_debug_sessions': {
-              result = await this.handleListDebugSessions();
+              result = await listDebugSessionsTool(this, args, toolName);
               break;
             }
             case 'set_breakpoint': {
@@ -1577,27 +1440,7 @@ export class DebugMcpServer implements ToolContext {
               break;
             }
             case 'close_debug_session': {
-              if (!args.sessionId) {
-                throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
-              }
-
-              const sessionName = this.getSessionName(args.sessionId);
-              const closed = await this.closeDebugSession(args.sessionId);
-
-              if (closed) {
-                // Log session closure
-                this.logger.info('session:closed', {
-                  sessionId: args.sessionId,
-                  sessionName: sessionName,
-                  timestamp: Date.now()
-                });
-
-                // The session's output resource is gone (issue #218)
-                this.outputResources.forgetSession(args.sessionId);
-                this.outputResources.notifyListChanged();
-              }
-              
-              result = { content: [{ type: 'text', text: JSON.stringify({ success: closed, message: closed ? `Closed debug session: ${args.sessionId}` : `Failed to close debug session: ${args.sessionId}` }) }] };
+              result = await closeDebugSessionTool(this, args, toolName);
               break;
             }
             case 'step_over':
@@ -1903,37 +1746,9 @@ export class DebugMcpServer implements ToolContext {
     );
   }
 
-  private async handleListDebugSessions(): Promise<ServerResult> {
-    try {
-      const sessionsInfo: DebugSessionInfo[] = this.sessionManager.getAllSessions();
-      const sessionData = sessionsInfo.map((session: DebugSessionInfo) => {
-        const mappedSession: Record<string, unknown> = { 
-            id: session.id, 
-            name: session.name, 
-            language: session.language as DebugLanguage, 
-            state: session.state, 
-            createdAt: session.createdAt.toISOString(),
-        };
-        if (session.updatedAt) {
-            mappedSession.updatedAt = session.updatedAt.toISOString();
-        }
-        if (session.lastStop) {
-            mappedSession.lastStop = session.lastStop;
-        }
-        if (session.exitCode !== undefined) {
-            mappedSession.exitCode = session.exitCode;
-        }
-        if (session.exposure) {
-            // Mirror endpoint host/port; the token never leaves expose_session.
-            mappedSession.exposure = session.exposure;
-        }
-        return mappedSession;
-      });
-      return { content: [{ type: 'text', text: JSON.stringify({ success: true, sessions: sessionData, count: sessionData.length }) }] };
-    } catch (error) {
-      this.logger.error('Failed to list debug sessions', { error });
-      throw new McpError(McpErrorCode.InternalError, `Failed to list debug sessions: ${(error as Error).message}`);
-    }
+  /** @internal test seam; removed in PR 6 */
+  private async handleListDebugSessions(): Promise<ToolResult> {
+    return handleListDebugSessions(this);
   }
 
   /**

--- a/src/server/handlers/breakpoint-tools.ts
+++ b/src/server/handlers/breakpoint-tools.ts
@@ -58,6 +58,8 @@ export const setBreakpointTool: ToolHandler = async (ctx, args) => {
 /**
  * Function-breakpoint branch of set_breakpoint (the `function` parameter).
  */
+// Module-private: callers must already have run setBreakpointTool's entry guard,
+// which is what makes the `args as SetBreakpointArgs` narrowing sound.
 async function setFunctionBreakpointBranch(ctx: ToolContext, args: SetBreakpointArgs): Promise<ToolResult> {
   // Function breakpoints are session-global symbols — no file,
   // no line, no content anchor, no logpoint, no suspend policy
@@ -130,6 +132,7 @@ async function setFunctionBreakpointBranch(ctx: ToolContext, args: SetBreakpoint
 /**
  * Line / statement branch of set_breakpoint.
  */
+// Module-private: see setFunctionBreakpointBranch — the entry guard has run.
 async function setLineBreakpointBranch(ctx: ToolContext, args: SetBreakpointArgs): Promise<ToolResult> {
   try {
     // Logpoint gating (issue #235): hard error for known-unsupported

--- a/src/server/handlers/breakpoint-tools.ts
+++ b/src/server/handlers/breakpoint-tools.ts
@@ -1,0 +1,383 @@
+/**
+ * Breakpoint tools: set_breakpoint (function and line branches),
+ * list_breakpoints, remove_breakpoint, clear_breakpoints.
+ */
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { Breakpoint, FunctionBreakpoint } from '@debugmcp/shared';
+import {
+  BP_ADDRESSING_ENV_KEY,
+  getBpAddressingMode,
+  supportsExpectedContent,
+  supportsStatementAnchors
+} from '../../utils/bp-addressing.js';
+import type { ToolArguments } from '../tool-arguments.js';
+import type { ToolContext, ToolHandler } from '../tool-context.js';
+import type { ToolResult } from '../tool-result.js';
+
+/** set_breakpoint arguments once the entry guard has established sessionId. */
+type SetBreakpointArgs = ToolArguments & { sessionId: string };
+
+export const setBreakpointTool: ToolHandler = async (ctx, args) => {
+  const isFunctionBp = args.function !== undefined;
+  if (!args.sessionId || (!isFunctionBp && (!args.file || (args.line === undefined && args.statement === undefined)))) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
+  }
+
+  // Addressing-mode gating (issue #271): reject params outside the
+  // configured mode even though the schema omits them — a client
+  // replaying a cached schema must not slip features into a
+  // restricted server. Checked on the raw args so unknown params
+  // are caught too.
+  const bpMode = getBpAddressingMode(ctx.environment);
+  if (args.expectedContent !== undefined && !supportsExpectedContent(bpMode)) {
+    throw new McpError(
+      McpErrorCode.InvalidParams,
+      `expectedContent is disabled (${BP_ADDRESSING_ENV_KEY}=${bpMode}). Use plain line addressing.`
+    );
+  }
+  if ((args.statement !== undefined || args.nearLine !== undefined) && !supportsStatementAnchors(bpMode)) {
+    throw new McpError(
+      McpErrorCode.InvalidParams,
+      `statement addressing is disabled (${BP_ADDRESSING_ENV_KEY}=${bpMode}). Use line addressing.`
+    );
+  }
+  if (isFunctionBp && !supportsStatementAnchors(bpMode)) {
+    throw new McpError(
+      McpErrorCode.InvalidParams,
+      `function breakpoints are disabled (${BP_ADDRESSING_ENV_KEY}=${bpMode}). Use line addressing.`
+    );
+  }
+
+  if (isFunctionBp) {
+    return setFunctionBreakpointBranch(ctx, args as SetBreakpointArgs);
+  }
+
+  return setLineBreakpointBranch(ctx, args as SetBreakpointArgs);
+};
+
+/**
+ * Function-breakpoint branch of set_breakpoint (the `function` parameter).
+ */
+async function setFunctionBreakpointBranch(ctx: ToolContext, args: SetBreakpointArgs): Promise<ToolResult> {
+  // Function breakpoints are session-global symbols — no file,
+  // no line, no content anchor, no logpoint, no suspend policy
+  // (DAP FunctionBreakpoint supports name + condition only).
+  if (args.file !== undefined) {
+    throw new McpError(McpErrorCode.InvalidParams,
+      'Function breakpoints are not file-scoped; omit file. The adapter resolves the symbol name across the whole program.');
+  }
+  if (args.line !== undefined || args.statement !== undefined ||
+      args.expectedContent !== undefined || args.nearLine !== undefined) {
+    throw new McpError(McpErrorCode.InvalidParams,
+      'Provide function alone (optionally with condition) — it cannot be combined with line, statement, expectedContent, or nearLine.');
+  }
+  if (args.logMessage !== undefined) {
+    throw new McpError(McpErrorCode.InvalidParams,
+      'logMessage is not supported on function breakpoints (DAP has no logpoint form for them); use a line or statement breakpoint.');
+  }
+  if (args.suspendPolicy !== undefined) {
+    throw new McpError(McpErrorCode.InvalidParams,
+      'suspendPolicy is not supported on function breakpoints.');
+  }
+
+  try {
+    const fnGate = ctx.validateFunctionBreakpointSupport(args.sessionId);
+    // Policy-certain rewrite (issue #467): a name the adapter can
+    // never bind as given (go bare 'main') is corrected instead
+    // of stored as a permanently-dead breakpoint; the warning
+    // says the rewrite happened.
+    const normalized = ctx.normalizeFunctionBreakpointName(args.sessionId, args.function!);
+    const effectiveName = normalized?.name ?? args.function!;
+    // Per-adapter name advisory (issues #303/#308): warn at set
+    // time about names the adapter is known to mis-resolve
+    // (rust bare 'main' -> CRT entry) or never bind (go bare
+    // identifiers). Advisory only — the breakpoint is still set.
+    const nameHint = normalized
+      ? undefined
+      : ctx.getFunctionBreakpointNameHint(args.sessionId, effectiveName);
+    const { breakpoint, warning: syncWarning } = await ctx.setFunctionBreakpoint(
+      args.sessionId, effectiveName, args.condition
+    );
+
+    ctx.logger.info('debug:breakpoint', {
+      event: 'set',
+      sessionId: args.sessionId,
+      sessionName: ctx.getSessionName(args.sessionId),
+      breakpointId: breakpoint.id,
+      functionName: breakpoint.functionName,
+      verified: breakpoint.verified,
+      timestamp: Date.now()
+    });
+
+    const warnings = [breakpoint.message, fnGate.warning, normalized?.note, nameHint, syncWarning].filter(Boolean);
+    return { content: [{ type: 'text', text: JSON.stringify({
+      success: true,
+      breakpointId: breakpoint.id,
+      ...(normalized ? { requestedName: args.function } : {}),
+      functionName: breakpoint.functionName,
+      condition: breakpoint.condition,
+      verified: breakpoint.verified,
+      boundFile: breakpoint.boundFile,
+      boundLine: breakpoint.boundLine,
+      message: breakpoint.message || `Function breakpoint set on ${breakpoint.functionName}`,
+      warning: warnings.length > 0 ? warnings.join('; ') : undefined
+    }) }] };
+  } catch (error) {
+    return ctx.handleBreakpointToolError(error);
+  }
+}
+
+/**
+ * Line / statement branch of set_breakpoint.
+ */
+async function setLineBreakpointBranch(ctx: ToolContext, args: SetBreakpointArgs): Promise<ToolResult> {
+  try {
+    // Logpoint gating (issue #235): hard error for known-unsupported
+    // adapters; a warning when support is unknown pre-launch.
+    const logPointGate = args.logMessage !== undefined
+      ? ctx.validateLogPointSupport(args.sessionId)
+      : {};
+
+    const { breakpoint, warning: syncWarning } = await ctx.setBreakpoint({
+      sessionId: args.sessionId,
+      // Non-function path: the entry guard above ensures file is set
+      file: args.file!,
+      line: args.line,
+      expectedContent: args.expectedContent,
+      statement: args.statement,
+      nearLine: args.nearLine,
+      condition: args.condition,
+      suspendPolicy: args.suspendPolicy,
+      logMessage: args.logMessage
+    });
+
+    // Log breakpoint event
+    ctx.logger.info('debug:breakpoint', {
+      event: 'set',
+      sessionId: args.sessionId,
+      sessionName: ctx.getSessionName(args.sessionId),
+      breakpointId: breakpoint.id,
+      file: breakpoint.file,
+      line: breakpoint.line,
+      verified: breakpoint.verified,
+      timestamp: Date.now()
+    });
+
+    // Try to get line context for the breakpoint
+    let context;
+    try {
+      const lineContext = await ctx.lineReader.getLineContext(
+        breakpoint.file,
+        breakpoint.line,
+        { contextLines: 2 }
+      );
+
+      if (lineContext) {
+        context = {
+          lineContent: lineContext.lineContent,
+          surrounding: lineContext.surrounding
+        };
+      }
+    } catch (contextError) {
+      // Log but don't fail if we can't get context
+      ctx.logger.debug('Could not get line context for breakpoint', { 
+        file: breakpoint.file, 
+        line: breakpoint.line, 
+        error: contextError 
+      });
+    }
+
+    // Loud snapping (issue #271): if the adapter bound the
+    // breakpoint to a different line than requested, say so
+    // prominently instead of silently reporting the moved line.
+    const snapped =
+      breakpoint.requestedLine !== undefined &&
+      breakpoint.line !== breakpoint.requestedLine;
+    const snapWarning = snapped
+      ? `Breakpoint moved by the debugger: requested line ${breakpoint.requestedLine}, bound to line ${breakpoint.line}${
+          context ? `: \`${context.lineContent.trim()}\`` : ''
+        }`
+      : undefined;
+
+    const warnings = [breakpoint.message, logPointGate.warning, syncWarning, snapWarning].filter(Boolean);
+    const result: ToolResult = { content: [{ type: 'text', text: JSON.stringify({
+      success: true,
+      breakpointId: breakpoint.id,
+      file: breakpoint.file,
+      line: breakpoint.line,
+      requestedLine: breakpoint.requestedLine,
+      anchor: breakpoint.anchor,
+      content: context?.lineContent,
+      verified: breakpoint.verified,
+      logMessage: breakpoint.logMessage,
+      message: snapWarning || breakpoint.message || `${breakpoint.logMessage !== undefined ? 'Logpoint' : 'Breakpoint'} set at ${breakpoint.file}:${breakpoint.line}`,
+      // Warn on adapter validation messages, sync failures, snaps,
+      // and unknown logpoint support
+      warning: warnings.length > 0 ? warnings.join('; ') : undefined,
+      // Include context if available
+      context: context || undefined
+    }) }] };
+    const contentEntry = Array.isArray(result.content) ? result.content[0] : undefined;
+    const textContent = contentEntry && typeof (contentEntry as { text?: unknown }).text === 'string'
+      ? (contentEntry as { text: string }).text
+      : undefined;
+    let parsedResponse: Record<string, unknown> | null = null;
+    if (typeof textContent === 'string') {
+      try {
+        parsedResponse = JSON.parse(textContent) as Record<string, unknown>;
+      } catch {
+        parsedResponse = null;
+      }
+    }
+    ctx.logger.info('tool:set_breakpoint:result', {
+      sessionId: args.sessionId,
+      response: parsedResponse
+    });
+    return result;
+  } catch (error) {
+    // Handle session state errors specifically
+    if (error instanceof McpError && 
+        (error.message.includes('terminated') || 
+         error.message.includes('closed') || 
+         (error.message.includes('not found') && error.message.includes('Session')))) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else {
+      // Re-throw all other errors (including file validation errors)
+      throw error;
+    }
+  }
+}
+
+export const listBreakpointsTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameter: sessionId');
+  }
+  try {
+    const breakpoints = ctx.listBreakpoints(args.sessionId, args.file);
+    // Function breakpoints are session-global, so a file filter
+    // deliberately excludes them (issue #271 phase 3).
+    const functionBreakpoints = args.file === undefined
+      ? ctx.sessionManager.listFunctionBreakpoints(args.sessionId)
+      : [];
+    return { content: [{ type: 'text', text: JSON.stringify({
+      success: true,
+      breakpoints,
+      count: breakpoints.length,
+      ...(args.file === undefined
+        ? { functionBreakpoints, functionCount: functionBreakpoints.length }
+        : {})
+    }) }] };
+  } catch (error) {
+    return ctx.handleBreakpointToolError(error);
+  }
+};
+
+export const removeBreakpointTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameter: sessionId');
+  }
+  if (!args.breakpointId && args.function === undefined && (!args.file || args.line === undefined)) {
+    throw new McpError(
+      McpErrorCode.InvalidParams,
+      'Provide breakpointId, function, or file and line together'
+    );
+  }
+  try {
+    let removed: Array<Breakpoint | FunctionBreakpoint>;
+    let warning: string | undefined;
+    // Function-addressed removal discloses names the way
+    // set_breakpoint does: `functionName` is always the effective
+    // name, `requestedName` appears only when a policy rewrite
+    // changed it (issue #550).
+    let functionDisclosure: { functionName: string; requestedName?: string } | undefined;
+    if (!args.breakpointId && args.function !== undefined) {
+      const requestedName = args.function;
+      // Use the same policy-certain rewrite as set_breakpoint so
+      // the name the caller supplied can remove the normalized
+      // record that was stored (issue #550). The literal name is
+      // matched too — a record stored un-rewritten (policy lookup
+      // failure, or set through another path) stays removable.
+      const normalized = ctx.normalizeFunctionBreakpointName(args.sessionId, requestedName);
+      const effectiveName = normalized?.name ?? requestedName;
+      functionDisclosure = {
+        functionName: effectiveName,
+        ...(normalized ? { requestedName } : {})
+      };
+      const matches = ctx.sessionManager
+        .listFunctionBreakpoints(args.sessionId)
+        .filter((bp) => bp.functionName === effectiveName || bp.functionName === requestedName);
+      removed = [];
+      const warnings: string[] = [];
+      for (const bp of matches) {
+        const res = await ctx.removeBreakpoint(args.sessionId, bp.id);
+        if (res.removed) removed.push(res.removed);
+        if (res.warning) warnings.push(res.warning);
+      }
+      if (removed.length === 0) {
+        // Same per-adapter name advisory set_breakpoint gives
+        // (issues #303/#308), so a bare Go name that never matched
+        // learns the package-qualified form it should use.
+        const nameHint = normalized
+          ? undefined
+          : ctx.getFunctionBreakpointNameHint(args.sessionId, effectiveName);
+        if (nameHint) warnings.push(nameHint);
+        return { content: [{ type: 'text', text: JSON.stringify({
+          success: false,
+          error: normalized
+            ? `No function breakpoint found for ${requestedName} (normalized to ${effectiveName})`
+            : `No function breakpoint found for ${requestedName}`,
+          ...functionDisclosure,
+          warning: warnings.length > 0 ? warnings.join('; ') : undefined
+        }) }] };
+      }
+      warning = warnings.length > 0 ? warnings.join('; ') : undefined;
+    } else if (args.breakpointId) {
+      const res = await ctx.removeBreakpoint(args.sessionId, args.breakpointId);
+      removed = res.removed ? [res.removed] : [];
+      warning = res.warning;
+      if (removed.length === 0) {
+        return { content: [{ type: 'text', text: JSON.stringify({
+          success: false,
+          error: `No breakpoint found with id ${args.breakpointId}`
+        }) }] };
+      }
+    } else {
+      const res = await ctx.removeBreakpointsByLocation(args.sessionId, args.file!, args.line!);
+      removed = res.removed;
+      warning = res.warning;
+      if (removed.length === 0) {
+        return { content: [{ type: 'text', text: JSON.stringify({
+          success: false,
+          error: `No breakpoint found at ${args.file}:${args.line}`
+        }) }] };
+      }
+    }
+    return { content: [{ type: 'text', text: JSON.stringify({
+      success: true,
+      removed,
+      message: `Removed ${removed.length} breakpoint(s)`,
+      ...(functionDisclosure ?? {}),
+      warning
+    }) }] };
+  } catch (error) {
+    return ctx.handleBreakpointToolError(error);
+  }
+};
+
+export const clearBreakpointsTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameter: sessionId');
+  }
+  try {
+    const res = await ctx.clearBreakpoints(args.sessionId, args.file);
+    return { content: [{ type: 'text', text: JSON.stringify({
+      success: true,
+      cleared: res.cleared,
+      files: res.files,
+      message: `Cleared ${res.cleared} breakpoint(s)`,
+      warning: res.warning
+    }) }] };
+  } catch (error) {
+    return ctx.handleBreakpointToolError(error);
+  }
+};

--- a/src/server/handlers/debuggee-tools.ts
+++ b/src/server/handlers/debuggee-tools.ts
@@ -1,0 +1,220 @@
+/**
+ * Debuggee lifecycle tools: start_debugging, restart_debugging,
+ * attach_to_process, detach_from_process, redefine_classes.
+ */
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolHandler } from '../tool-context.js';
+
+export const startDebuggingTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId || !args.scriptPath) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
+  }
+
+  try {
+    if (args.adapterLaunchConfig !== undefined) {
+      const cfg = args.adapterLaunchConfig;
+      if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
+        throw new McpError(McpErrorCode.InvalidParams, 'adapterLaunchConfig must be an object when provided');
+      }
+    }
+
+    const intake = ctx.normalizeStartDebuggingArgs(args.dapLaunchArgs, args.breakOnExceptions);
+    const debugResult = await ctx.startDebugging(
+      args.sessionId,
+      args.scriptPath,
+      args.args,
+      intake.dapLaunchArgs,
+      args.dryRunSpawn,
+      args.adapterLaunchConfig,
+      ctx.validateBreakOnExceptions(intake.breakOnExceptions)
+    );
+    const responsePayload: Record<string, unknown> = {
+      success: debugResult.success,
+      state: debugResult.state,
+      message: debugResult.error ? debugResult.error : (debugResult.data as Record<string, unknown>)?.message || `Operation status for ${args.scriptPath}`,
+    };
+    if (debugResult.data) {
+      responsePayload.data = debugResult.data;
+    }
+    // Top-level warning join (set_breakpoint pattern): intake
+    // normalization notes (issue #305) plus any session-manager
+    // warning (unbound function breakpoints, issue #308).
+    const dataWarning = (debugResult.data as { warning?: string } | undefined)?.warning;
+    const startWarnings = [...intake.warnings, dataWarning].filter(Boolean);
+    if (debugResult.success && startWarnings.length > 0) {
+      responsePayload.warning = startWarnings.join('; ');
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(responsePayload) }] };
+  } catch (error) {
+    // Handle session state errors specifically
+    if (error instanceof McpError && 
+        (error.message.includes('terminated') || 
+         error.message.includes('closed') || 
+         (error.message.includes('not found') && error.message.includes('Session')))) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message, state: 'stopped' }) }] };
+    } else {
+      // Re-throw all other errors (including file validation errors)
+      throw error;
+    }
+  }
+};
+
+export const restartDebuggingTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameter: sessionId');
+  }
+  try {
+    const debugResult = await ctx.restartDebugging(args.sessionId);
+    const responsePayload: Record<string, unknown> = {
+      success: debugResult.success,
+      state: debugResult.state,
+      message: debugResult.error
+        ? debugResult.error
+        : (debugResult.data as Record<string, unknown>)?.message || 'Debugging restarted',
+    };
+    if (debugResult.error) {
+      responsePayload.error = debugResult.error;
+    }
+    if (debugResult.data) {
+      responsePayload.data = debugResult.data;
+      // Surface the merged restart warning (stale anchors and/or
+      // unbound function breakpoints) at the top level too —
+      // same discoverability as set_breakpoint/start_debugging.
+      const restartWarning = (debugResult.data as { warning?: string }).warning;
+      if (debugResult.success && restartWarning) {
+        responsePayload.warning = restartWarning;
+      }
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(responsePayload) }] };
+  } catch (error) {
+    return ctx.handleBreakpointToolError(error);
+  }
+};
+
+export const attachToProcessTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+
+  try {
+    if (args.adapterConfig !== undefined) {
+      const cfg = args.adapterConfig;
+      if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
+        throw new McpError(McpErrorCode.InvalidParams, 'adapterConfig must be an object when provided');
+      }
+    }
+
+    ctx.logger.info('Attach to process requested', {
+      sessionId: args.sessionId,
+      port: args.port,
+      host: args.host,
+      processId: args.processId
+    });
+
+    const attachResult = await ctx.sessionManager.attachToProcess(args.sessionId, {
+      port: args.port,
+      host: args.host,
+      processId: args.processId,
+      timeout: args.timeout,
+      verifyTimeout: args.verifyTimeout,
+      sourcePaths: args.sourcePaths,
+      stopOnEntry: args.stopOnEntry,
+      justMyCode: args.justMyCode,
+      breakOnExceptions: ctx.validateBreakOnExceptions(args.breakOnExceptions),
+      adapterConfig: args.adapterConfig
+    });
+
+    const responsePayload: Record<string, unknown> = {
+      success: attachResult.success,
+      state: attachResult.state,
+      message: attachResult.error ||
+        (attachResult.data as Record<string, unknown>)?.message ||
+        'Attach operation completed'
+    };
+
+    if (attachResult.data) {
+      responsePayload.data = attachResult.data;
+      // Surface the dropped-adapterConfig-keys warning (issue
+      // #450) at the top level too — same discoverability as
+      // set_breakpoint/start_debugging/restart_debugging.
+      const attachWarning = (attachResult.data as { warning?: string }).warning;
+      if (attachResult.success && attachWarning) {
+        responsePayload.warning = attachWarning;
+      }
+    }
+
+    return { content: [{ type: 'text', text: JSON.stringify(responsePayload) }] };
+  } catch (error) {
+    // Handle session state errors specifically
+    if (error instanceof McpError &&
+        (error.message.includes('terminated') ||
+         error.message.includes('closed') ||
+         (error.message.includes('not found') && error.message.includes('Session')))) {
+      return { content: [{ type: 'text', text: JSON.stringify({
+        success: false,
+        error: error.message,
+        state: 'stopped'
+      }) }] };
+    } else {
+      throw error;
+    }
+  }
+};
+
+export const detachFromProcessTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+
+  try {
+    ctx.logger.info('Detach from process requested', {
+      sessionId: args.sessionId,
+      terminateProcess: args.terminateProcess
+    });
+
+    const detachResult = await ctx.sessionManager.detachFromProcess(
+      args.sessionId,
+      args.terminateProcess ?? false
+    );
+
+    const responsePayload: Record<string, unknown> = {
+      success: detachResult.success,
+      state: detachResult.state,
+      message: detachResult.error ||
+        (detachResult.data as Record<string, unknown>)?.message ||
+        'Detach operation completed'
+    };
+
+    if (detachResult.data) {
+      responsePayload.data = detachResult.data;
+    }
+
+    return { content: [{ type: 'text', text: JSON.stringify(responsePayload) }] };
+  } catch (error) {
+    // Handle session state errors specifically
+    if (error instanceof McpError &&
+        (error.message.includes('terminated') ||
+         error.message.includes('closed') ||
+         (error.message.includes('not found') && error.message.includes('Session')))) {
+      return { content: [{ type: 'text', text: JSON.stringify({
+        success: false,
+        error: error.message,
+        state: 'stopped'
+      }) }] };
+    } else {
+      throw error;
+    }
+  }
+};
+
+export const redefineClassesTool: ToolHandler = async (ctx, args) => {
+  const redefineResult = await ctx.sessionManager.redefineClasses(
+    args.sessionId as string,
+    args.classesDir as string,
+    (args.sinceTimestamp as number) || 0,
+    args.timeout
+  );
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(redefineResult, null, 2) }],
+  };
+};

--- a/src/server/handlers/execution-tools.ts
+++ b/src/server/handlers/execution-tools.ts
@@ -1,0 +1,161 @@
+/**
+ * Execution control tools: step_over / step_into / step_out (one handler
+ * keyed by toolName), continue_execution, pause_execution, list_threads.
+ */
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import {
+  SessionNotFoundError,
+  SessionTerminatedError,
+  ProxyNotRunningError
+} from '../../errors/debug-errors.js';
+import type { ToolContext, ToolHandler } from '../tool-context.js';
+import type { ToolResult } from '../tool-result.js';
+
+export const stepTool: ToolHandler = async (ctx, args, toolName) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+
+  try {
+    let stepResult: { success: boolean; state: string; error?: string; data?: unknown; };
+    if (toolName === 'step_over') {
+      stepResult = await ctx.stepOver(args.sessionId);
+    } else if (toolName === 'step_into') {
+      stepResult = await ctx.stepInto(args.sessionId);
+    } else {
+      stepResult = await ctx.stepOut(args.sessionId);
+    }
+
+    // Build response with location and line context if available
+    const stepType = toolName.replace('step_', '').replace('_', ' ');
+    const resultData = stepResult.data as { message?: string; location?: { file: string; line: number; column?: number }; pending?: boolean } | undefined;
+    const response: Record<string, unknown> = {
+      success: stepResult.success,
+      message: `Stepped ${stepType}`,
+      state: stepResult.state
+    };
+
+    // A pending step means the program is still executing (e.g. stepping
+    // over a long-running call); report that truthfully instead of "Stepped".
+    if (resultData?.pending) {
+      response.pending = true;
+      if (resultData.message) {
+        response.message = resultData.message;
+      }
+    }
+
+    // Extract location from result data
+    const location = resultData?.location;
+
+    if (location) {
+      response.location = location;
+
+      // Try to get line context
+      try {
+        const lineContext = await ctx.lineReader.getLineContext(
+          location.file,
+          location.line,
+          { contextLines: 2 }
+        );
+
+        if (lineContext) {
+          response.context = {
+            lineContent: lineContext.lineContent,
+            surrounding: lineContext.surrounding
+          };
+        }
+      } catch (contextError) {
+        // Log but don't fail if we can't get context
+        ctx.logger.debug('Could not get line context for step result', {
+          file: location.file,
+          line: location.line,
+          error: contextError
+        });
+      }
+    }
+
+    return { content: [{ type: 'text', text: JSON.stringify(response) }] };
+  } catch (error) {
+    // Handle validation errors specifically
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else if (error instanceof Error) {
+      // Handle other expected errors (like "Failed to step over")
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else {
+      // Re-throw unexpected errors
+      throw error;
+    }
+  }
+};
+
+export const continueExecutionTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+
+  try {
+    const continueResult = await ctx.continueExecution(args.sessionId);
+    return { content: [{ type: 'text', text: JSON.stringify({ success: continueResult, message: continueResult ? 'Continued execution' : 'Failed to continue execution' }) }] };
+  } catch (error) {
+    // Handle validation errors specifically
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else if (error instanceof Error) {
+      // Handle other expected errors
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else {
+      // Re-throw unexpected errors
+      throw error;
+    }
+  }
+};
+
+export async function handlePause(ctx: ToolContext, args: { sessionId: string; threadId?: number }): Promise<ToolResult> {
+  try {
+    ctx.validateSession(args.sessionId);
+    const result = await ctx.sessionManager.pause(args.sessionId, args.threadId);
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+  } catch (error) {
+    ctx.logger.error('Failed to pause execution', { error });
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    }
+    if (error instanceof McpError) throw error;
+    throw new McpError(McpErrorCode.InternalError, `Failed to pause execution: ${(error as Error).message}`);
+  }
+}
+
+export const pauseExecutionTool: ToolHandler = async (ctx, args) => {
+  return await handlePause(ctx, args as { sessionId: string; threadId?: number });
+};
+
+export async function handleListThreads(ctx: ToolContext, args: { sessionId: string }): Promise<ToolResult> {
+  try {
+    ctx.validateSession(args.sessionId);
+    const threads = await ctx.sessionManager.listThreads(args.sessionId);
+    return { content: [{ type: 'text', text: JSON.stringify({ success: true, threads }) }] };
+  } catch (error) {
+    ctx.logger.error('Failed to list threads', { error });
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    }
+    if (error instanceof McpError) throw error;
+    throw new McpError(McpErrorCode.InternalError, `Failed to list threads: ${(error as Error).message}`);
+  }
+}
+
+export const listThreadsTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+  return await handleListThreads(ctx, args as { sessionId: string });
+};

--- a/src/server/handlers/index.ts
+++ b/src/server/handlers/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Tool name -> handler table for the tools/call dispatch. Order mirrors the
+ * original switch in src/server.ts.
+ */
+import type { ToolHandler } from '../tool-context.js';
+import { createDebugSessionTool, listDebugSessionsTool, closeDebugSessionTool } from './session-tools.js';
+import {
+  setBreakpointTool,
+  listBreakpointsTool,
+  removeBreakpointTool,
+  clearBreakpointsTool
+} from './breakpoint-tools.js';
+import {
+  startDebuggingTool,
+  restartDebuggingTool,
+  attachToProcessTool,
+  detachFromProcessTool,
+  redefineClassesTool
+} from './debuggee-tools.js';
+import { exposeSessionTool, unexposeSessionTool } from './mirror-tools.js';
+import { stepTool, continueExecutionTool, pauseExecutionTool, listThreadsTool } from './execution-tools.js';
+import {
+  getVariablesTool,
+  getStackTraceTool,
+  getScopesTool,
+  evaluateExpressionTool,
+  getSourceContextTool,
+  getLocalVariablesTool
+} from './inspection-tools.js';
+import { getOutputTool } from './output-tools.js';
+import { listSupportedLanguagesTool } from './language-tools.js';
+
+export const TOOL_HANDLERS: Readonly<Record<string, ToolHandler>> = Object.freeze({
+  create_debug_session: createDebugSessionTool,
+  list_debug_sessions: listDebugSessionsTool,
+  set_breakpoint: setBreakpointTool,
+  list_breakpoints: listBreakpointsTool,
+  remove_breakpoint: removeBreakpointTool,
+  clear_breakpoints: clearBreakpointsTool,
+  start_debugging: startDebuggingTool,
+  restart_debugging: restartDebuggingTool,
+  attach_to_process: attachToProcessTool,
+  detach_from_process: detachFromProcessTool,
+  expose_session: exposeSessionTool,
+  unexpose_session: unexposeSessionTool,
+  close_debug_session: closeDebugSessionTool,
+  step_over: stepTool,
+  step_into: stepTool,
+  step_out: stepTool,
+  continue_execution: continueExecutionTool,
+  pause_execution: pauseExecutionTool,
+  list_threads: listThreadsTool,
+  get_variables: getVariablesTool,
+  get_stack_trace: getStackTraceTool,
+  get_scopes: getScopesTool,
+  evaluate_expression: evaluateExpressionTool,
+  get_source_context: getSourceContextTool,
+  get_local_variables: getLocalVariablesTool,
+  get_output: getOutputTool,
+  list_supported_languages: listSupportedLanguagesTool,
+  redefine_classes: redefineClassesTool
+});

--- a/src/server/handlers/inspection-tools.ts
+++ b/src/server/handlers/inspection-tools.ts
@@ -1,0 +1,420 @@
+/**
+ * Inspection tools: get_variables, get_stack_trace, get_scopes,
+ * evaluate_expression, get_source_context, get_local_variables.
+ */
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { SessionState } from '@debugmcp/shared';
+import {
+  SessionNotFoundError,
+  SessionTerminatedError,
+  ProxyNotRunningError
+} from '../../errors/debug-errors.js';
+import { buildTruncationNotice } from '../../session/variable-caps.js';
+import type { ToolContext, ToolHandler } from '../tool-context.js';
+import type { ToolResult } from '../tool-result.js';
+
+export const getVariablesTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId || args.scope === undefined) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
+  }
+  ctx.enforceExplicitNames('get_variables', args.names);
+
+  try {
+    const { variables, truncation } = await ctx.getVariablesDetailed(args.sessionId, args.scope, args.names);
+
+    // Log variable inspection (truncate large values)
+    const truncatedVars = variables.map(v => ({
+      name: v.name,
+      type: v.type,
+      value: v.value.length > 200 ? v.value.substring(0, 200) + '... (truncated)' : v.value
+    }));
+
+    ctx.logger.info('debug:variables', {
+      sessionId: args.sessionId,
+      sessionName: ctx.getSessionName(args.sessionId),
+      variablesReference: args.scope,
+      variableCount: variables.length,
+      variables: truncatedVars.slice(0, 10), // Log first 10 variables
+      timestamp: Date.now()
+    });
+
+    const redaction = ctx.redactionSummary(variables);
+    const notFound = args.names
+      ? args.names.filter(name => !variables.some(v => v.name === name))
+      : undefined;
+    const truncationInfo = truncation
+      ? { ...truncation, notice: buildTruncationNotice(truncation, variables) }
+      : undefined;
+    return { content: [{ type: 'text', text: JSON.stringify({ success: true, variables, count: variables.length, variablesReference: args.scope, ...(notFound !== undefined ? { notFound } : {}), ...(redaction ? { redaction } : {}), ...(truncationInfo ? { truncation: truncationInfo } : {}) }) }] };
+  } catch (error) {
+    // Handle validation errors specifically
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else {
+      // Re-throw unexpected errors
+      throw error;
+    }
+  }
+};
+
+export const getStackTraceTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+
+  try {
+    // Default to false for cleaner output
+    const includeInternals = args.includeInternals ?? false;
+    const stackTrace = await ctx.getStackTrace(args.sessionId, includeInternals, args.threadId);
+    const lastStop = ctx.sessionManager.getSession(args.sessionId)?.lastStop;
+    const payload: Record<string, unknown> = {
+      success: true,
+      stackFrames: stackTrace.frames,
+      count: stackTrace.frames.length,
+      ...(typeof stackTrace.threadId === 'number' ? { threadId: stackTrace.threadId } : {}),
+      includeInternals,
+      stopReason: lastStop?.reason,
+      lastStop
+    };
+    // Anything the result needs explaining (not paused, stack came
+    // from a different thread, all threads frameless) plus the
+    // issue #346 hidden-frames disclosure share the note field.
+    const notes: string[] = [];
+    if (stackTrace.note) {
+      notes.push(stackTrace.note);
+    }
+    if (stackTrace.hiddenFrameCount > 0) {
+      payload.hiddenFrames = stackTrace.hiddenFrameCount;
+      notes.push(stackTrace.allFramesInternal
+        ? `All ${stackTrace.totalFrameCount} frames are internal/runtime frames; showing the top internal frame so scopes and evaluate still work. Pass includeInternals: true to see the full stack.`
+        : `${stackTrace.hiddenFrameCount} internal frame(s) hidden — pass includeInternals: true to see them.`);
+    }
+    if (notes.length > 0) {
+      payload.note = notes.join(' ');
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(payload) }] };
+  } catch (error) {
+    // Handle validation errors specifically
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else if (error instanceof Error && !(error instanceof McpError)) {
+      // DAP-level failures (e.g. "Child session not ready ...")
+      // must surface as errors, not as an empty-but-successful
+      // stack trace (issue #124).
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else {
+      // Re-throw unexpected errors
+      throw error;
+    }
+  }
+};
+
+export const getScopesTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId || args.frameId === undefined) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
+  }
+
+  try {
+    const scopes = await ctx.getScopes(args.sessionId, args.frameId);
+    return { content: [{ type: 'text', text: JSON.stringify({ success: true, scopes }) }] };
+  } catch (error) {
+    // Handle validation errors specifically
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else {
+      // Re-throw unexpected errors
+      throw error;
+    }
+  }
+};
+
+export async function handleEvaluateExpression(ctx: ToolContext, args: { sessionId: string, expression: string, frameId?: number, timeout?: number }): Promise<ToolResult> {
+  try {
+    // Validate session
+    ctx.validateSession(args.sessionId);
+
+    // Check expression length (sanity check)
+    if (args.expression.length > 10240) {
+      throw new McpError(McpErrorCode.InvalidParams, 'Expression too long (max 10KB)');
+    }
+
+    // Call SessionManager's evaluateExpression method (no context is passed here;
+    // the adapter policy chooses the DAP evaluate context)
+    const result = await ctx.sessionManager.evaluateExpression(
+      args.sessionId,
+      args.expression,
+      args.frameId,
+      // Context is chosen by the adapter policy inside SessionManager
+      args.timeout
+    );
+
+    // Log for audit trail
+    ctx.logger.info('tool:evaluate_expression', {
+      sessionId: args.sessionId,
+      sessionName: ctx.getSessionName(args.sessionId),
+      expression: args.expression.substring(0, 100), // Truncate for logging
+      success: result.success,
+      hasResult: !!result.result,
+      timestamp: Date.now()
+    });
+
+    // Return formatted response
+    return { 
+      content: [{ 
+        type: 'text', 
+        text: JSON.stringify(result) 
+      }] 
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Log the error
+    ctx.logger.error('tool:evaluate_expression:error', {
+      sessionId: args.sessionId,
+      expression: args.expression.substring(0, 100),
+      error: errorMessage,
+      timestamp: Date.now()
+    });
+
+    // Handle session state errors specifically
+    if (error instanceof McpError && 
+        (error.message.includes('terminated') || 
+         error.message.includes('closed') || 
+         error.message.includes('not found') ||
+         error.message.includes('not paused'))) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    } else if (error instanceof McpError) {
+      throw error;
+    } else {
+      // Wrap unexpected errors
+      throw new McpError(McpErrorCode.InternalError, `Failed to evaluate expression: ${errorMessage}`);
+    }
+  }
+}
+
+export const evaluateExpressionTool: ToolHandler = async (ctx, args) => {
+  return await handleEvaluateExpression(ctx, args as { sessionId: string; expression: string; frameId?: number; timeout?: number });
+};
+
+export async function handleGetSourceContext(ctx: ToolContext, args: { sessionId: string, file: string, line: number, linesContext?: number }): Promise<ToolResult> {
+  try {
+    // Validate session
+    ctx.validateSession(args.sessionId);
+
+    // Check file exists for immediate feedback
+    const fileCheck = await ctx.fileChecker.checkExists(args.file);
+    if (!fileCheck.exists) {
+      throw ctx.fileNotFoundError('Source file', args.file, fileCheck);
+    }
+
+    ctx.logger.info(`Source context requested for session: ${args.sessionId}, file: ${fileCheck.effectivePath}, line: ${args.line}`);
+
+    // Get line context using the line reader
+    const contextLines = args.linesContext ?? 5; // Default to 5 lines of context
+    const lineContext = await ctx.lineReader.getLineContext(
+      fileCheck.effectivePath,
+      args.line,
+      { contextLines }
+    );
+
+    if (!lineContext) {
+      // File might be binary or unreadable
+      return { 
+        content: [{ 
+          type: 'text', 
+          text: JSON.stringify({ 
+            success: false, 
+            error: 'Could not read source context. File may be binary or inaccessible.',
+            file: args.file,
+            line: args.line
+          }) 
+        }] 
+      };
+    }
+
+    // Log source context request
+    ctx.logger.info('debug:source_context', {
+      sessionId: args.sessionId,
+      sessionName: ctx.getSessionName(args.sessionId),
+      file: args.file,
+      line: args.line,
+      contextLines: contextLines,
+      timestamp: Date.now()
+    });
+
+    return { 
+      content: [{ 
+        type: 'text', 
+        text: JSON.stringify({ 
+          success: true,
+          file: args.file,
+          line: args.line,
+          lineContent: lineContext.lineContent,
+          surrounding: lineContext.surrounding,
+          contextLines: contextLines
+        }) 
+      }] 
+    };
+  } catch (error) {
+    ctx.logger.error('Failed to get source context', { error });
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    }
+    if (error instanceof McpError) throw error;
+    throw new McpError(McpErrorCode.InternalError, `Failed to get source context: ${(error as Error).message}`);
+  }
+}
+
+export const getSourceContextTool: ToolHandler = async (ctx, args) => {
+  return await handleGetSourceContext(ctx, args as { sessionId: string; file: string; line: number; linesContext?: number });
+};
+
+export async function handleGetLocalVariables(ctx: ToolContext, args: { sessionId: string; includeSpecial?: boolean; names?: string[] }): Promise<ToolResult> {
+  ctx.enforceExplicitNames('get_local_variables', args.names);
+  try {
+    // Validate session
+    ctx.validateSession(args.sessionId);
+
+    // Get local variables using the new convenience method
+    const result = await ctx.getLocalVariables(
+      args.sessionId,
+      args.includeSpecial ?? false,
+      args.names
+    );
+
+    // Log for debugging
+    ctx.logger.info('tool:get_local_variables', {
+      sessionId: args.sessionId,
+      sessionName: ctx.getSessionName(args.sessionId),
+      includeSpecial: args.includeSpecial ?? false,
+      variableCount: result.variables.length,
+      frame: result.frame,
+      scopeName: result.scopeName,
+      timestamp: Date.now()
+    });
+
+    // Format response
+    const response: Record<string, unknown> = {
+      success: true,
+      variables: result.variables,
+      count: result.variables.length
+    };
+
+    const redaction = ctx.redactionSummary(result.variables);
+    if (redaction) {
+      response.redaction = redaction;
+    }
+
+    // Size-guard advisory (issues #356/#359): say explicitly that data was
+    // cut and how to fetch the rest, instead of silently dropping it.
+    if (result.truncation) {
+      response.truncation = {
+        ...result.truncation,
+        notice: buildTruncationNotice(result.truncation, result.variables)
+      };
+    }
+
+    if (args.names) {
+      response.notFound = args.names.filter(
+        name => !result.variables.some(v => v.name === name)
+      );
+    }
+
+    // Include frame information if available
+    if (result.frame) {
+      response.frame = result.frame;
+    }
+
+    // Include scope name if available
+    if (result.scopeName) {
+      response.scopeName = result.scopeName;
+    }
+
+    // The tool walked down past an empty runtime/stdlib top frame — say so,
+    // since `frame` no longer names the top of the stack (issue #468).
+    if (result.anchorNote) {
+      response.note = result.anchorNote;
+    }
+
+    // Surface adapter warnings embedded in the scope name — e.g. Delve
+    // reports "Locals (warning: optimized function)" when the debuggee was
+    // built with optimizations, which typically means missing variables.
+    const warningMatch = result.scopeName?.match(/\(warning:[^)]*\)/i);
+    if (warningMatch) {
+      response.warning =
+        `The debug adapter reported the locals scope as "${result.scopeName}". ` +
+        'This usually means the target was compiled with optimizations, so variables may be missing or unreadable. ' +
+        'For Go, rebuild the binary with -gcflags="all=-N -l" (exec mode) or launch the .go source directly (debug mode).';
+    }
+
+    // Add helpful messages for edge cases
+    if (result.variables.length === 0) {
+      if (!result.frame) {
+        // Distinguish "not paused" from "paused but the anchored thread has
+        // no frames" — the latter used to claim the debugger may not be
+        // paused while list_debug_sessions said paused (issue #465).
+        const sessionState = ctx.sessionManager.getSession(args.sessionId)?.state;
+        response.message = sessionState === SessionState.PAUSED
+          ? 'The session is paused, but the anchored thread reported no stack frames. ' +
+            'Try get_stack_trace with a threadId from list_threads, or continue_execution ' +
+            'followed by pause_execution to re-anchor on a reportable thread.'
+          : 'No stack frames available. The debugger may not be paused.';
+      } else if (!result.scopeName) {
+        response.message = 'No local scope found in the current frame.';
+      } else {
+        response.message = `The ${result.scopeName} scope is empty.`;
+      }
+    }
+
+    return { 
+      content: [{ 
+        type: 'text', 
+        text: JSON.stringify(response) 
+      }] 
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Log the error
+    ctx.logger.error('tool:get_local_variables:error', {
+      sessionId: args.sessionId,
+      error: errorMessage,
+      timestamp: Date.now()
+    });
+
+    // Handle session state errors specifically
+    if (error instanceof McpError &&
+        (error.message.includes('terminated') ||
+         error.message.includes('closed') ||
+         error.message.includes('not found') ||
+         error.message.includes('not paused'))) {
+      // A terminated session is a normal end state (e.g. a step_out ran the
+      // program to completion) — explain that instead of implying misuse.
+      const message = error.message.includes('terminated')
+        ? 'The program has terminated, so no frames or variables exist. Use restart_debugging to run it again.'
+        : 'Cannot get local variables. The session must be paused at a breakpoint.';
+      return { content: [{ type: 'text', text: JSON.stringify({
+        success: false,
+        error: error.message,
+        message
+      }) }] };
+    } else if (error instanceof McpError) {
+      throw error;
+    } else {
+      // Wrap unexpected errors
+      throw new McpError(McpErrorCode.InternalError, `Failed to get local variables: ${errorMessage}`);
+    }
+  }
+}
+
+export const getLocalVariablesTool: ToolHandler = async (ctx, args) => {
+  return await handleGetLocalVariables(ctx, args as { sessionId: string; includeSpecial?: boolean; names?: string[] });
+};

--- a/src/server/handlers/language-tools.ts
+++ b/src/server/handlers/language-tools.ts
@@ -1,0 +1,105 @@
+/**
+ * Language tool: list_supported_languages.
+ */
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getDisabledLanguages } from '../../utils/language-config.js';
+import { probeLanguageEntry, LanguageModes } from '../../utils/language-availability.js';
+import type { ToolContext, ToolHandler } from '../tool-context.js';
+import type { ToolResult } from '../tool-result.js';
+
+/**
+ * Entry in the list_supported_languages 'available' array.
+ * 'installed' keeps its historical meaning (adapter package loadable);
+ * 'modes' carries per-mode availability with reasons (issue #331).
+ */
+export interface AvailableLanguage {
+  language: string;
+  package: string;
+  installed: boolean;
+  description?: string;
+  modes: LanguageModes;
+}
+
+export async function handleListSupportedLanguages(ctx: ToolContext): Promise<ToolResult> {
+  try {
+    const adapterRegistry = ctx.getAdapterRegistry();
+    // Get installed languages via dynamic registry if available
+    const installed = await ctx.getSupportedLanguagesAsync();
+
+    // Also surface known adapters with install status if available from registry
+    let baseEntries: Array<{ language: string; package: string; installed: boolean; description?: string; attach: 'none' | 'direct-connect' | 'spawn' }> =
+      installed.map(lang => ({
+        language: lang,
+        package: `@debugmcp/adapter-${lang}`,
+        installed: true,
+        attach: 'none' as const
+      }));
+
+    // listAvailableAdapters/getFactory are on IAdapterRegistry (issue #435
+    // part 4); the runtime guards stay for partial registry doubles.
+    if (adapterRegistry && typeof adapterRegistry.listAvailableAdapters === 'function') {
+      try {
+        const meta = await adapterRegistry.listAvailableAdapters();
+        baseEntries = meta.map(m => ({
+          language: m.name,
+          package: m.packageName,
+          installed: m.installed,
+          description: m.description,
+          attach: m.attach ?? 'none'
+        }));
+      } catch (e) {
+        ctx.logger.warn('Failed to query detailed adapter metadata; returning installed list only', { error: (e as Error)?.message });
+      }
+    }
+
+    // Shared per-entry probe (issue #435): doctor consumes the same
+    // function, so the two views cannot drift apart. Probes run in
+    // parallel — on a cold cache each may import an adapter package and
+    // spawn a toolchain check, and this call should pay the max, not the
+    // sum (the doctor path already runs them concurrently).
+    const disabledSet = getDisabledLanguages();
+    const available: AvailableLanguage[] = await Promise.all(
+      baseEntries.map(async (entry) => {
+        const probe = await probeLanguageEntry(
+          {
+            language: entry.language,
+            packageName: entry.package,
+            installed: entry.installed,
+            attach: entry.attach
+          },
+          {
+            registry: adapterRegistry,
+            disabledSet,
+            runValidate: (language, validate) => ctx.validationCache.get(language, validate),
+            logger: ctx.logger
+          }
+        );
+        return {
+          language: entry.language,
+          package: entry.package,
+          installed: entry.installed,
+          description: entry.description,
+          modes: probe.modes
+        };
+      })
+    );
+
+    // Also build simple metadata array for backward compatibility with previous payload shape
+    const languageMetadata = await ctx.getLanguageMetadata();
+
+    return { content: [{ type: 'text', text: JSON.stringify({
+      success: true,
+      installed,
+      available,
+      languages: languageMetadata, // backward-compatible field with display info
+      count: installed.length
+    }) }] };
+  } catch (error) {
+    ctx.logger.error('Failed to list supported languages', { error });
+    throw new McpError(McpErrorCode.InternalError, `Failed to list supported languages: ${(error as Error).message}`);
+  }
+}
+
+export const listSupportedLanguagesTool: ToolHandler = async (ctx) => {
+  return await handleListSupportedLanguages(ctx);
+};

--- a/src/server/handlers/mirror-tools.ts
+++ b/src/server/handlers/mirror-tools.ts
@@ -1,0 +1,99 @@
+/**
+ * DAP mirror tools: expose_session, unexpose_session (issue #217).
+ */
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import {
+  SessionNotFoundError,
+  SessionTerminatedError,
+  ProxyNotRunningError
+} from '../../errors/debug-errors.js';
+import { isContainerMode } from '../../utils/container-path-utils.js';
+import type { ToolContext, ToolHandler } from '../tool-context.js';
+import type { ToolResult } from '../tool-result.js';
+
+export async function handleExposeSession(ctx: ToolContext, sessionId: string): Promise<ToolResult> {
+  try {
+    ctx.validateSession(sessionId);
+    const result = await ctx.sessionManager.exposeSession(sessionId);
+    if (!result.success) {
+      return { content: [{ type: 'text', text: JSON.stringify({
+        success: false,
+        state: result.state,
+        error: result.error
+      }) }] };
+    }
+    let message =
+      `Session exposed for IDE attach at ${result.host}:${result.port}. ` +
+      `VS Code: add a launch.json config {"name": "Mirror: agent debug session", ` +
+      `"type": "<your language's debug type, e.g. python>", "request": "attach", ` +
+      `"debugServer": ${result.port}, "mirrorToken": "${result.token}"} and start it. ` +
+      `The mirror is inspect-only; execution control stays with this session. ` +
+      `Full guidance: docs/tool-reference.md#expose_session.`;
+    if (isContainerMode(ctx.environment)) {
+      message +=
+        ' Note: this server runs inside a container — the mirror listens on the ' +
+        "container's loopback and is not reachable from your host IDE without extra " +
+        'networking (e.g. docker run --network host on Linux, or a socat/ssh forward ' +
+        'into the container).';
+    }
+    return { content: [{ type: 'text', text: JSON.stringify({
+      success: true,
+      state: result.state,
+      host: result.host,
+      port: result.port,
+      token: result.token,
+      message
+    }) }] };
+  } catch (error) {
+    ctx.logger.error('Failed to expose session', { error });
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    }
+    if (error instanceof McpError) throw error;
+    throw new McpError(McpErrorCode.InternalError, `Failed to expose session: ${(error as Error).message}`);
+  }
+}
+
+export const exposeSessionTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+  return await handleExposeSession(ctx, args.sessionId);
+};
+
+export async function handleUnexposeSession(ctx: ToolContext, sessionId: string): Promise<ToolResult> {
+  try {
+    ctx.validateSession(sessionId);
+    const result = await ctx.sessionManager.unexposeSession(sessionId);
+    const message = !result.success
+      ? undefined
+      : result.wasExposed
+        ? `Mirror endpoint closed${typeof result.closedClients === 'number' ? ` (${result.closedClients} client${result.closedClients === 1 ? '' : 's'} disconnected)` : ''}`
+        : 'Session was not exposed — nothing to close';
+    return { content: [{ type: 'text', text: JSON.stringify({
+      success: result.success,
+      state: result.state,
+      ...(result.wasExposed !== undefined ? { wasExposed: result.wasExposed } : {}),
+      ...(message ? { message } : {}),
+      ...(result.error ? { error: result.error } : {})
+    }) }] };
+  } catch (error) {
+    ctx.logger.error('Failed to unexpose session', { error });
+    if (error instanceof SessionTerminatedError ||
+        error instanceof SessionNotFoundError ||
+        error instanceof ProxyNotRunningError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }) }] };
+    }
+    if (error instanceof McpError) throw error;
+    throw new McpError(McpErrorCode.InternalError, `Failed to unexpose session: ${(error as Error).message}`);
+  }
+}
+
+export const unexposeSessionTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+  return await handleUnexposeSession(ctx, args.sessionId);
+};

--- a/src/server/handlers/output-tools.ts
+++ b/src/server/handlers/output-tools.ts
@@ -1,0 +1,34 @@
+/**
+ * Debuggee output tool: get_output.
+ */
+import type { ToolContext, ToolHandler } from '../tool-context.js';
+import type { ToolResult } from '../tool-result.js';
+
+export async function handleGetOutput(ctx: ToolContext, args: { sessionId: string; since?: number; limit?: number }): Promise<ToolResult> {
+  // Deliberately no validateSession(): that rejects TERMINATED sessions, but
+  // reading output after the program finished is the primary use case.
+  // Output stays readable until close_debug_session removes the session.
+  const session = ctx.sessionManager.getSession(args.sessionId);
+  if (!session) {
+    return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: `Session not found: ${args.sessionId}` }) }] };
+  }
+  const since = Math.max(0, args.since ?? 0);
+  const limit = Math.min(Math.max(1, args.limit ?? 100), 1000);
+  const read = session.outputBuffer
+    ? session.outputBuffer.read(since, limit)
+    : { entries: [], nextSince: since, hasMore: false, dropped: 0 }; // session created but never launched
+  const redaction = ctx.redactionSummary(read.entries);
+  return { content: [{ type: 'text', text: JSON.stringify({
+    success: true,
+    sessionId: args.sessionId,
+    entries: read.entries,
+    nextSince: read.nextSince,
+    hasMore: read.hasMore,
+    dropped: read.dropped,
+    ...(redaction ? { redaction } : {})
+  }) }] };
+}
+
+export const getOutputTool: ToolHandler = async (ctx, args) => {
+  return await handleGetOutput(ctx, args as { sessionId: string; since?: number; limit?: number });
+};

--- a/src/server/handlers/session-tools.ts
+++ b/src/server/handlers/session-tools.ts
@@ -1,0 +1,214 @@
+/**
+ * Session lifecycle tools: create_debug_session, list_debug_sessions,
+ * close_debug_session.
+ */
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { DebugLanguage, DebugSessionInfo } from '@debugmcp/shared';
+import { UnsupportedLanguageError } from '../../errors/debug-errors.js';
+import { ErrorMessages } from '../../utils/error-messages.js';
+import { checkLaunchToolchain } from '../../utils/language-availability.js';
+import type { ToolContext, ToolHandler } from '../tool-context.js';
+import type { ToolResult } from '../tool-result.js';
+
+export const createDebugSessionTool: ToolHandler = async (ctx, args) => {
+  // Validate before creating the session so a bad argument does
+  // not leave an orphan session behind (issue #336).
+  if (args.adapterConfig !== undefined) {
+    const cfg = args.adapterConfig;
+    if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
+      throw new McpError(McpErrorCode.InvalidParams, 'adapterConfig must be an object when provided');
+    }
+  }
+
+  // Ensure requested language is among dynamically supported ones
+  const supported = await ctx.getSupportedLanguagesAsync();
+  const lang = (args.language || DebugLanguage.PYTHON) as DebugLanguage;
+  const requested = lang as unknown as string;
+  const isContainer = process.env.MCP_CONTAINER === 'true';
+  const allowInContainer = isContainer && requested === DebugLanguage.PYTHON;
+  if (!allowInContainer && !supported.includes(lang)) {
+    throw new UnsupportedLanguageError(lang, supported);
+  }
+
+  // Fail fast when the adapter can't do ANYTHING here (issue
+  // #360). A failed launch-toolchain probe alone must not block
+  // session creation: the caller may intend to attach (with or
+  // without a port at create time), and direct-connect attach
+  // needs no local toolchain — e.g. ruby attach works in the
+  // container image without a launch toolchain. Launch itself is
+  // still gated at start_debugging.
+  {
+    const launchGate = await checkLaunchToolchain(
+      requested,
+      ctx.getAdapterRegistry(),
+      ctx.validationCache,
+      ctx.logger
+    );
+    if (!launchGate.available) {
+      const registry = ctx.getAdapterRegistry();
+      const attachMechanism = await (async () => {
+        try {
+          const factory = typeof registry?.getFactory === 'function'
+            ? await registry.getFactory(requested)
+            : undefined;
+          return factory?.getMetadata?.().modes?.attach ?? 'none';
+        } catch {
+          return 'none';
+        }
+      })();
+      // 'direct-connect' attach runs inside the debuggee — usable
+      // even when the local toolchain probe failed. 'spawn' attach
+      // shares the failing toolchain; 'none' has no attach at all.
+      if (attachMechanism !== 'direct-connect') {
+        return { content: [{ type: 'text', text: JSON.stringify({
+          success: false,
+          error: ErrorMessages.launchUnavailable(requested, launchGate.reason)
+        }) }] };
+      }
+      ctx.logger.warn(
+        `[Server] create_debug_session(${requested}): launch toolchain unavailable (${launchGate.reason}); ` +
+          `allowing session creation because direct-connect attach remains usable.`
+      );
+    }
+  }
+
+  const sessionInfo = await ctx.createDebugSession({
+    language: lang,
+    name: args.name,
+    executablePath: args.executablePath
+  });
+
+  // Log session creation
+  ctx.logger.info('session:created', {
+    sessionId: sessionInfo.id,
+    sessionName: sessionInfo.name,
+    language: sessionInfo.language,
+    executablePath: args.executablePath,
+    timestamp: Date.now()
+  });
+
+  // A new output resource is now listable (issue #218)
+  ctx.outputResources.notifyListChanged();
+
+  // Check if attach mode is requested (host/port provided)
+  const isAttachMode = args.port !== undefined;
+
+  if (isAttachMode) {
+    // Attach mode: immediately attach to the running process
+    ctx.logger.info('session:attach-mode', {
+      sessionId: sessionInfo.id,
+      host: args.host || 'localhost',
+      port: args.port,
+      timestamp: Date.now()
+    });
+
+    try {
+      const attachResult = await ctx.sessionManager.attachToProcess(sessionInfo.id, {
+        port: args.port as number,
+        host: (args.host as string) || 'localhost',
+        timeout: (args.timeout as number) || 30000,
+        stopOnEntry: args.stopOnEntry,
+        verifyTimeout: args.verifyTimeout,
+        adapterConfig: args.adapterConfig,
+      });
+
+      // Forward the attach payload the same way attach_to_process
+      // does: structured failure diagnostics (initProgress /
+      // proxyLogPath, issue #551) and the dropped-adapterConfig
+      // warning (issue #450) must reach this entry point too.
+      const attachData = attachResult.data as { warning?: string } | undefined;
+      const attachWarning = attachResult.success ? attachData?.warning : undefined;
+      return { content: [{ type: 'text', text: JSON.stringify({
+        success: attachResult.success,
+        sessionId: sessionInfo.id,
+        state: attachResult.state,
+        message: attachResult.success
+          ? `Created and attached ${sessionInfo.language} debug session: ${sessionInfo.name}`
+          : `Created session but attach failed: ${attachResult.error || 'Unknown error'}`,
+        ...(attachData ? { data: attachData } : {}),
+        ...(attachWarning ? { warning: attachWarning } : {})
+      }) }] };
+    } catch (error) {
+      ctx.logger.error('session:attach-failed', {
+        sessionId: sessionInfo.id,
+        error: error instanceof Error ? error.message : String(error),
+        timestamp: Date.now()
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify({
+        success: false,
+        sessionId: sessionInfo.id,
+        state: 'error',
+        message: `Created session but failed to attach: ${error instanceof Error ? error.message : String(error)}`
+      }) }] };
+    }
+  } else {
+    // Launch mode: just create the session
+    return { content: [{ type: 'text', text: JSON.stringify({
+      success: true,
+      sessionId: sessionInfo.id,
+      message: `Created ${sessionInfo.language} debug session: ${sessionInfo.name}`
+    }) }] };
+  }
+};
+
+export async function handleListDebugSessions(ctx: ToolContext): Promise<ToolResult> {
+  try {
+    const sessionsInfo: DebugSessionInfo[] = ctx.sessionManager.getAllSessions();
+    const sessionData = sessionsInfo.map((session: DebugSessionInfo) => {
+      const mappedSession: Record<string, unknown> = { 
+          id: session.id, 
+          name: session.name, 
+          language: session.language as DebugLanguage, 
+          state: session.state, 
+          createdAt: session.createdAt.toISOString(),
+      };
+      if (session.updatedAt) {
+          mappedSession.updatedAt = session.updatedAt.toISOString();
+      }
+      if (session.lastStop) {
+          mappedSession.lastStop = session.lastStop;
+      }
+      if (session.exitCode !== undefined) {
+          mappedSession.exitCode = session.exitCode;
+      }
+      if (session.exposure) {
+          // Mirror endpoint host/port; the token never leaves expose_session.
+          mappedSession.exposure = session.exposure;
+      }
+      return mappedSession;
+    });
+    return { content: [{ type: 'text', text: JSON.stringify({ success: true, sessions: sessionData, count: sessionData.length }) }] };
+  } catch (error) {
+    ctx.logger.error('Failed to list debug sessions', { error });
+    throw new McpError(McpErrorCode.InternalError, `Failed to list debug sessions: ${(error as Error).message}`);
+  }
+}
+
+export const listDebugSessionsTool: ToolHandler = async (ctx) => {
+  return handleListDebugSessions(ctx);
+};
+
+export const closeDebugSessionTool: ToolHandler = async (ctx, args) => {
+  if (!args.sessionId) {
+    throw new McpError(McpErrorCode.InvalidParams, 'Missing required sessionId');
+  }
+
+  const sessionName = ctx.getSessionName(args.sessionId);
+  const closed = await ctx.closeDebugSession(args.sessionId);
+
+  if (closed) {
+    // Log session closure
+    ctx.logger.info('session:closed', {
+      sessionId: args.sessionId,
+      sessionName: sessionName,
+      timestamp: Date.now()
+    });
+
+    // The session's output resource is gone (issue #218)
+    ctx.outputResources.forgetSession(args.sessionId);
+    ctx.outputResources.notifyListChanged();
+  }
+
+  return { content: [{ type: 'text', text: JSON.stringify({ success: closed, message: closed ? `Closed debug session: ${args.sessionId}` : `Failed to close debug session: ${args.sessionId}` }) }] };
+};

--- a/src/server/language-discovery.ts
+++ b/src/server/language-discovery.ts
@@ -1,0 +1,144 @@
+/**
+ * Supported-language discovery for the MCP server: which languages the
+ * adapter registry can serve (with the disabled-language filter and the
+ * container-runtime python guarantee applied), and the display metadata
+ * list_supported_languages reports for them.
+ */
+import { DebugLanguage, IAdapterRegistry, ILogger } from '@debugmcp/shared';
+import { getDisabledLanguages } from '../utils/language-config.js';
+
+export const DEFAULT_LANGUAGES = Object.freeze([DebugLanguage.PYTHON, DebugLanguage.MOCK] as const);
+
+export function getDefaultLanguages(): string[] {
+  return [...DEFAULT_LANGUAGES];
+}
+
+export function ensureLanguage(
+  languages: readonly string[],
+  language: string
+): string[] {
+  return languages.includes(language) ? [...languages] : [...languages, language];
+}
+
+export function filterDisabledLanguages(
+  languages: readonly string[],
+  disabled?: Set<string>,
+): string[] {
+  const disabledSet = disabled ?? getDisabledLanguages();
+  if (!disabledSet.size) {
+    return [...languages];
+  }
+  return languages.filter((lang) => !disabledSet.has(lang));
+}
+
+/**
+ * Get supported languages from the adapter registry. Prefers dynamic
+ * discovery, then already-registered factories, then the shipped defaults;
+ * python is always advertised in the container runtime.
+ */
+export async function discoverSupportedLanguages(
+  adapterRegistry: IAdapterRegistry | undefined,
+  logger: ILogger
+): Promise<string[]> {
+  const disabled = getDisabledLanguages();
+  const filter = (langs: readonly string[]) => filterDisabledLanguages(langs, disabled);
+  // Guard against undefined registry in certain test environments
+  if (!adapterRegistry) {
+    return filter(getDefaultLanguages());
+  }
+  // Prefer dynamic discovery. listLanguages is on IAdapterRegistry (issue
+  // #435 part 4); the runtime guard stays for partial registry doubles.
+  const maybeList = adapterRegistry.listLanguages;
+  if (typeof maybeList === 'function') {
+    try {
+      const langs = await maybeList.call(adapterRegistry);
+      if (Array.isArray(langs) && langs.length > 0) {
+        const normalized =
+          process.env.MCP_CONTAINER === 'true' ? ensureLanguage(langs, DebugLanguage.PYTHON) : langs;
+        return filter(normalized);
+      }
+    } catch (e) {
+      logger.warn('Dynamic adapter language discovery failed, falling back to registered languages', { error: (e as Error)?.message });
+    }
+  }
+  // Fallback to already-registered factories (may be empty until first use)
+  const langs = adapterRegistry.getSupportedLanguages?.() || [];
+  if (langs.length > 0) {
+    // In container runtime, ensure python is advertised even if not yet registered (preload may be async)
+    if (process.env.MCP_CONTAINER === 'true') {
+      return filter(ensureLanguage(langs, DebugLanguage.PYTHON));
+    }
+    return filter(langs);
+  }
+  // Final fallback to known defaults for UX (ensure python listed in container)
+  if (process.env.MCP_CONTAINER === 'true') {
+    return filter(ensureLanguage(getDefaultLanguages(), DebugLanguage.PYTHON));
+  }
+  return filter(getDefaultLanguages());
+}
+
+/**
+ * Language metadata for supported languages
+ */
+export interface LanguageMetadata {
+  id: string;
+  displayName: string;
+  version: string;
+  requiresExecutable: boolean;
+  defaultExecutable?: string;
+}
+
+/** Get language metadata for all supported languages. */
+export function buildLanguageMetadata(languages: string[]): LanguageMetadata[] {
+  // Hardcoded metadata fallback; adapters could provide this via registry in the future
+  return languages.map((lang: string) => {
+    switch (lang) {
+      case DebugLanguage.PYTHON:
+        return {
+          id: DebugLanguage.PYTHON,
+          displayName: 'Python',
+          version: '1.0.0',
+          requiresExecutable: true,
+          defaultExecutable: 'python'
+        };
+      case DebugLanguage.RUBY:
+        return {
+          id: DebugLanguage.RUBY,
+          displayName: 'Ruby',
+          version: '1.0.0',
+          requiresExecutable: true,
+          defaultExecutable: 'ruby'
+        };
+      case DebugLanguage.MOCK:
+        return {
+          id: DebugLanguage.MOCK,
+          displayName: 'Mock',
+          version: '1.0.0',
+          requiresExecutable: false
+        };
+      case DebugLanguage.JAVASCRIPT:
+        return {
+          id: DebugLanguage.JAVASCRIPT,
+          displayName: 'JavaScript/TypeScript',
+          version: '1.0.0',
+          requiresExecutable: true,
+          defaultExecutable: 'node'
+        };
+      case DebugLanguage.CPP:
+        return {
+          id: DebugLanguage.CPP,
+          displayName: 'C/C++',
+          version: '1.0.0',
+          requiresExecutable: true,
+          defaultExecutable: 'g++'
+        };
+      default:
+        return {
+          id: lang,
+          displayName: lang.charAt(0).toUpperCase() + lang.slice(1),
+          version: '1.0.0',
+          requiresExecutable: true
+        };
+    }
+  });
+}

--- a/src/server/output-resources.ts
+++ b/src/server/output-resources.ts
@@ -1,0 +1,173 @@
+/**
+ * Debuggee-output resources (issue #218).
+ *
+ * Each debug session exposes its captured debuggee output as
+ * debug://sessions/{id}/output — a verbatim console transcript (all categories
+ * interleaved, in arrival order). Clients may subscribe to receive coalesced
+ * resources/updated pings as output arrives; structured/cursor access is
+ * available via the get_output tool.
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+  ErrorCode as McpErrorCode,
+  McpError
+} from '@modelcontextprotocol/sdk/types.js';
+import { ILogger } from '@debugmcp/shared';
+import type { SessionManager } from '../session/session-manager.js';
+
+export function outputResourceUri(sessionId: string): string {
+  return `debug://sessions/${sessionId}/output`;
+}
+
+/** Returns the sessionId encoded in a debug output resource URI, or undefined. */
+export function parseOutputResourceUri(uri: string): string | undefined {
+  const match = /^debug:\/\/sessions\/([^/]+)\/output$/.exec(uri);
+  return match?.[1];
+}
+
+/** Debounce window for resources/updated pings. */
+export const OUTPUT_UPDATE_DEBOUNCE_MS = 150;
+
+/**
+ * Subscription bookkeeping and debounced resources/updated pings for the
+ * output resources. URIs subscribed via resources/subscribe; updated-pings are
+ * debounced so notification volume is independent of debuggee output volume.
+ */
+export class OutputResourceNotifier {
+  private readonly subscribedUris = new Set<string>();
+  private readonly outputUpdateTimers = new Map<string, NodeJS.Timeout>();
+
+  constructor(
+    private readonly server: Server,
+    private readonly logger: ILogger
+  ) {}
+
+  /**
+   * Stable listener for SessionManager's 'output-captured' event: the owner
+   * registers this exact reference with on() and removes it with
+   * removeListener() on stop().
+   */
+  readonly handleOutputCaptured = (sessionId: string): void => {
+    this.scheduleUpdated(sessionId);
+  };
+
+  subscribe(uri: string): void {
+    this.subscribedUris.add(uri);
+  }
+
+  unsubscribe(uri: string): void {
+    this.subscribedUris.delete(uri);
+    this.clearTimer(uri);
+  }
+
+  /** The session's output resource is gone: drop its subscription and timer. */
+  forgetSession(sessionId: string): void {
+    this.unsubscribe(outputResourceUri(sessionId));
+  }
+
+  /**
+   * Throttled resources/updated ping for a session's output resource: the
+   * first captured event after a quiet period arms a timer; everything that
+   * arrives inside the window rides the same ping.
+   */
+  scheduleUpdated(sessionId: string): void {
+    const uri = outputResourceUri(sessionId);
+    if (!this.subscribedUris.has(uri) || this.outputUpdateTimers.has(uri)) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.outputUpdateTimers.delete(uri);
+      this.server.sendResourceUpdated({ uri }).catch((error: unknown) => {
+        // Not connected yet / transport gone — nothing to notify, not an error.
+        this.logger.debug(`[Server] Failed to send resources/updated for ${uri}`, { error });
+      });
+    }, OUTPUT_UPDATE_DEBOUNCE_MS);
+    timer.unref?.();
+    this.outputUpdateTimers.set(uri, timer);
+  }
+
+  /** Fire-and-forget resources/list_changed (sessions appeared/disappeared). */
+  notifyListChanged(): void {
+    this.server.sendResourceListChanged().catch((error: unknown) => {
+      this.logger.debug('[Server] Failed to send resources/list_changed', { error });
+    });
+  }
+
+  /**
+   * Tear down output-resource bookkeeping: pending debounce timers must not
+   * outlive the server (the test suite runs with a strict leak guard).
+   */
+  dispose(): void {
+    for (const uri of this.outputUpdateTimers.keys()) {
+      this.clearTimer(uri);
+    }
+    this.subscribedUris.clear();
+  }
+
+  private clearTimer(uri: string): void {
+    const timer = this.outputUpdateTimers.get(uri);
+    if (timer) {
+      clearTimeout(timer);
+      this.outputUpdateTimers.delete(uri);
+    }
+  }
+}
+
+/**
+ * Registers the MCP resource handlers (resources/list, resources/read,
+ * resources/subscribe, resources/unsubscribe) for the debuggee-output resources.
+ */
+export function registerResourceHandlers(
+  server: Server,
+  sessionManager: SessionManager,
+  notifier: OutputResourceNotifier
+): void {
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    const sessions = sessionManager.getAllSessions();
+    return {
+      resources: sessions.map(session => ({
+        uri: outputResourceUri(session.id),
+        name: `Debuggee output — ${session.name}`,
+        description: `stdout/stderr/console output captured for ${session.language} debug session '${session.name}'`,
+        mimeType: 'text/plain'
+      }))
+    };
+  });
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    const sessionId = parseOutputResourceUri(uri);
+    const session = sessionId ? sessionManager.getSession(sessionId) : undefined;
+    if (!session) {
+      throw new McpError(McpErrorCode.InvalidParams, `Unknown resource: ${uri}`);
+    }
+    return {
+      contents: [{
+        uri,
+        mimeType: 'text/plain',
+        // Empty until the first launch creates the buffer
+        text: session.outputBuffer?.renderText() ?? ''
+      }]
+    };
+  });
+
+  server.setRequestHandler(SubscribeRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    const sessionId = parseOutputResourceUri(uri);
+    if (!sessionId || !sessionManager.getSession(sessionId)) {
+      throw new McpError(McpErrorCode.InvalidParams, `Unknown resource: ${uri}`);
+    }
+    notifier.subscribe(uri);
+    return {};
+  });
+
+  server.setRequestHandler(UnsubscribeRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    notifier.unsubscribe(uri);
+    return {};
+  });
+}

--- a/src/server/prompts.ts
+++ b/src/server/prompts.ts
@@ -1,0 +1,43 @@
+/**
+ * MCP prompt handlers. The single `debugging-workflow` prompt serves the
+ * condensed debugging skill in-band so any connected agent can pull workflow
+ * guidance without a separate skill install (the full skill with per-language
+ * references ships in skills/debugging/).
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+  ErrorCode as McpErrorCode,
+  McpError
+} from '@modelcontextprotocol/sdk/types.js';
+import { IEnvironment } from '@debugmcp/shared';
+import { buildDebuggingWorkflowPrompt } from '../skill-content.js';
+import { getBpAddressingMode } from '../utils/bp-addressing.js';
+
+export function registerPromptHandlers(server: Server, environment: IEnvironment): void {
+  const promptDescriptor = {
+    name: 'debugging-workflow',
+    description:
+      'How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks.'
+  };
+
+  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+    prompts: [promptDescriptor]
+  }));
+
+  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    if (request.params.name !== promptDescriptor.name) {
+      throw new McpError(McpErrorCode.InvalidParams, `Unknown prompt: ${request.params.name}`);
+    }
+    return {
+      description: promptDescriptor.description,
+      messages: [
+        {
+          role: 'user' as const,
+          content: { type: 'text' as const, text: buildDebuggingWorkflowPrompt(getBpAddressingMode(environment)) }
+        }
+      ]
+    };
+  });
+}

--- a/src/server/tool-arguments.ts
+++ b/src/server/tool-arguments.ts
@@ -1,0 +1,118 @@
+/**
+ * MCP tool arguments: the argument bag every tool handler receives, and the
+ * schema-driven coercion applied to it once per request.
+ */
+import { DebugProtocol } from '@vscode/debugprotocol';
+
+/**
+ * Tool arguments interface
+ */
+export interface ToolArguments {
+  sessionId?: string;
+  language?: string;
+  name?: string;
+  executablePath?: string;  // Language-agnostic executable path
+  file?: string;
+  line?: number;
+  condition?: string;
+  logMessage?: string;
+  expectedContent?: string;
+  statement?: string;
+  nearLine?: number;
+  function?: string;
+  breakpointId?: string;
+  scriptPath?: string;
+  args?: string[];
+  dapLaunchArgs?: Partial<DebugProtocol.LaunchRequestArguments>;
+  dryRunSpawn?: boolean;
+  breakOnExceptions?: string;
+  adapterLaunchConfig?: Record<string, unknown>;
+  scope?: number;
+  frameId?: number;
+  expression?: string;
+  linesContext?: number;
+  includeInternals?: boolean;
+  includeSpecial?: boolean;
+  names?: string[];
+  // Attach-related parameters
+  port?: number;
+  host?: string;
+  processId?: number | string;
+  timeout?: number;
+  verifyTimeout?: number;
+  sourcePaths?: string[];
+  stopOnEntry?: boolean;
+  justMyCode?: boolean;
+  adapterConfig?: Record<string, unknown>;
+  terminateProcess?: boolean;
+  suspendPolicy?: 'all' | 'thread';
+  threadId?: number;
+  // redefine_classes parameters
+  classesDir?: string;
+  sinceTimestamp?: number;
+  // get_output parameters
+  since?: number;
+  limit?: number;
+}
+
+/**
+ * Schema-driven type coercion for MCP tool arguments.
+ *
+ * Works around a known Claude Code bug (anthropics/claude-code#11359) where
+ * SSE-transport tool arguments arrive as strings instead of their declared
+ * JSON-Schema types.  Called once per request on the fresh args object — no
+ * shared state is mutated.
+ */
+export const TOOL_ARG_EXPECTED_TYPES: Record<string, 'number' | 'boolean' | 'object' | 'array'> = {
+  // numbers
+  line: 'number', linesContext: 'number', scope: 'number',
+  frameId: 'number', port: 'number', timeout: 'number', threadId: 'number',
+  verifyTimeout: 'number', since: 'number', limit: 'number',
+  sinceTimestamp: 'number', nearLine: 'number',
+  // booleans
+  includeInternals: 'boolean', includeSpecial: 'boolean',
+  stopOnEntry: 'boolean', justMyCode: 'boolean',
+  dryRunSpawn: 'boolean', terminateProcess: 'boolean',
+  // objects
+  dapLaunchArgs: 'object', adapterLaunchConfig: 'object', adapterConfig: 'object',
+  // arrays
+  args: 'array', sourcePaths: 'array', names: 'array',
+};
+
+export function coerceToolArguments(args: Record<string, unknown>): Record<string, unknown> {
+  for (const [key, expectedType] of Object.entries(TOOL_ARG_EXPECTED_TYPES)) {
+    const val = args[key];
+    if (val === undefined) continue;
+
+    // Handle "null" string → undefined for optional params
+    if (val === 'null') { args[key] = undefined; continue; }
+
+    if (typeof val !== 'string') continue; // already correct type
+
+    switch (expectedType) {
+      case 'number': {
+        if (val !== '') {
+          const n = Number(val);
+          if (!Number.isNaN(n)) args[key] = n;
+        }
+        break;
+      }
+      case 'boolean':
+        if (val === 'true') args[key] = true;
+        else if (val === 'false') args[key] = false;
+        break;
+      case 'object':
+      case 'array':
+        try {
+          const parsed = JSON.parse(val);
+          if (expectedType === 'object' && typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            args[key] = parsed;
+          } else if (expectedType === 'array' && Array.isArray(parsed)) {
+            args[key] = parsed;
+          }
+        } catch { /* leave as-is, downstream validation will catch */ }
+        break;
+    }
+  }
+  return args;
+}

--- a/src/server/tool-context.ts
+++ b/src/server/tool-context.ts
@@ -1,0 +1,143 @@
+/**
+ * The contract every tool handler in src/server/handlers/ programs against.
+ *
+ * DebugMcpServer implements it and passes itself, so handlers read every
+ * dependency (sessionManager, logger, fileChecker, ...) from the live server
+ * at call time rather than from copies captured at construction — the
+ * server-coverage tests swap those fields on a constructed server and expect
+ * the handlers to see the swap.
+ *
+ * Type-only imports throughout; this module never imports src/server.ts.
+ */
+import type { McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { DebugProtocol } from '@vscode/debugprotocol';
+import type {
+  Breakpoint,
+  DebugLanguage,
+  DebugSessionInfo,
+  ExceptionBreakMode,
+  FunctionBreakpoint,
+  IAdapterRegistry,
+  IEnvironment,
+  ILogger,
+  Variable
+} from '@debugmcp/shared';
+import type { SessionManager } from '../session/session-manager.js';
+import type { StackTraceResult } from '../session/session-manager-data.js';
+import type { VariableTruncationSummary } from '../session/variable-caps.js';
+import type { SimpleFileChecker, FileExistenceResult } from '../utils/simple-file-checker.js';
+import type { LineReader } from '../utils/line-reader.js';
+import type { ValidationResultCache } from '../utils/language-availability.js';
+import type { OutputResourceNotifier } from './output-resources.js';
+import type { LanguageMetadata } from './language-discovery.js';
+import type { ToolArguments } from './tool-arguments.js';
+import type { ToolResult } from './tool-result.js';
+
+/**
+ * Request shape for DebugMcpServer.setBreakpoint (issue #271).
+ */
+export interface SetBreakpointRequest {
+  sessionId: string;
+  file: string;
+  /** 1-based target line (required unless statement is given) */
+  line?: number;
+  /** Assert the target line's trimmed content before setting (assert/content modes) */
+  expectedContent?: string;
+  /** Content anchor: whole-line trimmed-equality match (content mode) */
+  statement?: string;
+  /** Disambiguates a multi-match statement to the closest occurrence */
+  nearLine?: number;
+  condition?: string;
+  logMessage?: string;
+  suspendPolicy?: 'all' | 'thread';
+}
+
+export interface ToolContext {
+  // ---- live dependencies ----
+  readonly sessionManager: SessionManager;
+  readonly logger: ILogger;
+  readonly fileChecker: SimpleFileChecker;
+  readonly lineReader: LineReader;
+  readonly environment: IEnvironment;
+  readonly validationCache: ValidationResultCache;
+  readonly outputResources: OutputResourceNotifier;
+
+  // ---- context services ----
+  getAdapterRegistry(): IAdapterRegistry;
+  getSessionName(sessionId: string): string;
+  validateSession(sessionId: string): void;
+  fileNotFoundError(label: string, originalPath: string, fileCheck: FileExistenceResult): McpError;
+  getSupportedLanguagesAsync(): Promise<string[]>;
+  getLanguageMetadata(): Promise<LanguageMetadata[]>;
+
+  // ---- breakpoint gating ----
+  validateLogPointSupport(sessionId: string): { warning?: string };
+  validateFunctionBreakpointSupport(sessionId: string): { warning?: string };
+  getFunctionBreakpointNameHint(sessionId: string, functionName: string): string | undefined;
+  normalizeFunctionBreakpointName(
+    sessionId: string,
+    functionName: string
+  ): { name: string; note: string } | undefined;
+  handleBreakpointToolError(error: unknown): ToolResult;
+
+  // ---- intake validation and result shaping ----
+  validateBreakOnExceptions(value: string | undefined): ExceptionBreakMode | undefined;
+  normalizeStartDebuggingArgs(
+    dapLaunchArgs: Partial<DebugProtocol.LaunchRequestArguments> | undefined,
+    topLevelBreakOnExceptions: string | undefined
+  ): {
+    dapLaunchArgs: Partial<DebugProtocol.LaunchRequestArguments> | undefined;
+    breakOnExceptions: string | undefined;
+    warnings: string[];
+  };
+  enforceExplicitNames(toolName: string, names: string[] | undefined): void;
+  redactionSummary(items: Array<{ redacted?: boolean }>): { masked: number; notice: string } | undefined;
+
+  // ---- public facade (unchanged signatures) ----
+  createDebugSession(params: { language: DebugLanguage; name?: string; executablePath?: string; }): Promise<DebugSessionInfo>;
+  startDebugging(
+    sessionId: string,
+    scriptPath: string,
+    args?: string[],
+    dapLaunchArgs?: Partial<DebugProtocol.LaunchRequestArguments>,
+    dryRunSpawn?: boolean,
+    adapterLaunchConfig?: Record<string, unknown>,
+    breakOnExceptions?: ExceptionBreakMode
+  ): Promise<{ success: boolean; state: string; error?: string; data?: unknown; errorType?: string; errorCode?: number; }>;
+  restartDebugging(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown }>;
+  closeDebugSession(sessionId: string): Promise<boolean>;
+  setFunctionBreakpoint(
+    sessionId: string,
+    functionName: string,
+    condition?: string
+  ): Promise<{ breakpoint: FunctionBreakpoint; warning?: string }>;
+  setBreakpoint(req: SetBreakpointRequest): Promise<{ breakpoint: Breakpoint; warning?: string }>;
+  listBreakpoints(sessionId: string, file?: string): Breakpoint[];
+  removeBreakpoint(sessionId: string, breakpointId: string): Promise<{ removed?: Breakpoint | FunctionBreakpoint; warning?: string }>;
+  removeBreakpointsByLocation(sessionId: string, file: string, line: number): Promise<{ removed: Breakpoint[]; warning?: string }>;
+  clearBreakpoints(sessionId: string, file?: string): Promise<{ cleared: number; files: string[]; warning?: string }>;
+  getVariables(sessionId: string, variablesReference: number, names?: string[]): Promise<Variable[]>;
+  getVariablesDetailed(sessionId: string, variablesReference: number, names?: string[]): Promise<{
+    variables: Variable[];
+    truncation?: VariableTruncationSummary;
+  }>;
+  getStackTrace(sessionId: string, includeInternals?: boolean, threadId?: number): Promise<StackTraceResult>;
+  getScopes(sessionId: string, frameId: number): Promise<DebugProtocol.Scope[]>;
+  getLocalVariables(sessionId: string, includeSpecial?: boolean, names?: string[]): Promise<{
+    variables: Variable[];
+    frame: { name: string; file: string; line: number } | null;
+    scopeName: string | null;
+    anchorNote?: string;
+    truncation?: VariableTruncationSummary;
+  }>;
+  continueExecution(sessionId: string): Promise<boolean>;
+  stepOver(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }>;
+  stepInto(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }>;
+  stepOut(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }>;
+}
+
+/**
+ * One MCP tool. `toolName` is the name the request carried, for handlers that
+ * serve several tools (step_over / step_into / step_out).
+ */
+export type ToolHandler = (ctx: ToolContext, args: ToolArguments, toolName: string) => Promise<ToolResult>;

--- a/src/server/tool-dispatch.ts
+++ b/src/server/tool-dispatch.ts
@@ -1,0 +1,79 @@
+/**
+ * MCP tool registration: the tools/list handler and the tools/call dispatch
+ * wrapper (tool:call / tool:response / tool:error logging) around
+ * TOOL_HANDLERS. The unknown-tool check sits inside the try so an unknown
+ * name produces the same tool:error log line as a failing handler.
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  ErrorCode as McpErrorCode,
+  McpError,
+  ServerResult
+} from '@modelcontextprotocol/sdk/types.js';
+import { coerceToolArguments, ToolArguments } from './tool-arguments.js';
+import { extractPayloadSuccess, sanitizeRequest } from './tool-result.js';
+import { buildToolDefinitions } from './tool-schemas.js';
+import type { ToolContext } from './tool-context.js';
+import { TOOL_HANDLERS } from './handlers/index.js';
+
+export function registerToolHandlers(server: Server, ctx: ToolContext): void {
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    ctx.logger.debug('Handling ListToolsRequest');
+    
+    // Get supported languages dynamically - deferred until request time
+    const supportedLanguages = await ctx.getSupportedLanguagesAsync();
+    
+    return { tools: buildToolDefinitions({ supportedLanguages, environment: ctx.environment }) };
+  });
+
+  server.setRequestHandler(
+    CallToolRequestSchema,
+    async (request): Promise<ServerResult> => {
+      const toolName = request.params.name;
+      const args = coerceToolArguments((request.params.arguments ?? {}) as Record<string, unknown>) as ToolArguments;
+
+      // Log tool call with structured logging
+      ctx.logger.info('tool:call', {
+        tool: toolName,
+        sessionId: args.sessionId,
+        sessionName: args.sessionId ? ctx.getSessionName(args.sessionId) : undefined,
+        request: sanitizeRequest(args as Record<string, unknown>),
+        timestamp: Date.now()
+      });
+
+      try {
+        if (!Object.hasOwn(TOOL_HANDLERS, toolName)) {
+          throw new McpError(McpErrorCode.MethodNotFound, `Unknown tool: ${toolName}`);
+        }
+        const result = await TOOL_HANDLERS[toolName](ctx, args, toolName);
+        
+        // Log tool response; success mirrors the payload's own success flag (issue #397)
+        ctx.logger.info('tool:response', {
+          tool: toolName,
+          sessionId: args.sessionId,
+          sessionName: args.sessionId ? ctx.getSessionName(args.sessionId) : undefined,
+          success: extractPayloadSuccess(result),
+          timestamp: Date.now()
+        });
+        
+        return result;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        
+        // Log tool error
+        ctx.logger.error('tool:error', {
+          tool: toolName,
+          sessionId: args.sessionId,
+          sessionName: args.sessionId ? ctx.getSessionName(args.sessionId) : undefined,
+          error: errorMessage,
+          timestamp: Date.now()
+        });
+        
+        if (error instanceof McpError) throw error;
+        throw new McpError(McpErrorCode.InternalError, `Failed to execute tool ${toolName}: ${errorMessage}`);
+      }
+    }
+  );
+}

--- a/src/server/tool-result.ts
+++ b/src/server/tool-result.ts
@@ -1,0 +1,58 @@
+/**
+ * Tool result shape and the request/response plumbing helpers shared by the
+ * CallTool dispatch: request sanitizing for logs and payload-success
+ * extraction for the tool:response log line.
+ */
+import { ServerResult } from '@modelcontextprotocol/sdk/types.js';
+import path from 'path';
+
+/** The single text-content result every tool handler produces. */
+export type ToolResult = { content: [{ type: 'text'; text: string }] };
+
+/** Wrap a JSON-serializable payload as a tool result. */
+export function jsonResult(payload: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] };
+}
+
+/** Wrap a JSON-serializable payload as a pretty-printed (2-space) tool result. */
+export function prettyJsonResult(payload: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+}
+
+/**
+ * Sanitize request data for logging (remove sensitive information)
+ */
+export function sanitizeRequest(args: Record<string, unknown>): Record<string, unknown> {
+  const sanitized = { ...args };
+  // Remove absolute paths from executablePath
+  if (sanitized.executablePath && typeof sanitized.executablePath === 'string' && path.isAbsolute(sanitized.executablePath)) {
+    sanitized.executablePath = '<absolute-path>';
+  }
+  // Truncate long arrays
+  if (sanitized.args && Array.isArray(sanitized.args) && sanitized.args.length > 5) {
+    sanitized.args = [...sanitized.args.slice(0, 5), `... +${sanitized.args.length - 5} more`];
+  }
+  return sanitized;
+}
+
+/**
+ * Derive the success flag for the tool:response log line from the tool's own
+ * payload. Handlers report failures as { success: false } inside the JSON
+ * text content without throwing; the log line must agree with the payload
+ * rather than meaning merely "the handler didn't throw" (issue #397).
+ */
+export function extractPayloadSuccess(result: ServerResult): boolean {
+  try {
+    const content = (result as { content?: Array<{ type?: string; text?: string }> }).content;
+    const first = content?.[0];
+    if (first?.type === 'text' && typeof first.text === 'string') {
+      const payload = JSON.parse(first.text) as unknown;
+      if (payload && typeof payload === 'object' && typeof (payload as { success?: unknown }).success === 'boolean') {
+        return (payload as { success: boolean }).success;
+      }
+    }
+  } catch {
+    // Non-JSON payloads carry no success flag; treat handler completion as success.
+  }
+  return true;
+}

--- a/src/server/tool-schemas.ts
+++ b/src/server/tool-schemas.ts
@@ -1,0 +1,158 @@
+/**
+ * tools/list schema builder. Pure: the only inputs are the supported
+ * language list and the environment (path wording, addressing-mode and
+ * variable-access gating), so the advertised schemas can be built and
+ * snapshot-tested without a server.
+ */
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { IEnvironment } from '@debugmcp/shared';
+import { isContainerMode } from '../utils/container-path-utils.js';
+import {
+  getBpAddressingMode,
+  supportsExpectedContent,
+  supportsStatementAnchors
+} from '../utils/bp-addressing.js';
+import { getVariableAccessMode, requiresExplicitNames } from '../utils/variable-access.js';
+
+export function getPathDescription(environment: IEnvironment, parameterName: string): string {
+  if (isContainerMode(environment)) {
+    return `Path to the ${parameterName}. Use paths relative to the project root (e.g., examples/python/script.py). The server resolves these against the workspace mount.`;
+  }
+  if (parameterName === 'script') {
+    return `Path to the script to debug. Use absolute paths or paths relative to your current working directory`;
+  }
+  return `Path to the ${parameterName}. Use absolute paths or paths relative to your current working directory`;
+}
+
+export interface BuildToolDefinitionsOptions {
+  /** Languages advertised in create_debug_session.language.enum */
+  supportedLanguages: string[];
+  environment: IEnvironment;
+}
+
+export function buildToolDefinitions(options: BuildToolDefinitionsOptions): Tool[] {
+  const { supportedLanguages, environment } = options;
+
+  // Generate dynamic descriptions for path parameters
+  const fileDescription = getPathDescription(environment, 'source file');
+  const scriptPathDescription = getPathDescription(environment, 'script');
+
+  // Addressing-mode-gated set_breakpoint params (issue #271): a server
+  // restricted to line mode must not advertise content-addressing at all.
+  const bpMode = getBpAddressingMode(environment);
+  const setBreakpointExtraProps: Record<string, unknown> = {};
+  let setBreakpointRequired = ['sessionId', 'file', 'line'];
+  if (supportsExpectedContent(bpMode)) {
+    setBreakpointExtraProps.expectedContent = {
+      type: 'string',
+      description: 'Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior'
+    };
+  }
+  if (supportsStatementAnchors(bpMode)) {
+    setBreakpointExtraProps.statement = {
+      type: 'string',
+      description: 'Address by content instead of line number: the text of the target line, like an Edit-tool match — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored; an exact whole-line match always wins over substring matches). Preferred over line — it can only land on a line containing your text (an inexact or multi-candidate match adds a warning to the response) and survives file edits across restart_debugging. If the text appears on multiple lines, the error lists every match; add nearLine to pick one. Provide statement OR line, not both'
+    };
+    setBreakpointExtraProps.nearLine = {
+      type: 'number',
+      description: 'With statement only: when the statement text appears on multiple lines, bind to the match closest to this line'
+    };
+    setBreakpointExtraProps.function = {
+      type: 'string',
+      description: 'Address by symbol name instead of file location: break on entry to this function/method (DAP function breakpoint). No file or line needed — names survive edits better than both. Composes with condition only. Supported by Python, Go, Rust, .NET, Java, and JavaScript adapters. JavaScript names are dotted runtime paths (e.g. "handler" or "obj.method") bound to the current function value: top-level function declarations of the main module bind at launch; functions in modules loaded later bind at the next pause'
+    };
+    setBreakpointRequired = ['sessionId'];
+  }
+
+  // Least-privilege gating (issue #237): in explicit mode the names
+  // filter is required, and the schema must say so.
+  const varAccessExplicit = requiresExplicitNames(getVariableAccessMode(environment));
+  const namesProp = {
+    type: 'array',
+    items: { type: 'string' },
+    description: 'Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response\'s notFound.' +
+      (varAccessExplicit ? ' Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled.' : '')
+  };
+  const getVariablesRequired = varAccessExplicit ? ['sessionId', 'scope', 'names'] : ['sessionId', 'scope'];
+  const getLocalVariablesRequired = varAccessExplicit ? ['sessionId', 'names'] : ['sessionId'];
+
+  return [
+    { name: 'create_debug_session', description: 'Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode', inputSchema: { type: 'object', properties: { language: { type: 'string', enum: supportedLanguages, description: 'Programming language for debugging' }, name: { type: 'string', description: 'Optional session name' }, executablePath: {type: 'string', description: 'Path to language executable (optional, will auto-detect if not provided)'}, host: { type: 'string', description: 'Host to attach to for remote debugging (optional, triggers attach mode)' }, port: { type: 'number', description: 'Debug port to attach to for remote debugging (optional, triggers attach mode)' }, timeout: { type: 'number', description: 'Connection timeout in milliseconds for attach mode (default: 30000)' }, verifyTimeout: { type: 'number', description: 'Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)' }, adapterConfig: { type: 'object', description: 'Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)', additionalProperties: true } }, required: ['language'] } },
+    { name: 'list_supported_languages', description: 'List all supported debugging languages with metadata', inputSchema: { type: 'object', properties: {} } },
+    { name: 'list_debug_sessions', description: 'List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. "breakpoint" vs "exception")', inputSchema: { type: 'object', properties: {} } },
+    { name: 'set_breakpoint', description: 'Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. "com.example.MyClass" or "com.example.Outer$Inner") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths.' }, line: { type: 'number', description: 'Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior' }, ...setBreakpointExtraProps, condition: { type: 'string', description: 'Optional expression: only break (or log) when it evaluates truthy' }, logMessage: { type: 'string', description: 'Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. "order={orderId} total={total}"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby' }, suspendPolicy: { type: 'string', enum: ['all', 'thread'], description: 'Suspend policy when breakpoint is hit: "all" suspends all threads (default), "thread" only suspends the event thread. Only supported by the Java/JDI adapter.' } }, required: setBreakpointRequired } },
+    { name: 'list_breakpoints', description: 'List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Optional: only list breakpoints in this file' } }, required: ['sessionId'] } },
+    { name: 'remove_breakpoint', description: 'Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, breakpointId: { type: 'string', description: 'Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line' }, function: { type: 'string', description: 'Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go "main" matches the stored "main.main"); the response reports the effective name as functionName and, when rewritten, the original as requestedName' }, file: { type: 'string', description: 'Alternative addressing: source file path (use together with line)' }, line: { type: 'number', description: 'Alternative addressing: line number (use together with file)' } }, required: ['sessionId'] } },
+    { name: 'clear_breakpoints', description: 'Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: 'Optional: only clear breakpoints in this file' } }, required: ['sessionId'] } },
+    { name: 'start_debugging', description: 'Start debugging a script', inputSchema: {
+        type: 'object', 
+        properties: { 
+          sessionId: { type: 'string' }, 
+          scriptPath: { type: 'string', description: scriptPathDescription }, 
+          args: { type: 'array', items: { type: 'string' } }, 
+          dapLaunchArgs: { 
+            type: 'object', 
+            properties: { 
+              stopOnEntry: { type: 'boolean' },
+              justMyCode: { type: 'boolean' } 
+            },
+            additionalProperties: true
+          },
+          dryRunSpawn: { type: 'boolean' },
+          breakOnExceptions: { type: 'string', enum: ['uncaught', 'all', 'none'], description: 'Break when exceptions are thrown: "uncaught" pauses at uncaught exceptions at the crash site instead of terminating the session; "all" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to "uncaught" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays "none"); pass "none" to opt out and let crashing scripts run to termination' },
+          adapterLaunchConfig: {
+            type: 'object',
+            description: 'Optional adapter-specific launch configuration overrides',
+            additionalProperties: true
+          }
+        },
+        required: ['sessionId', 'scriptPath']
+      }
+    },
+    { name: 'restart_debugging', description: 'Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'attach_to_process', description: 'Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down', inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string', description: 'Debug session ID' },
+          port: { type: 'number', description: 'Debug port to attach to' },
+          host: { type: 'string', description: 'Host to attach to (default: localhost)' },
+          processId: { type: ['number', 'string'], description: 'Process ID (for local attach, language-specific)' },
+          timeout: { type: 'number', description: 'Connection timeout in milliseconds (default: 30000)' },
+          verifyTimeout: { type: 'number', description: 'How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable' },
+          sourcePaths: { type: 'array', items: { type: 'string' }, description: 'Source paths for code mapping' },
+          stopOnEntry: { type: 'boolean', description: 'Stop on entry after attaching' },
+          justMyCode: { type: 'boolean', description: 'Only debug user code (skip library code)' },
+          breakOnExceptions: { type: 'string', enum: ['uncaught', 'all', 'none'], description: 'Break when exceptions are thrown: "uncaught" pauses at uncaught exceptions at the crash site; "all" also pauses on caught/raised exceptions (language-dependent). Default "none" — attach sessions never apply a language default (unlike launch)' },
+          adapterConfig: { type: 'object', description: 'Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like "settings set target.exec-search-paths /proc/<pid>/root"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)', additionalProperties: true }
+        },
+        required: ['sessionId']
+      }
+    },
+    { name: 'detach_from_process', description: 'Detach from the debugged process without terminating it', inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string', description: 'Debug session ID' },
+          terminateProcess: { type: 'boolean', description: 'Whether to terminate the process on detach (default: false)' }
+        },
+        required: ['sessionId']
+      }
+    },
+    { name: 'expose_session', description: 'Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as "mirrorToken" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'unexpose_session', description: 'Close a session\'s DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'close_debug_session', description: 'Close a debugging session', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'step_over', description: 'Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state "running" and pending:true — the session becomes "paused" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'step_into', description: 'Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state "running" and pending:true — the session becomes "paused" when the step completes', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'step_out', description: 'Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state "running" and pending:true — the session becomes "paused" when the step completes', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'continue_execution', description: 'Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes "paused" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. "breakpoint" vs "exception"). Use get_output to read the program\'s stdout/stderr', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'pause_execution', description: 'Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports "paused" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, threadId: { type: 'number', description: 'Thread ID to pause. If omitted or 0, pauses all threads.' } }, required: ['sessionId'] } },
+    { name: 'list_threads', description: 'List all threads in the debugged process', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] } },
+    { name: 'get_variables', description: 'Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, scope: { type: 'number', description: "The variablesReference number from a StackFrame or Variable" }, names: namesProp }, required: getVariablesRequired } },
+    { name: 'get_local_variables', description: 'Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeSpecial: { type: 'boolean', description: 'Include special/internal variables like this, __proto__, __builtins__, etc. Default: false' }, names: namesProp }, required: getLocalVariablesRequired } },
+    { name: 'get_stack_trace', description: 'Get stack trace. The response includes stopReason — why the session is paused (e.g. "breakpoint" vs "exception"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, includeInternals: { type: 'boolean', description: 'Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output.' }, threadId: { type: 'number', description: 'Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread' } }, required: ['sessionId'] } },
+    { name: 'get_scopes', description: 'Get scopes for a stack frame', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, frameId: { type: 'number', description: "The ID of the stack frame from a stackTrace response" } }, required: ['sessionId', 'frameId'] } },
+    { name: 'evaluate_expression', description: 'Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, expression: { type: 'string' }, frameId: { type: 'number', description: 'Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically' }, timeout: { type: 'number', description: 'Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout' } }, required: ['sessionId', 'expression'] } },
+    { name: 'get_source_context', description: 'Get source context around a specific line in a file', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, file: { type: 'string', description: fileDescription }, line: { type: 'number', description: 'Line number to get context for' }, linesContext: { type: 'number', description: 'Number of lines before and after to include (default: 5)' } }, required: ['sessionId', 'file', 'line'] } },
+    { name: 'get_output', description: 'Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, since: { type: 'number', description: 'Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer' }, limit: { type: 'number', description: 'Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available' } }, required: ['sessionId'] } },
+    { name: 'redefine_classes', description: 'Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.', inputSchema: { type: 'object', properties: { sessionId: { type: 'string' }, classesDir: { type: 'string', description: 'Absolute path to compiled classes directory (e.g. build/classes/java/main/)' }, sinceTimestamp: { type: 'number', description: 'Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files.' }, timeout: { type: 'number', description: 'Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once' } }, required: ['sessionId', 'classesDir'] } },
+  ];
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-assert.va-explicit.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-assert.va-explicit.json
@@ -1,0 +1,711 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound. Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope",
+            "names"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound. Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled."
+            }
+          },
+          "required": [
+            "sessionId",
+            "names"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-assert.va-open.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-assert.va-open.json
@@ -1,0 +1,709 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-assert.va-unset.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-assert.va-unset.json
@@ -1,0 +1,709 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-content.va-explicit.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-content.va-explicit.json
@@ -1,0 +1,721 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "statement": {
+              "type": "string",
+              "description": "Address by content instead of line number: the text of the target line, like an Edit-tool match — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored; an exact whole-line match always wins over substring matches). Preferred over line — it can only land on a line containing your text (an inexact or multi-candidate match adds a warning to the response) and survives file edits across restart_debugging. If the text appears on multiple lines, the error lists every match; add nearLine to pick one. Provide statement OR line, not both"
+            },
+            "nearLine": {
+              "type": "number",
+              "description": "With statement only: when the statement text appears on multiple lines, bind to the match closest to this line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Address by symbol name instead of file location: break on entry to this function/method (DAP function breakpoint). No file or line needed — names survive edits better than both. Composes with condition only. Supported by Python, Go, Rust, .NET, Java, and JavaScript adapters. JavaScript names are dotted runtime paths (e.g. \"handler\" or \"obj.method\") bound to the current function value: top-level function declarations of the main module bind at launch; functions in modules loaded later bind at the next pause"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound. Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope",
+            "names"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound. Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled."
+            }
+          },
+          "required": [
+            "sessionId",
+            "names"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-content.va-open.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-content.va-open.json
@@ -1,0 +1,719 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "statement": {
+              "type": "string",
+              "description": "Address by content instead of line number: the text of the target line, like an Edit-tool match — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored; an exact whole-line match always wins over substring matches). Preferred over line — it can only land on a line containing your text (an inexact or multi-candidate match adds a warning to the response) and survives file edits across restart_debugging. If the text appears on multiple lines, the error lists every match; add nearLine to pick one. Provide statement OR line, not both"
+            },
+            "nearLine": {
+              "type": "number",
+              "description": "With statement only: when the statement text appears on multiple lines, bind to the match closest to this line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Address by symbol name instead of file location: break on entry to this function/method (DAP function breakpoint). No file or line needed — names survive edits better than both. Composes with condition only. Supported by Python, Go, Rust, .NET, Java, and JavaScript adapters. JavaScript names are dotted runtime paths (e.g. \"handler\" or \"obj.method\") bound to the current function value: top-level function declarations of the main module bind at launch; functions in modules loaded later bind at the next pause"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-content.va-unset.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-content.va-unset.json
@@ -1,0 +1,719 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "statement": {
+              "type": "string",
+              "description": "Address by content instead of line number: the text of the target line, like an Edit-tool match — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored; an exact whole-line match always wins over substring matches). Preferred over line — it can only land on a line containing your text (an inexact or multi-candidate match adds a warning to the response) and survives file edits across restart_debugging. If the text appears on multiple lines, the error lists every match; add nearLine to pick one. Provide statement OR line, not both"
+            },
+            "nearLine": {
+              "type": "number",
+              "description": "With statement only: when the statement text appears on multiple lines, bind to the match closest to this line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Address by symbol name instead of file location: break on entry to this function/method (DAP function breakpoint). No file or line needed — names survive edits better than both. Composes with condition only. Supported by Python, Go, Rust, .NET, Java, and JavaScript adapters. JavaScript names are dotted runtime paths (e.g. \"handler\" or \"obj.method\") bound to the current function value: top-level function declarations of the main module bind at launch; functions in modules loaded later bind at the next pause"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-line.va-explicit.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-line.va-explicit.json
@@ -1,0 +1,707 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound. Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope",
+            "names"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound. Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled."
+            }
+          },
+          "required": [
+            "sessionId",
+            "names"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-line.va-open.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-line.va-open.json
@@ -1,0 +1,705 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-line.va-unset.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-line.va-unset.json
@@ -1,0 +1,705 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-unset.va-explicit.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-unset.va-explicit.json
@@ -1,0 +1,721 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "statement": {
+              "type": "string",
+              "description": "Address by content instead of line number: the text of the target line, like an Edit-tool match — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored; an exact whole-line match always wins over substring matches). Preferred over line — it can only land on a line containing your text (an inexact or multi-candidate match adds a warning to the response) and survives file edits across restart_debugging. If the text appears on multiple lines, the error lists every match; add nearLine to pick one. Provide statement OR line, not both"
+            },
+            "nearLine": {
+              "type": "number",
+              "description": "With statement only: when the statement text appears on multiple lines, bind to the match closest to this line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Address by symbol name instead of file location: break on entry to this function/method (DAP function breakpoint). No file or line needed — names survive edits better than both. Composes with condition only. Supported by Python, Go, Rust, .NET, Java, and JavaScript adapters. JavaScript names are dotted runtime paths (e.g. \"handler\" or \"obj.method\") bound to the current function value: top-level function declarations of the main module bind at launch; functions in modules loaded later bind at the next pause"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound. Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope",
+            "names"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound. Required: this server runs in least-privilege mode (DEBUG_MCP_VARIABLE_ACCESS=explicit) — unfiltered scope dumps are disabled."
+            }
+          },
+          "required": [
+            "sessionId",
+            "names"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-unset.va-open.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-unset.va-open.json
@@ -1,0 +1,719 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "statement": {
+              "type": "string",
+              "description": "Address by content instead of line number: the text of the target line, like an Edit-tool match — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored; an exact whole-line match always wins over substring matches). Preferred over line — it can only land on a line containing your text (an inexact or multi-candidate match adds a warning to the response) and survives file edits across restart_debugging. If the text appears on multiple lines, the error lists every match; add nearLine to pick one. Provide statement OR line, not both"
+            },
+            "nearLine": {
+              "type": "number",
+              "description": "With statement only: when the statement text appears on multiple lines, bind to the match closest to this line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Address by symbol name instead of file location: break on entry to this function/method (DAP function breakpoint). No file or line needed — names survive edits better than both. Composes with condition only. Supported by Python, Go, Rust, .NET, Java, and JavaScript adapters. JavaScript names are dotted runtime paths (e.g. \"handler\" or \"obj.method\") bound to the current function value: top-level function declarations of the main module bind at launch; functions in modules loaded later bind at the next pause"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/__snapshots__/tool-list/bp-unset.va-unset.json
+++ b/tests/core/unit/server/__snapshots__/tool-list/bp-unset.va-unset.json
@@ -1,0 +1,719 @@
+{
+  "tools": {
+    "tools": [
+      {
+        "name": "create_debug_session",
+        "description": "Create a new debugging session. Provide host and port to attach to a running process; omit them for launch mode",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": [
+                "python",
+                "mock"
+              ],
+              "description": "Programming language for debugging"
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional session name"
+            },
+            "executablePath": {
+              "type": "string",
+              "description": "Path to language executable (optional, will auto-detect if not provided)"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to for remote debugging (optional, triggers attach mode)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds for attach mode (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "Attach mode only: how long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Attach mode only: adapter-specific attach configuration merged into the attach config (see attach_to_process)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "language"
+          ]
+        }
+      },
+      {
+        "name": "list_supported_languages",
+        "description": "List all supported debugging languages with metadata",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "list_debug_sessions",
+        "description": "List all active debugging sessions. Paused sessions include lastStop with the reason for the most recent stop (e.g. \"breakpoint\" vs \"exception\")",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "set_breakpoint",
+        "description": "Set a breakpoint. Setting breakpoints on non-executable lines (structural, declarative) may lead to unexpected behavior",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file or Java FQCN. For Java, passing a fully-qualified class name (e.g. \"com.example.MyClass\" or \"com.example.Outer$Inner\") is preferred — it works reliably with all classloaders including custom classloaders. Alternatively, use absolute file paths."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number where to set breakpoint. Executable statements (assignments, function calls, conditionals, returns) work best. Structural lines (function/class definitions), declarative lines (imports), or non-executable lines (comments, blank lines) may cause unexpected stepping behavior"
+            },
+            "expectedContent": {
+              "type": "string",
+              "description": "Optional assertion: text you expect on the target line — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored). If it does not match, the breakpoint is NOT set and the error shows the actual content of that line and its neighbors — use this to catch stale or off-by-one line numbers before they cause confusing behavior"
+            },
+            "statement": {
+              "type": "string",
+              "description": "Address by content instead of line number: the text of the target line, like an Edit-tool match — a distinctive substring is enough (leading/trailing whitespace and trailing //- or #-comments are ignored; an exact whole-line match always wins over substring matches). Preferred over line — it can only land on a line containing your text (an inexact or multi-candidate match adds a warning to the response) and survives file edits across restart_debugging. If the text appears on multiple lines, the error lists every match; add nearLine to pick one. Provide statement OR line, not both"
+            },
+            "nearLine": {
+              "type": "number",
+              "description": "With statement only: when the statement text appears on multiple lines, bind to the match closest to this line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Address by symbol name instead of file location: break on entry to this function/method (DAP function breakpoint). No file or line needed — names survive edits better than both. Composes with condition only. Supported by Python, Go, Rust, .NET, Java, and JavaScript adapters. JavaScript names are dotted runtime paths (e.g. \"handler\" or \"obj.method\") bound to the current function value: top-level function declarations of the main module bind at launch; functions in modules loaded later bind at the next pause"
+            },
+            "condition": {
+              "type": "string",
+              "description": "Optional expression: only break (or log) when it evaluates truthy"
+            },
+            "logMessage": {
+              "type": "string",
+              "description": "Create a logpoint: instead of pausing, log this message when the line is hit. Expressions in {curly braces} are interpolated (e.g. \"order={orderId} total={total}\"). Messages arrive in get_output while the program runs at full speed. Supported by the Python, JavaScript, Go, Rust, and mock adapters; not by Java, .NET, or Ruby"
+            },
+            "suspendPolicy": {
+              "type": "string",
+              "enum": [
+                "all",
+                "thread"
+              ],
+              "description": "Suspend policy when breakpoint is hit: \"all\" suspends all threads (default), \"thread\" only suspends the event thread. Only supported by the Java/JDI adapter."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_breakpoints",
+        "description": "List all breakpoints in a session with their verified state and adapter-assigned ids. Session-global function breakpoints appear separately as functionBreakpoints (omitted when filtering by file). Works before launch (queued, verified=false), while running or paused, and after the program exits",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only list breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "remove_breakpoint",
+        "description": "Remove a breakpoint by breakpointId (returned by set_breakpoint / list_breakpoints), by function name, or by file + line (removes all breakpoints at that location). Takes effect immediately while the program is running or paused; also works after the program exits, before a relaunch",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "breakpointId": {
+              "type": "string",
+              "description": "Breakpoint id from set_breakpoint or list_breakpoints. Takes precedence over file + line"
+            },
+            "function": {
+              "type": "string",
+              "description": "Alternative addressing: remove all function breakpoints with this symbol name. Applies the same per-language rewrite as set_breakpoint (e.g. a bare Go \"main\" matches the stored \"main.main\"); the response reports the effective name as functionName and, when rewritten, the original as requestedName"
+            },
+            "file": {
+              "type": "string",
+              "description": "Alternative addressing: source file path (use together with line)"
+            },
+            "line": {
+              "type": "number",
+              "description": "Alternative addressing: line number (use together with file)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "clear_breakpoints",
+        "description": "Remove all breakpoints in a session, or all breakpoints in one file. Clearing zero breakpoints is success. Takes effect immediately while the program is running or paused",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Optional: only clear breakpoints in this file"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "start_debugging",
+        "description": "Start debugging a script",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scriptPath": {
+              "type": "string",
+              "description": "Path to the script to debug. Use absolute paths or paths relative to your current working directory"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dapLaunchArgs": {
+              "type": "object",
+              "properties": {
+                "stopOnEntry": {
+                  "type": "boolean"
+                },
+                "justMyCode": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            },
+            "dryRunSpawn": {
+              "type": "boolean"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site instead of terminating the session; \"all\" also pauses on caught/raised exceptions (language-dependent). Launch sessions default to \"uncaught\" (Ruby is the exception — rdbg has no uncaught-only filter, so it stays \"none\"); pass \"none\" to opt out and let crashing scripts run to termination"
+            },
+            "adapterLaunchConfig": {
+              "type": "object",
+              "description": "Optional adapter-specific launch configuration overrides",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId",
+            "scriptPath"
+          ]
+        }
+      },
+      {
+        "name": "restart_debugging",
+        "description": "Restart the debuggee: terminate the current program (if still running) and relaunch it with the same configuration as the last start_debugging. All current breakpoints are re-applied automatically. The get_output buffer starts fresh — read from since=0 after a restart. Works while running, paused, or after the program has exited. Not available for attach sessions or sessions never launched",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "attach_to_process",
+        "description": "Attach to a running process for debugging. After the attach handshake the target is verified by polling for threads; if none are reported within verifyTimeout (~20s default) the attach fails and the debug proxy is torn down",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "port": {
+              "type": "number",
+              "description": "Debug port to attach to"
+            },
+            "host": {
+              "type": "string",
+              "description": "Host to attach to (default: localhost)"
+            },
+            "processId": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Process ID (for local attach, language-specific)"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Connection timeout in milliseconds (default: 30000)"
+            },
+            "verifyTimeout": {
+              "type": "number",
+              "description": "How long to wait (ms) for the debugger to report at least one thread after attaching before failing the attach (default: 20000, max: 600000). Decrease for fast failure-by-design probes; increase for targets that are exceptionally slow to become debuggable"
+            },
+            "sourcePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source paths for code mapping"
+            },
+            "stopOnEntry": {
+              "type": "boolean",
+              "description": "Stop on entry after attaching"
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Only debug user code (skip library code)"
+            },
+            "breakOnExceptions": {
+              "type": "string",
+              "enum": [
+                "uncaught",
+                "all",
+                "none"
+              ],
+              "description": "Break when exceptions are thrown: \"uncaught\" pauses at uncaught exceptions at the crash site; \"all\" also pauses on caught/raised exceptions (language-dependent). Default \"none\" — attach sessions never apply a language default (unlike launch)"
+            },
+            "adapterConfig": {
+              "type": "object",
+              "description": "Adapter-specific attach configuration merged into the attach config before the adapter transforms it (e.g. C/C++/LLDB: program — the binary path for symbol resolution when /proc/<pid>/maps paths are not openable, as in a kubectl-debug ephemeral container — or initCommands like \"settings set target.exec-search-paths /proc/<pid>/root\"). Reserved keys request/__attachMode are ignored; set stopOnEntry via the top-level parameter. Keys the adapter does not recognize are still forwarded to the debugger and named in the response warning — a near-miss of a supported key gets a did-you-mean suggestion. js-debug pins its attach orchestration keys (address/port/continueOnAttach/attachExistingChildren) over caller values; its autoAttachChildProcesses defaults to false on attach — child processes the target forks run undebugged (set it true to auto-attach children; only one child can be adopted at a time, further children are resumed undebugged)",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "detach_from_process",
+        "description": "Detach from the debugged process without terminating it",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string",
+              "description": "Debug session ID"
+            },
+            "terminateProcess": {
+              "type": "boolean",
+              "description": "Whether to terminate the process on detach (default: false)"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "expose_session",
+        "description": "Expose a debug session as a read-only DAP mirror endpoint on 127.0.0.1 so an IDE (e.g. VS Code) can attach as a second debug client and inspect live state: threads, stack, scopes, variables, evaluate. Returns host, port, and a session token the IDE must include as \"mirrorToken\" in its attach configuration. The mirror never drives execution — continue/step/pause and breakpoint changes are rejected; control stays with this MCP session. Requires an active session (launched or attached); works while running or paused. Calling it again returns the same endpoint. The endpoint closes on unexpose_session, close_debug_session, restart, or debuggee exit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "unexpose_session",
+        "description": "Close a session's DAP mirror endpoint and disconnect any attached IDE clients. Succeeds as a no-op if the session is not exposed",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "close_debug_session",
+        "description": "Close a debugging session",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_over",
+        "description": "Step over the current line. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. stepping over a long-running call), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes (check list_debug_sessions, or call pause_execution to interrupt)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_into",
+        "description": "Step into the current call. Waits briefly for the program to stop; if the step is still executing after ~5s, returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "step_out",
+        "description": "Step out of the current function. Waits briefly for the program to stop; if the step is still executing after ~5s (e.g. the rest of the function is long-running), returns success with state \"running\" and pending:true — the session becomes \"paused\" when the step completes",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "continue_execution",
+        "description": "Continue execution. Returns immediately after the adapter acknowledges; does not wait for the next stop. When the program stops again the session state becomes \"paused\" — check list_debug_sessions or get_stack_trace, whose lastStop/stopReason tells you why it stopped (e.g. \"breakpoint\" vs \"exception\"). Use get_output to read the program's stdout/stderr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "pause_execution",
+        "description": "Pause a running program. Waits briefly for the stop; if the program cannot stop within ~5s (e.g. blocked in native code, or an idle server waiting for input), returns success with pending:true and the session reports \"paused\" the next time the program runs code. Fails with an actionable error if the session has no debuggable target to pause (e.g. a js attach whose target session was never adopted or has ended)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Thread ID to pause. If omitted or 0, pauses all threads."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "list_threads",
+        "description": "List all threads in the debugged process",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_variables",
+        "description": "Get variables (scope is variablesReference: number). Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "number",
+              "description": "The variablesReference number from a StackFrame or Variable"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId",
+            "scope"
+          ]
+        }
+      },
+      {
+        "name": "get_local_variables",
+        "description": "Get local variables for the current stack frame. This is a convenience tool that returns just the local variables without needing to traverse stack->scopes->variables manually. Responses are size-guarded: oversized values are cut (truncated:true) and very large scopes return a capped list with a truncation notice — pass names:[...] to fetch specific variables in full",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeSpecial": {
+              "type": "boolean",
+              "description": "Include special/internal variables like this, __proto__, __builtins__, etc. Default: false"
+            },
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Only return variables with these exact names (case-sensitive). Requested names missing from the scope are listed in the response's notFound."
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_stack_trace",
+        "description": "Get stack trace. The response includes stopReason — why the session is paused (e.g. \"breakpoint\" vs \"exception\"). Internal/runtime frames are filtered by default; when any are hidden the response carries hiddenFrames and a note (the top frame is always kept even if internal, so frameId anchors keep working)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "includeInternals": {
+              "type": "boolean",
+              "description": "Include internal/framework frames (e.g., Node.js internals). Default: false for cleaner output."
+            },
+            "threadId": {
+              "type": "number",
+              "description": "Inspect a specific thread (ids from list_threads). When that thread reports frames it becomes the anchor for follow-up scopes/locals/evaluate calls — the escape hatch when the session is anchored to a frameless thread"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "get_scopes",
+        "description": "Get scopes for a stack frame",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "The ID of the stack frame from a stackTrace response"
+            }
+          },
+          "required": [
+            "sessionId",
+            "frameId"
+          ]
+        }
+      },
+      {
+        "name": "evaluate_expression",
+        "description": "Evaluate expression in the current debug context. Expressions can read and modify program state. Waits up to 30s for the result by default; pass timeout for long-running expressions",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "frameId": {
+              "type": "number",
+              "description": "Optional stack frame ID for evaluation context. Must be a frame ID from a get_stack_trace response. If not provided, uses the current (top) frame automatically"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the evaluation to complete (default: 30000, max: 600000). On expiry the request fails but the expression may keep executing in the debuggee. Note: your MCP client may enforce its own overall request timeout"
+            }
+          },
+          "required": [
+            "sessionId",
+            "expression"
+          ]
+        }
+      },
+      {
+        "name": "get_source_context",
+        "description": "Get source context around a specific line in a file",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "file": {
+              "type": "string",
+              "description": "Path to the source file. Use absolute paths or paths relative to your current working directory"
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to get context for"
+            },
+            "linesContext": {
+              "type": "number",
+              "description": "Number of lines before and after to include (default: 5)"
+            }
+          },
+          "required": [
+            "sessionId",
+            "file",
+            "line"
+          ]
+        }
+      },
+      {
+        "name": "get_output",
+        "description": "Get debuggee output (stdout/stderr/console) captured for a session. Buffered per launch (last 1000 entries; adapter telemetry and known adapter-internal diagnostics — e.g. LLDB DWARF-parser noise — filtered out). Works while the program is running and after it finishes, until the session is closed. Pass since=nextSince from the previous response to fetch only new output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "since": {
+              "type": "number",
+              "description": "Only return entries with seq greater than this cursor (use nextSince from the previous response). Default: 0 = from the start of the buffer"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Maximum entries to return (default: 100, max: 1000). hasMore:true in the response means more entries are available"
+            }
+          },
+          "required": [
+            "sessionId"
+          ]
+        }
+      },
+      {
+        "name": "redefine_classes",
+        "description": "Hot-swap changed Java classes into a running JVM. Scans a classes directory for .class files modified after sinceTimestamp, matches them against loaded classes in the target JVM, and redefines them using JDI. Returns which classes were redefined and the newest file timestamp (pass as sinceTimestamp on next call for incremental updates). Statement-anchored breakpoints are re-resolved against the new source after the swap (anchorResolution reports moved/stale). Only works with Java debug sessions.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionId": {
+              "type": "string"
+            },
+            "classesDir": {
+              "type": "string",
+              "description": "Absolute path to compiled classes directory (e.g. build/classes/java/main/)"
+            },
+            "sinceTimestamp": {
+              "type": "number",
+              "description": "Unix timestamp (ms). Only redefine .class files modified after this time. 0 or omitted = all files."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Max time (ms) to wait for the redefinition to complete (default: 30000, max: 600000). Increase when hot-swapping many classes at once"
+            }
+          },
+          "required": [
+            "sessionId",
+            "classesDir"
+          ]
+        }
+      }
+    ]
+  },
+  "resources": {
+    "resources": [
+      {
+        "uri": "debug://sessions/sess-1/output",
+        "name": "Debuggee output — alpha",
+        "description": "stdout/stderr/console output captured for python debug session 'alpha'",
+        "mimeType": "text/plain"
+      },
+      {
+        "uri": "debug://sessions/sess-2/output",
+        "name": "Debuggee output — beta",
+        "description": "stdout/stderr/console output captured for mock debug session 'beta'",
+        "mimeType": "text/plain"
+      }
+    ]
+  },
+  "prompts": {
+    "prompts": [
+      {
+        "name": "debugging-workflow",
+        "description": "How to debug effectively with mcp-debugger: session golden path, root-cause discipline, attach/remote recipes, and per-language quirks."
+      }
+    ]
+  }
+}

--- a/tests/core/unit/server/dynamic-tool-documentation.test.ts
+++ b/tests/core/unit/server/dynamic-tool-documentation.test.ts
@@ -55,6 +55,7 @@ vi.mock('../../../../src/session/session-manager.js', () => ({
 
 // Import the schema we need to check against
 import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { registerToolHandlers } from '../../../../src/server/tool-dispatch.js';
 
 // Helper function to extract tools from server
 async function getToolsFromServer(server: DebugMcpServer): Promise<Array<{
@@ -66,8 +67,8 @@ async function getToolsFromServer(server: DebugMcpServer): Promise<Array<{
     required?: string[];
   };
 }>> {
-  // The server has a private registerTools method that sets up handlers
-  // We need to capture what it registers
+  // Tool registration lives in src/server/tool-dispatch.ts; re-run it against
+  // the live server to capture the tools/list handler it registers
   let capturedHandler: unknown = null;
   
   // Spy on setRequestHandler
@@ -83,7 +84,7 @@ async function getToolsFromServer(server: DebugMcpServer): Promise<Array<{
   );
   
   // Re-register tools to capture them
-  (server as unknown as { registerTools(): void }).registerTools();
+  registerToolHandlers(server.server, server);
   
   // Check if we captured the handler
   if (!capturedHandler) {

--- a/tests/core/unit/server/server-test-helpers.ts
+++ b/tests/core/unit/server/server-test-helpers.ts
@@ -2,6 +2,16 @@
  * Shared test helpers and mock setup for server tests
  */
 import { vi } from 'vitest';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema
+} from '@modelcontextprotocol/sdk/types.js';
 import { createMockLogger } from '../../../test-utils/helpers/test-dependencies.js';
 import { createMockAdapterRegistry } from '../../../test-utils/mocks/mock-adapter-registry.js';
 
@@ -141,30 +151,39 @@ export function createMockStdioTransport() {
   return {};
 }
 
+/**
+ * Find the handler registered for a request schema. Lookup is by schema
+ * identity rather than registration position, so the registration order in
+ * src/server.ts (tools, resources, prompts) is not a hidden test contract;
+ * @modelcontextprotocol/sdk/types.js is never mocked, so the identity is safe.
+ */
+function findHandler(mockServer: any, schema: unknown) {
+  const call = mockServer.setRequestHandler.mock.calls.find(
+    ([registered]: [unknown, unknown]) => registered === schema
+  );
+  return call?.[1];
+}
+
 export function getToolHandlers(mockServer: any) {
-  const handlers = mockServer.setRequestHandler.mock.calls;
   return {
-    listToolsHandler: handlers[0]?.[1], // First handler is for ListToolsRequestSchema
-    callToolHandler: handlers[1]?.[1]   // Second handler is for CallToolRequestSchema
+    listToolsHandler: findHandler(mockServer, ListToolsRequestSchema),
+    callToolHandler: findHandler(mockServer, CallToolRequestSchema)
   };
 }
 
-// Resource handlers are registered by registerResources() right after the two
-// tool handlers, in this order (issue #218).
+// Debuggee-output resource handlers (issue #218).
 export function getResourceHandlers(mockServer: any) {
-  const handlers = mockServer.setRequestHandler.mock.calls;
   return {
-    listResourcesHandler: handlers[2]?.[1],
-    readResourceHandler: handlers[3]?.[1],
-    subscribeHandler: handlers[4]?.[1],
-    unsubscribeHandler: handlers[5]?.[1]
+    listResourcesHandler: findHandler(mockServer, ListResourcesRequestSchema),
+    readResourceHandler: findHandler(mockServer, ReadResourceRequestSchema),
+    subscribeHandler: findHandler(mockServer, SubscribeRequestSchema),
+    unsubscribeHandler: findHandler(mockServer, UnsubscribeRequestSchema)
   };
 }
 
 export function getPromptHandlers(mockServer: any) {
-  const handlers = mockServer.setRequestHandler.mock.calls;
   return {
-    listPromptsHandler: handlers[6]?.[1],
-    getPromptHandler: handlers[7]?.[1]
+    listPromptsHandler: findHandler(mockServer, ListPromptsRequestSchema),
+    getPromptHandler: findHandler(mockServer, GetPromptRequestSchema)
   };
 }

--- a/tests/core/unit/server/server-tool-list-snapshot.test.ts
+++ b/tests/core/unit/server/server-tool-list-snapshot.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tool-schema snapshot fence for the src/server.ts extraction.
+ *
+ * Pins the exact tools/list, resources/list and prompts/list payloads for
+ * every DEBUG_MCP_BP_ADDRESSING x DEBUG_MCP_VARIABLE_ACCESS combination the
+ * server accepts (see src/utils/bp-addressing.ts and
+ * src/utils/variable-access.ts). The snapshots were recorded from the
+ * pre-split server.ts and must stay byte-identical through every commit that
+ * moves code into src/server/ — a diff here means a description, key order,
+ * or gating rule drifted.
+ *
+ * Environment is stubbed with vi.stubEnv the way the gating tests do: the
+ * mock environment from createMockDependencies reads process.env live.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { DebugMcpServer } from '../../../../src/server.js';
+import { SessionManager } from '../../../../src/session/session-manager.js';
+import { createProductionDependencies } from '../../../../src/container/dependencies.js';
+import {
+  createMockDependencies,
+  createMockServer,
+  createMockSessionManager,
+  createMockStdioTransport,
+  getToolHandlers,
+  getResourceHandlers,
+  getPromptHandlers
+} from './server-test-helpers.js';
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js');
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js');
+vi.mock('../../../../src/session/session-manager.js');
+vi.mock('../../../../src/container/dependencies.js');
+
+/** Every value getBpAddressingMode() accepts, plus unset (falls back to 'content'). */
+const BP_ADDRESSING_MODES: ReadonlyArray<string | undefined> = [undefined, 'line', 'assert', 'content'];
+
+/** Every value getVariableAccessMode() accepts, plus unset (falls back to 'open'). */
+const VARIABLE_ACCESS_MODES: ReadonlyArray<string | undefined> = [undefined, 'open', 'explicit'];
+
+/** Fixed session fixture so the resource descriptors are deterministic. */
+const SESSION_FIXTURE = [
+  { id: 'sess-1', name: 'alpha', language: 'python' },
+  { id: 'sess-2', name: 'beta', language: 'mock' }
+];
+
+function label(value: string | undefined): string {
+  return value ?? 'unset';
+}
+
+describe('Server tool/resource/prompt list snapshot fence', () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+
+  beforeEach(() => {
+    const mockDependencies = createMockDependencies();
+    vi.mocked(createProductionDependencies).mockReturnValue(mockDependencies as never);
+
+    mockServer = createMockServer();
+    vi.mocked(Server).mockImplementation(function () { return mockServer as never; });
+    vi.mocked(StdioServerTransport).mockImplementation(function () { return createMockStdioTransport() as never; });
+
+    const mockSessionManager = createMockSessionManager(mockDependencies.adapterRegistry);
+    mockSessionManager.getAllSessions.mockReturnValue(SESSION_FIXTURE);
+    vi.mocked(SessionManager).mockImplementation(function () { return mockSessionManager as never; });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  for (const bpMode of BP_ADDRESSING_MODES) {
+    for (const vaMode of VARIABLE_ACCESS_MODES) {
+      it(`DEBUG_MCP_BP_ADDRESSING=${label(bpMode)} DEBUG_MCP_VARIABLE_ACCESS=${label(vaMode)}`, async () => {
+        vi.stubEnv('DEBUG_MCP_BP_ADDRESSING', bpMode);
+        vi.stubEnv('DEBUG_MCP_VARIABLE_ACCESS', vaMode);
+        vi.stubEnv('MCP_CONTAINER', undefined);
+
+        new DebugMcpServer();
+        const { listToolsHandler } = getToolHandlers(mockServer);
+        const { listResourcesHandler } = getResourceHandlers(mockServer);
+        const { listPromptsHandler } = getPromptHandlers(mockServer);
+
+        const tools = await listToolsHandler({ method: 'tools/list', params: {} });
+        const resources = await listResourcesHandler({ method: 'resources/list', params: {} });
+        const prompts = await listPromptsHandler({ method: 'prompts/list', params: {} });
+
+        const snapshot = JSON.stringify({ tools, resources, prompts }, null, 2) + '\n';
+        await expect(snapshot).toMatchFileSnapshot(
+          `./__snapshots__/tool-list/bp-${label(bpMode)}.va-${label(vaMode)}.json`
+        );
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Pure refactor, zero behavior change (`no-changelog`). Fourth PR of the structural-refactor series (after #563, #564, #565).

`src/server.ts` was 3027 lines, 1198 of them one `registerTools()` method whose `CallTool` handler was a single 1,064-line `switch` — the churn epicenter of the repo (90 commits in the last 250). This PR moves it, mechanically, into `src/server/`:

```
src/server.ts                       DebugMcpServer — composition root (907 lines): constructor, start/stop, the public
                                    facade methods, `implements ToolContext`
src/server/tool-arguments.ts        ToolArguments, coerceToolArguments (re-exported from src/server.ts)
src/server/tool-result.ts           ToolResult + envelope helpers
src/server/tool-schemas.ts          the 28 tool definitions (pure)
src/server/tool-context.ts          ToolContext + ToolHandler
src/server/tool-dispatch.ts         ListTools + CallTool wrappers (logging verbatim; unknown tool still logs tool:error)
src/server/language-discovery.ts    discovery + metadata
src/server/output-resources.ts      OutputResourceNotifier + resource handlers
src/server/prompts.ts
src/server/handlers/*-tools.ts      session / debuggee / breakpoint / execution / inspection / output / mirror / language
src/server/handlers/index.ts        TOOL_HANDLERS
```

**How "zero behavior change" is enforced, not asserted:**
- Commit 1 adds a **snapshot fence** over the tool, resource and prompt lists for every `DEBUG_MCP_BP_ADDRESSING` × `DEBUG_MCP_VARIABLE_ACCESS` mode (12 snapshots, `JSON.stringify(…, null, 2)` so key *order* is pinned), generated from the unchanged code; it stays byte-identical through all 14 refactor commits.
- Handler bodies move with `this.` → `ctx.` and `result = X; break;` → `return X;` and nothing else. The review's independent string-literal set comparison across the old file and all new modules found exactly one difference: an import specifier. Every `McpError`, log key, JSON key and message survives at identical counts — including the duplication that PR 6 will remove (three `sessionId` message variants, two catch dialects, ten copies of the typed-error block). No dedupe here.
- Handlers read every dependency live through `ctx` (`=== this`) at call time — the existing coverage tests that monkey-patch `sessionManager`/`logger`/`fileChecker`/`lineReader`/`validateSession` after construction keep working; seven `handleX` private delegates stay on the class as test seams (removed in PR 6).
- `tests/core/unit/server/server-test-helpers.ts` looks handlers up by schema identity instead of `setRequestHandler.mock.calls[i]` position.

Nothing under `src/session`, `src/proxy`, `src/adapters` changes. `src/server.ts` ≤ 907 lines; the largest handler module is 420.

## Test plan

- [x] Snapshot fence byte-identical: `git diff --stat <fence-commit>..HEAD -- tests/core/unit/server/__snapshots__` empty
- [x] `pnpm run typecheck` 0; `pnpm run typecheck:all` exit 0 (baseline unchanged 751/92); `npm run lint`
- [x] `npx vitest run tests/core/unit/server tests/unit/server-coverage.test.ts` 25 files / 374 tests; `--project unit` green; `tests/unit/index.test.ts tests/unit/cli` 184/184
- [x] `npm run build` incl. bundle; `dist/server/**/*.js` present
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eq9fRrPuacc6ScMEkEGX9T
