### PR TITLE
refactor(session): OperationsContext + leaf collaborators (breakpoints, execution, evaluate, jvm, mirror)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,14 @@ The codebase follows a **layered architecture with dependency injection** and **
    - Central orchestrator for debug sessions, implemented as a 4-class inheritance hierarchy:
      - `SessionManagerCore` (`session-manager-core.ts`): Lifecycle, state management, event handling, dependency wiring
      - `SessionManagerData` (`session-manager-data.ts`): Data retrieval (variables, stack traces, scopes) and adapter policy selection via `selectPolicy()`
-     - `SessionManagerOperations` (`session-manager-operations.ts`): Debug operations (start, step, continue, breakpoints, attach/detach)
+     - `SessionManagerOperations` (`session-manager-operations.ts`): Debug operations. Launch and attach (`startProxyManager`, `startDebugging`, `restartDebugging`, `attachToProcess`, `detachFromProcess`) live here; everything else is a one-line delegate to a collaborator
      - `SessionManager` (`session-manager.ts`): Final composition class that extends SessionManagerOperations. Implements `handleAutoContinue(sessionId)` which auto-continues past entry breakpoints when `stopOnEntry=false`
+   - `SessionManagerOperations` is itself a facade over per-slice collaborators, wired as protected fields and always reached at call time (`this.breakpoints.…`):
+     - `breakpoints/breakpoint-controller.ts` (`BreakpointController`): set/remove/clear plus the replace-all DAP re-sends
+     - `breakpoints/anchor-resolution.ts` (`reresolveAnchors`) and `breakpoints/launch-warnings.ts` (pure warning builders)
+     - `execution/execution-controller.ts` (`ExecutionController`): stepping (table-driven over `STEP_KINDS`), continue, pause, thread list
+     - `inspection/expression-evaluator.ts` (`ExpressionEvaluator`), `jvm/redefine-classes-controller.ts` (`RedefineClassesController`), `mirror/mirror-controller.ts` (`MirrorController`)
+   - Collaborators see the facade through `OperationsContext` (`operations-context.ts`), whose members are late-bound arrows and getters — never captured references — so reassigning a facade method or writing a tunable on a live instance is visible to them; each takes the narrowest `Pick<>` slice it uses. Shared per-request DAP helpers live in `dap-request-helpers.ts`
    - Coordinates ProxyManager instances (one per session)
    - Handles breakpoint management and queuing
 

--- a/docs/architecture/component-design.md
+++ b/docs/architecture/component-design.md
@@ -10,10 +10,32 @@ This document provides detailed design information for the major components of t
 |-------|------|----------------|
 | `SessionManagerCore` | `src/session/session-manager-core.ts` | Lifecycle, state management, event handler setup/cleanup, dependency injection |
 | `SessionManagerData` | `src/session/session-manager-data.ts` | Data retrieval: variables, stack traces, scopes, local variables; `selectPolicy()` |
-| `SessionManagerOperations` | `src/session/session-manager-operations.ts` | Debug operations: start, step, continue, pause, breakpoints, attach/detach, evaluate |
+| `SessionManagerOperations` | `src/session/session-manager-operations.ts` | Debug operations. Launch and attach live here; the rest are one-line delegates to the collaborators below |
 | `SessionManager` | `src/session/session-manager.ts` | Thin facade that extends `SessionManagerOperations` and implements `handleAutoContinue` |
 
 The inheritance chain is: `SessionManagerCore` -> `SessionManagerData` -> `SessionManagerOperations` -> `SessionManager`.
+
+`SessionManagerOperations` is itself a facade over per-slice collaborators, wired
+as protected fields and reached at call time (`this.breakpoints.…`) so each one
+can be spied on or replaced:
+
+| Collaborator | File | Responsibility |
+|-------|------|----------------|
+| `BreakpointController` | `src/session/breakpoints/breakpoint-controller.ts` | Set/remove/clear breakpoints; the replace-all DAP re-sends and the live-sync warning |
+| `reresolveAnchors` | `src/session/breakpoints/anchor-resolution.ts` | Re-resolve statement anchors against the current source (restart and JVM hot swap) |
+| launch warnings | `src/session/breakpoints/launch-warnings.ts` | Pure builders: unbound-at-exit, logpoint downgrade, unbound function breakpoints |
+| `ExecutionController` | `src/session/execution/execution-controller.ts` | Stepping (table-driven over `STEP_KINDS`), continue, pause, thread list |
+| `ExpressionEvaluator` | `src/session/inspection/expression-evaluator.ts` | `evaluate_expression`, including frame resolution and secret redaction |
+| `RedefineClassesController` | `src/session/jvm/redefine-classes-controller.ts` | JVM hot swap plus the post-swap anchor re-resolution and breakpoint re-send |
+| `MirrorController` | `src/session/mirror/mirror-controller.ts` | `expose_session` / `unexpose_session` |
+
+They see the facade through `OperationsContext`
+(`src/session/operations-context.ts`), whose members are late-bound arrows and
+getters — never captured references — so reassigning a facade method or writing
+a tunable on a live instance is visible to the collaborators. Each collaborator's
+constructor takes the narrowest `Pick<>` slice of that context it uses.
+Shared per-request DAP helpers (timeout override validation, the timeout hint,
+log truncation) live in `src/session/dap-request-helpers.ts`.
 
 ### Overview
 SessionManager is the central orchestrator for all debug sessions. It implements a facade pattern, providing a simplified interface for complex debugging operations while managing the lifecycle of ProxyManager instances.

--- a/src/session/breakpoints/anchor-resolution.ts
+++ b/src/session/breakpoints/anchor-resolution.ts
@@ -1,0 +1,135 @@
+/**
+ * Statement-anchor re-resolution (issue #271).
+ *
+ * A content-addressed breakpoint remembers the statement it was set on, not
+ * just a line. Whenever the file underneath it may have changed — a restart
+ * replaying the launch, or a JVM hot swap (issue #464) — the anchors are
+ * re-resolved against what is on disk now, so the breakpoint follows the code
+ * instead of the line number.
+ *
+ * A free function rather than a method because both callers live in different
+ * collaborators and it needs nothing but a filesystem and a logger.
+ */
+import { resolveStatement } from '../../utils/breakpoint-resolver.js';
+import type { Breakpoint } from '@debugmcp/shared';
+import type { ManagedSession } from '../session-store.js';
+import type { AnchorContext } from '../operations-context.js';
+
+/** An anchor that re-resolved to a different line than the breakpoint held. */
+export interface AnchorMove {
+  breakpointId: string;
+  file: string;
+  from: number;
+  to: number;
+  statement: string;
+  candidates?: number[];
+}
+
+/** An anchor that no longer matches; the breakpoint keeps its stale line. */
+export interface AnchorStale {
+  breakpointId: string;
+  file: string;
+  line: number;
+  statement: string;
+  reason: string;
+}
+
+export interface AnchorResolution {
+  moved: AnchorMove[];
+  stale: AnchorStale[];
+}
+
+/**
+ * Re-resolve statement-anchored breakpoints against the current file
+ * contents (fresh read — deliberately not the server's LineReader cache).
+ * The breakpoint's current line doubles as the nearLine hint so duplicate
+ * statements re-anchor to the nearest occurrence of where the breakpoint
+ * last was. Anchors that no longer match keep their stale line and warn:
+ * failing the restart would block the edit-relaunch loop, and dropping the
+ * breakpoint would destroy user state (issue #271).
+ *
+ * Returns undefined when the session has no anchored breakpoints at all.
+ */
+export async function reresolveAnchors(
+  session: Pick<ManagedSession, 'breakpoints'>,
+  ctx: AnchorContext
+): Promise<AnchorResolution | undefined> {
+  const anchored = Array.from(session.breakpoints.values()).filter(
+    (bp): bp is Breakpoint & { anchor: { statement: string; nearLine?: number } } => bp.anchor !== undefined
+  );
+  if (anchored.length === 0) {
+    return undefined;
+  }
+
+  const moved: AnchorMove[] = [];
+  const stale: AnchorStale[] = [];
+
+  const byFile = new Map<string, typeof anchored>();
+  for (const bp of anchored) {
+    const group = byFile.get(bp.file);
+    if (group) {
+      group.push(bp);
+    } else {
+      byFile.set(bp.file, [bp]);
+    }
+  }
+
+  for (const [file, bps] of byFile) {
+    let lines: string[] | null = null;
+    try {
+      const content = await ctx.fileSystem.readFile(file, 'utf8');
+      lines = content.split(/\r?\n/);
+    } catch (error) {
+      ctx.logger.warn(
+        `[SessionManager] Could not re-read ${file} for anchor re-resolution: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+
+    for (const bp of bps) {
+      if (!lines) {
+        stale.push({
+          breakpointId: bp.id,
+          file,
+          line: bp.line,
+          statement: bp.anchor.statement,
+          reason: 'file unreadable',
+        });
+        continue;
+      }
+      const resolution = resolveStatement(lines, bp.anchor.statement, file, bp.line);
+      if (resolution.ok) {
+        if (resolution.line !== bp.line) {
+          moved.push({
+            breakpointId: bp.id,
+            file,
+            from: bp.line,
+            to: resolution.line,
+            statement: bp.anchor.statement,
+            // The bp's old line doubles as nearLine here, so the ambiguity
+            // error can never fire on this path — a multi-match proximity
+            // pick must be flagged instead of passing as unambiguous
+            // (issue #379).
+            ...(resolution.candidates !== undefined ? { candidates: resolution.candidates } : {}),
+          });
+          ctx.logger.info(
+            `[SessionManager] Anchor re-resolved: breakpoint ${bp.id} moved ${bp.line} -> ${resolution.line} ("${bp.anchor.statement}")`
+          );
+          bp.line = resolution.line;
+          bp.requestedLine = resolution.line;
+        }
+      } else {
+        stale.push({
+          breakpointId: bp.id,
+          file,
+          line: bp.line,
+          statement: bp.anchor.statement,
+          reason: 'statement not found',
+        });
+      }
+    }
+  }
+
+  return { moved, stale };
+}

--- a/src/session/breakpoints/anchor-resolution.ts
+++ b/src/session/breakpoints/anchor-resolution.ts
@@ -10,6 +10,7 @@
  * A free function rather than a method because both callers live in different
  * collaborators and it needs nothing but a filesystem and a logger.
  */
+import { getErrorMessage } from '../../errors/debug-errors.js';
 import { resolveStatement } from '../../utils/breakpoint-resolver.js';
 import type { Breakpoint } from '@debugmcp/shared';
 import type { ManagedSession } from '../session-store.js';

--- a/src/session/breakpoints/anchor-resolution.ts
+++ b/src/session/breakpoints/anchor-resolution.ts
@@ -82,7 +82,7 @@ export async function reresolveAnchors(
     } catch (error) {
       ctx.logger.warn(
         `[SessionManager] Could not re-read ${file} for anchor re-resolution: ${
-          error instanceof Error ? error.message : String(error)
+          getErrorMessage(error)
         }`
       );
     }

--- a/src/session/breakpoints/breakpoint-controller.ts
+++ b/src/session/breakpoints/breakpoint-controller.ts
@@ -1,0 +1,493 @@
+/**
+ * Breakpoint tooling: the store-of-record for a session's breakpoints, and the
+ * DAP re-sends that push it at a live debuggee.
+ *
+ * The invariant the whole slice is built around: the session store is the
+ * source of truth and every mutation lands there first. DAP setBreakpoints is
+ * replace-all per file (and setFunctionBreakpoints replace-all per session), so
+ * a change is expressed by re-sending the surviving set; and a failed re-send
+ * is reported as a `warning`, never thrown, because the stored set is still
+ * correct and gets re-applied on the next launch.
+ */
+import { v4 as uuidv4 } from 'uuid';
+import {
+  Breakpoint,
+  FunctionBreakpoint,
+  SessionLifecycleState,
+  SessionState,
+  toFunctionBreakpoint,
+  toSourceBreakpoint,
+  type AdapterPolicy
+} from '@debugmcp/shared';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { SessionTerminatedError } from '../../errors/debug-errors.js';
+import { consumeChildSourced } from '../../utils/child-origin-events.js';
+import { normalizeBreakpointMessage } from '../../utils/breakpoint-message.js';
+import type { ManagedSession } from '../session-store.js';
+import type { BreakpointContext } from '../operations-context.js';
+import { buildFunctionBreakpointLaunchWarning } from './launch-warnings.js';
+
+/** Outcome of a DAP re-send: whether it reached the adapter, and why not. */
+export interface BreakpointSyncOutcome {
+  synced: boolean;
+  warning?: string;
+}
+
+export class BreakpointController {
+  constructor(private readonly ctx: BreakpointContext) {}
+
+  async setBreakpoint(
+    sessionId: string,
+    bp: {
+      /** Validated/translated by server.ts before reaching here */
+      file: string;
+      /** Resolved line (anchors are resolved to a line in the server layer) */
+      line: number;
+      condition?: string;
+      suspendPolicy?: 'all' | 'thread';
+      logMessage?: string;
+      /** Set only in assert/content addressing modes (loud snapping, #271) */
+      requestedLine?: number;
+      /** Content anchor for restart re-resolution (content mode, #271) */
+      anchor?: { statement: string; nearLine?: number };
+    }
+  ): Promise<{ breakpoint: Breakpoint; warning?: string }> {
+    const session = this.ctx.getSession(sessionId);
+
+    // Check if session is terminated
+    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
+      throw new SessionTerminatedError(sessionId);
+    }
+
+    const bpId = uuidv4();
+
+    this.ctx.logger.info(
+      `[SessionManager setBreakpoint] Using validated file path "${bp.file}" for session ${sessionId}`
+    );
+
+    const newBreakpoint: Breakpoint = {
+      id: bpId,
+      file: bp.file,
+      line: bp.line,
+      condition: bp.condition,
+      suspendPolicy: bp.suspendPolicy,
+      logMessage: bp.logMessage,
+      verified: false
+    };
+    if (bp.requestedLine !== undefined) {
+      newBreakpoint.requestedLine = bp.requestedLine;
+    }
+    if (bp.anchor !== undefined) {
+      newBreakpoint.anchor = bp.anchor;
+    }
+
+    if (!session.breakpoints) session.breakpoints = new Map();
+    session.breakpoints.set(bpId, newBreakpoint);
+    this.ctx.logger.info(
+      `[SessionManager] Breakpoint ${bpId} queued for ${bp.file}:${bp.line} in session ${sessionId}.`
+    );
+
+    const sync = await this.syncBreakpointsForFile(session, bp.file);
+    return { breakpoint: newBreakpoint, warning: sync.warning };
+  }
+
+  /**
+   * Re-send the session's full breakpoint set for one file to the adapter
+   * (DAP setBreakpoints is replace-all per file) and merge the response back
+   * into the stored breakpoints (positional match). No-op unless the proxy is
+   * live and the session is RUNNING or PAUSED. Never throws: a DAP failure is
+   * logged and reported via `warning` — the store remains the source of truth
+   * and the set is re-applied on the next launch.
+   */
+  async syncBreakpointsForFile(
+    session: ManagedSession,
+    file: string,
+    options?: { forceFreshEcho?: boolean }
+  ): Promise<BreakpointSyncOutcome> {
+    const sessionId = session.id;
+    if (
+      !session.proxyManager ||
+      !session.proxyManager.isRunning() ||
+      (session.state !== SessionState.RUNNING && session.state !== SessionState.PAUSED)
+    ) {
+      return { synced: false };
+    }
+
+    // Collect ALL breakpoints for this source file (DAP setBreakpoints is replace-all)
+    const allBpsForFile = Array.from(session.breakpoints.values())
+      .filter(bp => bp.file === file);
+
+    try {
+      this.ctx.logger.info(
+        `[SessionManager] Active proxy for session ${sessionId}, sending ${allBpsForFile.length} breakpoint(s) for ${file}.`
+      );
+      const response =
+        await session.proxyManager.sendDapRequest<DebugProtocol.SetBreakpointsResponse>(
+          'setBreakpoints',
+          {
+            source: { path: file },
+            breakpoints: allBpsForFile.map(toSourceBreakpoint),
+            // Reserved key, stripped by the proxy before the adapter sees
+            // it: asks a child-mirroring proxy for an authoritative echo
+            // even when the set is unchanged (issue #500).
+            ...(options?.forceFreshEcho === true ? { __mcpForceFreshEcho: true } : {}),
+          }
+        );
+      if (
+        response &&
+        response.body &&
+        response.body.breakpoints
+      ) {
+        const responseBps = response.body.breakpoints;
+        // For child-mirroring adapters (js-debug), setBreakpoints responses
+        // come from the parent session, which owns no runtime: its verified
+        // flags are pessimistic and its ids belong to a different id space
+        // than the child events that carry the real verification. Treat the
+        // child as authoritative — never let a parent response downgrade
+        // verified state or clobber child adapter ids.
+        const childAuthoritative =
+          !!this.ctx.selectPolicy(session.language)?.getDapClientBehavior?.().mirrorBreakpointsToChild;
+        // A response the proxy marked child-sourced (issue #500) carries the
+        // child session's own answer — the authoritative one — so it stamps
+        // fully instead of upgrade-only.
+        const childSourced = consumeChildSourced(response);
+        // Update ALL breakpoints from response (positional match)
+        for (let i = 0; i < Math.min(responseBps.length, allBpsForFile.length); i++) {
+          const bpInfo = responseBps[i];
+          const keepChildState =
+            childAuthoritative && !childSourced && allBpsForFile[i].verified === true;
+          if (childAuthoritative && childSourced) {
+            allBpsForFile[i].verified = bpInfo.verified;
+            // Only a VERIFIED child id enters the store: stub ids are
+            // unstable across the pending→bound transition (issue #495).
+            if (bpInfo.verified === true && typeof bpInfo.id === 'number') {
+              allBpsForFile[i].adapterId = bpInfo.id;
+            }
+          } else if (childAuthoritative) {
+            allBpsForFile[i].verified = allBpsForFile[i].verified || bpInfo.verified;
+          } else {
+            allBpsForFile[i].verified = bpInfo.verified;
+            allBpsForFile[i].adapterId = bpInfo.id ?? allBpsForFile[i].adapterId;
+          }
+          allBpsForFile[i].line = bpInfo.line || allBpsForFile[i].line;
+          if (!keepChildState) {
+            // Normalize before storing (issue #471): raw l10n keys like
+            // js-debug's "breakpoint.provisionalBreakpoint" must never sit in
+            // the store, and a provisional note must not survive verification.
+            allBpsForFile[i].message = normalizeBreakpointMessage(
+              bpInfo.message,
+              allBpsForFile[i].verified
+            );
+          }
+          // Enhance "no symbols" message for .NET with PDB format guidance
+          if (bpInfo.message && session.language === 'dotnet' &&
+              bpInfo.message.toLowerCase().includes('no symbols')) {
+            allBpsForFile[i].message += ' (Hint: netcoredbg requires Portable PDB format. Compile with /debug:portable or convert with Pdb2Pdb.)';
+          }
+          this.ctx.logger.info(
+            `[SessionManager] Breakpoint ${allBpsForFile[i].id} response received. Verified: ${allBpsForFile[i].verified}${
+              bpInfo.message ? `, Message: ${bpInfo.message}` : ''
+            }`
+          );
+
+          // Log breakpoint verification with structured logging
+          if (allBpsForFile[i].verified) {
+            this.ctx.logger.info('debug:breakpoint', {
+              event: 'verified',
+              sessionId: sessionId,
+              sessionName: session.name,
+              breakpointId: allBpsForFile[i].id,
+              file: allBpsForFile[i].file,
+              line: allBpsForFile[i].line,
+              verified: true,
+              timestamp: Date.now(),
+            });
+          }
+        }
+      }
+      return { synced: true };
+    } catch (error) {
+      this.ctx.logger.error(
+        `[SessionManager] Error sending setBreakpoints to proxy for session ${sessionId}:`,
+        error
+      );
+      const message = error instanceof Error ? error.message : String(error);
+      return { synced: false, warning: this.buildLiveSyncWarning(session, message) };
+    }
+  }
+
+  /**
+   * Compose the live-sync failure warning. For ruby attach sessions whose
+   * error is rdbg's "<path> is not available", append topology guidance
+   * (issue #357): the path was rejected on the debug TARGET's filesystem
+   * (e.g. container server + host rdbg, or vice versa) — expected behavior,
+   * not a debugger fault. Same hint-append style as the netcoredbg
+   * no-symbols guidance above.
+   */
+  private buildLiveSyncWarning(session: ManagedSession, message: string): string {
+    let warning = `Breakpoint state updated, but live sync failed: ${message}`;
+    if (session.attachMode && session.language === 'ruby' && /is not available/.test(message)) {
+      warning += ' (Hint: attach sessions send breakpoint paths to the remote debugger verbatim; the path must be valid on the debug target\'s filesystem. Use target-side paths, or pass localfsMap in the attach config to map local paths to remote ones.)';
+    }
+    return warning;
+  }
+
+  /**
+   * Set a function (symbol-addressed) breakpoint (issue #271 phase 3).
+   * Session-global — no file. Queued like line breakpoints when no debuggee
+   * is live; synced immediately otherwise.
+   */
+  async setFunctionBreakpoint(
+    sessionId: string,
+    bp: {
+      functionName: string;
+      condition?: string;
+    }
+  ): Promise<{ breakpoint: FunctionBreakpoint; warning?: string }> {
+    const session = this.ctx.getSession(sessionId);
+
+    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
+      throw new SessionTerminatedError(sessionId);
+    }
+
+    const newBreakpoint: FunctionBreakpoint = {
+      id: uuidv4(),
+      functionName: bp.functionName,
+      condition: bp.condition,
+      verified: false
+    };
+
+    if (!session.functionBreakpoints) session.functionBreakpoints = new Map();
+    session.functionBreakpoints.set(newBreakpoint.id, newBreakpoint);
+    this.ctx.logger.info(
+      `[SessionManager] Function breakpoint ${newBreakpoint.id} queued for ${bp.functionName} in session ${sessionId}.`
+    );
+
+    const sync = await this.syncFunctionBreakpoints(session);
+    return { breakpoint: newBreakpoint, warning: sync.warning };
+  }
+
+  /**
+   * Re-send the session's FULL function-breakpoint set to the adapter (DAP
+   * setFunctionBreakpoints is replace-all for the whole session, not per
+   * file). Same live-session guard and never-throws contract as
+   * syncBreakpointsForFile.
+   */
+  async syncFunctionBreakpoints(session: ManagedSession): Promise<BreakpointSyncOutcome> {
+    const sessionId = session.id;
+    if (
+      !session.proxyManager ||
+      !session.proxyManager.isRunning() ||
+      (session.state !== SessionState.RUNNING && session.state !== SessionState.PAUSED)
+    ) {
+      return { synced: false };
+    }
+
+    const allFnBps = Array.from(session.functionBreakpoints.values());
+
+    try {
+      this.ctx.logger.info(
+        `[SessionManager] Active proxy for session ${sessionId}, sending ${allFnBps.length} function breakpoint(s).`
+      );
+      const response =
+        await session.proxyManager.sendDapRequest<DebugProtocol.SetFunctionBreakpointsResponse>(
+          'setFunctionBreakpoints',
+          { breakpoints: allFnBps.map(toFunctionBreakpoint) }
+        );
+      const responseBps = response?.body?.breakpoints;
+      if (responseBps) {
+        // Positional match, same DAP guarantee as setBreakpoints
+        for (let i = 0; i < Math.min(responseBps.length, allFnBps.length); i++) {
+          const bpInfo = responseBps[i];
+          allFnBps[i].verified = bpInfo.verified;
+          allFnBps[i].adapterId = bpInfo.id ?? allFnBps[i].adapterId;
+          allFnBps[i].message = bpInfo.message;
+          if (typeof bpInfo.line === 'number') {
+            allFnBps[i].boundLine = bpInfo.line;
+          }
+          if (bpInfo.source?.path) {
+            allFnBps[i].boundFile = bpInfo.source.path;
+          }
+          if (allFnBps[i].verified) {
+            this.ctx.logger.info('debug:breakpoint', {
+              event: 'verified',
+              sessionId,
+              sessionName: session.name,
+              breakpointId: allFnBps[i].id,
+              functionName: allFnBps[i].functionName,
+              line: allFnBps[i].boundLine,
+              verified: true,
+              timestamp: Date.now(),
+            });
+          }
+        }
+      }
+      return { synced: true };
+    } catch (error) {
+      this.ctx.logger.error(
+        `[SessionManager] Error sending setFunctionBreakpoints to proxy for session ${sessionId}:`,
+        error
+      );
+      const message = error instanceof Error ? error.message : String(error);
+      return { synced: false, warning: this.buildLiveSyncWarning(session, message) };
+    }
+  }
+
+  /**
+   * The launch-time unbound-function-breakpoint warning, with the policy
+   * resolved from the session store. The store's lookup throws for an unknown
+   * language, and a warning is never worth failing a launch over, so the throw
+   * degrades to "no policy" — which is also what the pure builder expects.
+   */
+  functionBreakpointLaunchWarning(session: ManagedSession): string | undefined {
+    let policy: AdapterPolicy | undefined;
+    try {
+      policy = this.ctx.selectStorePolicy(session.language);
+    } catch {
+      policy = undefined;
+    }
+    return buildFunctionBreakpointLaunchWarning(session, policy);
+  }
+
+  /**
+   * Remove one breakpoint by its id (the id returned by setBreakpoint).
+   * The removal always takes effect in the session's breakpoint store; if the
+   * debuggee is live the file's remaining set is re-sent immediately.
+   * Deliberately works after the debuggee exits — the surviving set is
+   * re-applied on the next launch. Checks line and function breakpoints
+   * alike (shared UUID namespace).
+   */
+  async removeBreakpoint(
+    sessionId: string,
+    breakpointId: string
+  ): Promise<{ removed?: Breakpoint | FunctionBreakpoint; warning?: string }> {
+    const session = this.ctx.getSession(sessionId);
+
+    const functionBreakpoint = session.functionBreakpoints?.get(breakpointId);
+    if (functionBreakpoint) {
+      session.functionBreakpoints.delete(breakpointId);
+      this.ctx.logger.info('debug:breakpoint', {
+        event: 'removed',
+        sessionId,
+        sessionName: session.name,
+        breakpointId,
+        functionName: functionBreakpoint.functionName,
+        timestamp: Date.now(),
+      });
+      const { warning } = await this.syncFunctionBreakpoints(session);
+      return { removed: functionBreakpoint, warning };
+    }
+
+    const breakpoint = session.breakpoints.get(breakpointId);
+    if (!breakpoint) {
+      return { removed: undefined };
+    }
+
+    session.breakpoints.delete(breakpointId);
+    this.ctx.logger.info('debug:breakpoint', {
+      event: 'removed',
+      sessionId,
+      sessionName: session.name,
+      breakpointId,
+      file: breakpoint.file,
+      line: breakpoint.line,
+      timestamp: Date.now(),
+    });
+
+    const { warning } = await this.syncBreakpointsForFile(session, breakpoint.file);
+    return { removed: breakpoint, warning };
+  }
+
+  /**
+   * Remove ALL breakpoints at a file:line location (duplicates at one line —
+   * e.g. with different conditions — are removed together; DAP replace-all
+   * semantics cannot distinguish them anyway). Same lifecycle behavior as
+   * removeBreakpoint.
+   */
+  async removeBreakpointsByLocation(
+    sessionId: string,
+    file: string,
+    line: number
+  ): Promise<{ removed: Breakpoint[]; warning?: string }> {
+    const session = this.ctx.getSession(sessionId);
+
+    const removed = Array.from(session.breakpoints.values())
+      .filter(bp => bp.file === file && bp.line === line);
+    if (removed.length === 0) {
+      return { removed: [] };
+    }
+
+    for (const bp of removed) {
+      session.breakpoints.delete(bp.id);
+      this.ctx.logger.info('debug:breakpoint', {
+        event: 'removed',
+        sessionId,
+        sessionName: session.name,
+        breakpointId: bp.id,
+        file: bp.file,
+        line: bp.line,
+        timestamp: Date.now(),
+      });
+    }
+
+    const { warning } = await this.syncBreakpointsForFile(session, file);
+    return { removed, warning };
+  }
+
+  /**
+   * Remove all of the session's breakpoints, or all breakpoints in one file.
+   * Clearing zero breakpoints is success, not an error. Works in every
+   * lifecycle state; live sessions get one empty/remaining setBreakpoints
+   * re-send per affected file.
+   */
+  async clearBreakpoints(
+    sessionId: string,
+    file?: string
+  ): Promise<{ cleared: number; files: string[]; warning?: string }> {
+    const session = this.ctx.getSession(sessionId);
+
+    const toClear = Array.from(session.breakpoints.values())
+      .filter(bp => file === undefined || bp.file === file);
+    const files = [...new Set(toClear.map(bp => bp.file))];
+
+    // Function breakpoints are not file-scoped: only an unscoped clear
+    // touches them (issue #271 phase 3).
+    const fnToClear = file === undefined
+      ? Array.from(session.functionBreakpoints?.values() ?? [])
+      : [];
+
+    for (const bp of toClear) {
+      session.breakpoints.delete(bp.id);
+    }
+    for (const bp of fnToClear) {
+      session.functionBreakpoints.delete(bp.id);
+    }
+    if (toClear.length > 0 || fnToClear.length > 0) {
+      this.ctx.logger.info('debug:breakpoint', {
+        event: 'cleared',
+        sessionId,
+        sessionName: session.name,
+        cleared: toClear.length + fnToClear.length,
+        files,
+        functionBreakpoints: fnToClear.length,
+        timestamp: Date.now(),
+      });
+    }
+
+    const warnings: string[] = [];
+    for (const clearedFile of files) {
+      const { warning } = await this.syncBreakpointsForFile(session, clearedFile);
+      if (warning) warnings.push(warning);
+    }
+    if (fnToClear.length > 0) {
+      const { warning } = await this.syncFunctionBreakpoints(session);
+      if (warning) warnings.push(warning);
+    }
+
+    return {
+      cleared: toClear.length + fnToClear.length,
+      files,
+      ...(warnings.length > 0 ? { warning: warnings.join('; ') } : {})
+    };
+  }
+}

--- a/src/session/breakpoints/breakpoint-controller.ts
+++ b/src/session/breakpoints/breakpoint-controller.ts
@@ -9,6 +9,7 @@
  * is reported as a `warning`, never thrown, because the stored set is still
  * correct and gets re-applied on the next launch.
  */
+import { getErrorMessage } from '../../errors/debug-errors.js';
 import { v4 as uuidv4 } from 'uuid';
 import {
   Breakpoint,

--- a/src/session/breakpoints/breakpoint-controller.ts
+++ b/src/session/breakpoints/breakpoint-controller.ts
@@ -211,7 +211,7 @@ export class BreakpointController {
         `[SessionManager] Error sending setBreakpoints to proxy for session ${sessionId}:`,
         error
       );
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       return { synced: false, warning: this.buildLiveSyncWarning(session, message) };
     }
   }
@@ -328,7 +328,7 @@ export class BreakpointController {
         `[SessionManager] Error sending setFunctionBreakpoints to proxy for session ${sessionId}:`,
         error
       );
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       return { synced: false, warning: this.buildLiveSyncWarning(session, message) };
     }
   }

--- a/src/session/breakpoints/launch-warnings.ts
+++ b/src/session/breakpoints/launch-warnings.ts
@@ -1,0 +1,109 @@
+/**
+ * Launch-time breakpoint warnings.
+ *
+ * Each of these reads session state and returns a string — no adapter, no
+ * proxy, no clock. They were already written that way as methods (their tests
+ * called them off the prototype with a bare receiver to prove it); as free
+ * functions the purity is the signature rather than a convention.
+ */
+import path from 'path';
+import type { AdapterPolicy } from '@debugmcp/shared';
+import { normalizeBreakpointMessage } from '../../utils/breakpoint-message.js';
+import type { ManagedSession } from '../session-store.js';
+
+/**
+ * Ran-to-completion unbound-breakpoint warning (issue #467). Built only
+ * when the launch ends in STOPPED: at that point an unverified breakpoint
+ * never bound and never will, for bind-late adapters too — so this is a
+ * zero-false-positive moment to surface the per-breakpoint diagnostics the
+ * store already holds (e.g. the path-remap suggestion CodeLLDB puts in
+ * `message`).
+ */
+export function buildUnboundBreakpointExitWarning(
+  session: Pick<ManagedSession, 'breakpoints'>
+): string | undefined {
+  const unbound = Array.from(session.breakpoints.values()).filter(bp => !bp.verified);
+  if (unbound.length === 0) {
+    return undefined;
+  }
+  const parts = unbound.map(bp => {
+    // Some stamp paths store the raw js-debug l10n key — translate it
+    // rather than showing 'breakpoint.provisionalBreakpoint' (issue #471).
+    const message = normalizeBreakpointMessage(bp.message, bp.verified);
+    return `${path.basename(bp.file)}:${bp.line}${message ? ` (${message})` : ''}`;
+  });
+  return (
+    `${unbound.length} breakpoint(s) never bound during this run: ${parts.join('; ')}. ` +
+    `The program ran to completion without stopping there — check the file path and line, ` +
+    `or list_breakpoints for the full per-breakpoint state`
+  );
+}
+
+/**
+ * Launch-time logpoint-downgrade warning (issue #469). A logpoint accepted
+ * pre-launch under unknown policy support ("it will be validated against
+ * the adapter's capabilities at launch") gets its promised verdict here:
+ * when the live adapter does not advertise supportsLogPoints, the logpoint
+ * has been silently downgraded to a pausing breakpoint — say so in the
+ * start_debugging response instead of only in the server log.
+ */
+export function buildLogpointDowngradeLaunchWarning(
+  session: Pick<ManagedSession, 'breakpoints' | 'adapterCapabilities' | 'language'>
+): string | undefined {
+  const caps = session.adapterCapabilities;
+  if (!caps || caps.supportsLogPoints === true) {
+    return undefined;
+  }
+  const downgraded: string[] = [];
+  for (const bp of session.breakpoints.values()) {
+    if (bp.logMessage !== undefined) {
+      downgraded.push(`${path.basename(bp.file)}:${bp.line}`);
+    }
+  }
+  if (downgraded.length === 0) {
+    return undefined;
+  }
+  return (
+    `Logpoint(s) at ${downgraded.join(', ')} were downgraded to pausing breakpoints: ` +
+    `the ${session.language} adapter does not advertise supportsLogPoints, so the ` +
+    `logMessage will not be logged and the program will PAUSE at those lines instead ` +
+    `of running through them`
+  );
+}
+
+/**
+ * Launch-time unbound-function-breakpoint warning (issue #308). Called
+ * after the post-launch re-sync, when verified state is fresh. Returns
+ * undefined for bind-late policies (js/java) — unverified-at-launch is
+ * their designed deferral, not a failure.
+ *
+ * The policy is a parameter because the caller resolves it from the session
+ * store, whose lookup throws for an unknown language.
+ */
+export function buildFunctionBreakpointLaunchWarning(
+  session: Pick<ManagedSession, 'functionBreakpoints'>,
+  policy: AdapterPolicy | undefined
+): string | undefined {
+  if ((session.functionBreakpoints?.size ?? 0) === 0) {
+    return undefined;
+  }
+  if (policy?.functionBreakpointsBindLate === true) {
+    return undefined;
+  }
+  const parts: string[] = [];
+  for (const bp of session.functionBreakpoints.values()) {
+    if (bp.verified) {
+      continue;
+    }
+    const hint = policy?.functionBreakpointNameHint?.(bp.functionName) ?? bp.message;
+    parts.push(`'${bp.functionName}'${hint ? ` (${hint})` : ''}`);
+  }
+  if (parts.length === 0) {
+    return undefined;
+  }
+  return (
+    `Function breakpoint(s) not bound at launch: ${parts.join('; ')}. ` +
+    `The adapter could not resolve the name, so the program will not stop there — ` +
+    `check the symbol name; list_breakpoints shows the current state`
+  );
+}

--- a/src/session/dap-request-helpers.ts
+++ b/src/session/dap-request-helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * Small helpers shared by every tool that sends a DAP request on the caller's
+ * behalf (evaluate, redefineClasses, the mirror commands): validating the
+ * optional per-request timeout override, hinting at it when a request times
+ * out, and keeping log lines from swallowing a megabyte of program output.
+ *
+ * They were three private methods on the session-manager operations class and
+ * depend on nothing but their arguments, so they live here as free functions —
+ * a collaborator that needs one imports it instead of inheriting it.
+ */
+import type { ILogger } from '@debugmcp/shared';
+import { ErrorMessages } from '../utils/error-messages.js';
+
+/** Upper bound for caller-supplied per-request DAP timeouts (10 minutes). */
+export const MAX_DAP_TIMEOUT_MS = 600000;
+
+/**
+ * Truncate long strings for logging.
+ */
+export function truncateForLog(value: string, maxLength: number = 1000): string {
+  if (!value) return '';
+  return value.length > maxLength ? value.substring(0, maxLength) + '... (truncated)' : value;
+}
+
+/**
+ * Validate and clamp a caller-supplied per-request DAP timeout override (ms).
+ * Returns { error } for invalid values, { timeoutMs } with the (possibly
+ * clamped) override, or {} when no override was given.
+ */
+export function resolveDapTimeoutOverride(
+  timeoutMs: number | undefined,
+  logContext: string,
+  logger: ILogger
+): { error?: string; timeoutMs?: number } {
+  if (timeoutMs === undefined) {
+    return {};
+  }
+  if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return {
+      error: `Invalid 'timeout': must be a positive number of milliseconds (got ${timeoutMs})`
+    };
+  }
+  if (timeoutMs > MAX_DAP_TIMEOUT_MS) {
+    logger.warn(
+      `[${logContext}] 'timeout' ${timeoutMs}ms exceeds the maximum; clamping to ${MAX_DAP_TIMEOUT_MS}ms`
+    );
+    return { timeoutMs: MAX_DAP_TIMEOUT_MS };
+  }
+  return { timeoutMs };
+}
+
+/** Append the 'timeout' tool-arg hint to DAP timeout failures. */
+export function withTimeoutHint(errorMessage: string): string {
+  if (!/timed out|did not respond/i.test(errorMessage)) {
+    return errorMessage;
+  }
+  const separator = errorMessage.trimEnd().endsWith('.') ? ' ' : '. ';
+  return `${errorMessage}${separator}${ErrorMessages.dapRequestTimeoutHint()}`;
+}

--- a/src/session/execution/execution-controller.ts
+++ b/src/session/execution/execution-controller.ts
@@ -121,7 +121,7 @@ export class ExecutionController {
         successMessage,
       });
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = getErrorMessage(error);
       this.ctx.logger.error(`[SM ${logTag} ${sessionId}] Error during step:`, error);
       this.ctx.updateState(session, SessionState.ERROR);
       return { success: false, error: errorMessage, state: session.state };
@@ -236,7 +236,7 @@ export class ExecutionController {
       proxyManager
         .sendDapRequest(options.command, { threadId: options.threadId })
         .catch((error: unknown) => {
-          const errorMessage = error instanceof Error ? error.message : String(error);
+          const errorMessage = getErrorMessage(error);
           this.ctx.logger.error(
             `[SM ${options.logTag} ${sessionId}] Error during step request:`,
             error
@@ -294,7 +294,7 @@ export class ExecutionController {
     } catch (error) {
       // Revert to PAUSED — the VM didn't actually resume
       this.ctx.updateState(session, SessionState.PAUSED);
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = getErrorMessage(error);
       this.ctx.logger.error(
         `[SessionManager continue] Error sending 'continue' to proxy for session ${sessionId}: ${errorMessage}`
       );
@@ -494,7 +494,7 @@ export class ExecutionController {
         })
         .catch((error: unknown) => {
           session.pausePending = false;
-          const errorMessage = error instanceof Error ? error.message : String(error);
+          const errorMessage = getErrorMessage(error);
           this.ctx.logger.error(
             `[SessionManager pause] Error sending 'pause' for session ${sessionId}: ${errorMessage}`
           );

--- a/src/session/execution/execution-controller.ts
+++ b/src/session/execution/execution-controller.ts
@@ -1,0 +1,536 @@
+/**
+ * Execution control: stepping, continue, pause, and the thread list.
+ *
+ * Everything here shares one shape. The DAP request only acknowledges that the
+ * debugger accepted the command; the state change arrives later as a `stopped`
+ * event handled by the core listener. So each operation registers its
+ * listeners BEFORE sending, and settles on whichever comes first — the stop,
+ * the debuggee ending, or a grace window elapsing. The grace window is not a
+ * deadline on the debuggee: it converts "still running" into an honest
+ * `pending: true` success rather than a failure, and the operation completes
+ * asynchronously afterwards.
+ */
+import {
+  NO_DEBUG_TARGET_MARKER,
+  SessionLifecycleState,
+  SessionState
+} from '@debugmcp/shared';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { ProxyNotRunningError, SessionTerminatedError } from '../../errors/debug-errors.js';
+import { ErrorMessages } from '../../utils/error-messages.js';
+import type { ManagedSession } from '../session-store.js';
+import type { DebugResult } from '../session-manager-core.js';
+import type { ExecutionContext } from '../operations-context.js';
+
+/** What distinguishes the three step flavours: everything else is shared. */
+interface StepKind {
+  /** The DAP request to send. */
+  command: 'next' | 'stepIn' | 'stepOut';
+  /** How the operation is named in a ProxyNotRunningError. */
+  operation: string;
+  /** The `[SM <tag> <id>]` log prefix. */
+  logTag: string;
+  successMessage: string;
+}
+
+const STEP_KINDS = {
+  stepOver: {
+    command: 'next',
+    operation: 'step over',
+    logTag: 'stepOver',
+    successMessage: 'Step completed.'
+  },
+  stepInto: {
+    command: 'stepIn',
+    operation: 'step into',
+    logTag: 'stepInto',
+    successMessage: 'Step into completed.'
+  },
+  stepOut: {
+    command: 'stepOut',
+    operation: 'step out',
+    logTag: 'stepOut',
+    successMessage: 'Step out completed.'
+  }
+} as const satisfies Record<string, StepKind>;
+
+export type StepKindName = keyof typeof STEP_KINDS;
+
+/** The per-step options `executeStep` waits on. */
+export interface StepOperationOptions {
+  command: 'next' | 'stepIn' | 'stepOut';
+  threadId: number;
+  logTag: string;
+  successMessage: string;
+  terminatedMessage?: string;
+  exitedMessage?: string;
+}
+
+export class ExecutionController {
+  constructor(private readonly ctx: ExecutionContext) {}
+
+  async stepOver(sessionId: string): Promise<DebugResult> {
+    return this.step(sessionId, 'stepOver');
+  }
+
+  async stepInto(sessionId: string): Promise<DebugResult> {
+    return this.step(sessionId, 'stepInto');
+  }
+
+  async stepOut(sessionId: string): Promise<DebugResult> {
+    return this.step(sessionId, 'stepOut');
+  }
+
+  /**
+   * The preamble the three step flavours share: liveness and paused-ness
+   * checks, the current thread, and the error handling around the wait.
+   */
+  private async step(sessionId: string, kind: StepKindName): Promise<DebugResult> {
+    const { command, operation, logTag, successMessage } = STEP_KINDS[kind];
+    const session = this.ctx.getSession(sessionId);
+
+    // Check if session is terminated
+    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
+      throw new SessionTerminatedError(sessionId);
+    }
+
+    const threadId = session.proxyManager?.getCurrentThreadId();
+    this.ctx.logger.info(
+      `[SM ${logTag} ${sessionId}] Entered. Current state: ${session.state}, ThreadID: ${threadId}`
+    );
+
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      throw new ProxyNotRunningError(sessionId, operation);
+    }
+    if (session.state !== SessionState.PAUSED) {
+      this.ctx.logger.warn(`[SM ${logTag} ${sessionId}] Not paused. State: ${session.state}`);
+      return { success: false, error: 'Not paused', state: session.state };
+    }
+    if (typeof threadId !== 'number') {
+      this.ctx.logger.warn(`[SM ${logTag} ${sessionId}] No current thread ID.`);
+      return { success: false, error: 'No current thread ID', state: session.state };
+    }
+
+    this.ctx.logger.info(`[SM ${logTag} ${sessionId}] Sending DAP '${command}' for threadId ${threadId}`);
+
+    try {
+      return await this.executeStep(session, sessionId, {
+        command,
+        threadId,
+        logTag,
+        successMessage,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.ctx.logger.error(`[SM ${logTag} ${sessionId}] Error during step:`, error);
+      this.ctx.updateState(session, SessionState.ERROR);
+      return { success: false, error: errorMessage, state: session.state };
+    }
+  }
+
+  /**
+   * Send one step request and wait for whatever ends it. Public because the
+   * step preamble and its tests both drive it directly.
+   */
+  executeStep(
+    session: ManagedSession,
+    sessionId: string,
+    options: StepOperationOptions
+  ): Promise<DebugResult> {
+    const proxyManager = session.proxyManager;
+
+    if (!proxyManager) {
+      return Promise.resolve({
+        success: false,
+        error: 'Proxy manager unavailable',
+        state: session.state,
+      });
+    }
+
+    const terminatedMessage =
+      options.terminatedMessage ?? 'Step completed as session terminated.';
+    const exitedMessage = options.exitedMessage ?? 'Step completed as session exited.';
+
+    return new Promise((resolve) => {
+      let settled = false;
+
+      const cleanup = () => {
+        proxyManager.off('stopped', onStopped);
+        proxyManager.off('terminated', onTerminated);
+        proxyManager.off('exited', onExited);
+        proxyManager.off('exit', onExit);
+        clearTimeout(timeout);
+      };
+
+      const settle = (result: DebugResult) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(result);
+      };
+
+      const success = (message: string, location?: { file: string; line: number; column?: number }) => {
+        this.ctx.logger.info(`[SM ${options.logTag} ${sessionId}] ${message} Current state: ${session.state}`);
+        const data: { message: string; location?: { file: string; line: number; column?: number } } = { message };
+        if (location) {
+          data.location = location;
+        }
+        settle({
+          success: true,
+          state: session.state,
+          data,
+        });
+      };
+
+      const onStopped = async () => {
+        // Try to get current location from stack trace
+        let location: { file: string; line: number; column?: number } | undefined;
+        try {
+          // Wait a brief moment for state to settle after stopped event
+          await new Promise(resolve => setTimeout(resolve, 10));
+
+          const stackFrames = await this.ctx.getStackTrace(sessionId);
+          if (stackFrames && stackFrames.length > 0) {
+            const topFrame = stackFrames[0];
+            location = {
+              file: topFrame.file,
+              line: topFrame.line,
+              column: topFrame.column
+            };
+            this.ctx.logger.debug(`[SM ${options.logTag} ${sessionId}] Captured location: ${location.file}:${location.line}`);
+          }
+        } catch (error) {
+          // Log but don't fail the step operation if we can't get location
+          this.ctx.logger.debug(`[SM ${options.logTag} ${sessionId}] Could not capture location:`, error);
+        }
+        success(options.successMessage, location);
+      };
+
+      const onTerminated = () => success(terminatedMessage);
+      const onExited = () => success(exitedMessage);
+      const onExit = () => success(exitedMessage);
+
+      const timeout = setTimeout(() => {
+        this.ctx.logger.info(
+          `[SM ${options.logTag} ${sessionId}] Step still running after ${this.ctx.tunables.stepGraceMs}ms grace window; completing asynchronously`
+        );
+        settle({
+          success: true,
+          state: session.state,
+          data: {
+            message: ErrorMessages.stepStillRunning(this.ctx.tunables.stepGraceMs / 1000),
+            pending: true,
+          },
+        });
+      }, this.ctx.tunables.stepGraceMs);
+
+      proxyManager.on('stopped', onStopped);
+      proxyManager.on('terminated', onTerminated);
+      proxyManager.on('exited', onExited);
+      proxyManager.on('exit', onExit);
+
+      this.ctx.updateState(session, SessionState.RUNNING);
+
+      proxyManager
+        .sendDapRequest(options.command, { threadId: options.threadId })
+        .catch((error: unknown) => {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          this.ctx.logger.error(
+            `[SM ${options.logTag} ${sessionId}] Error during step request:`,
+            error
+          );
+          this.ctx.updateState(session, SessionState.ERROR);
+          settle({ success: false, error: errorMessage, state: session.state });
+        });
+    });
+  }
+
+  async continue(sessionId: string): Promise<DebugResult> {
+    const session = this.ctx.getSession(sessionId);
+
+    // Check if session is terminated
+    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
+      throw new SessionTerminatedError(sessionId);
+    }
+
+    const threadId = session.proxyManager?.getCurrentThreadId();
+    this.ctx.logger.info(
+      `[SessionManager continue] Called for session ${sessionId}. Current state: ${session.state}, ThreadID: ${threadId}`
+    );
+
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      throw new ProxyNotRunningError(sessionId, 'continue');
+    }
+    if (session.state !== SessionState.PAUSED) {
+      this.ctx.logger.warn(
+        `[SessionManager continue] Session ${sessionId} not paused. State: ${session.state}.`
+      );
+      return { success: false, error: 'Not paused', state: session.state };
+    }
+    if (typeof threadId !== 'number') {
+      this.ctx.logger.warn(
+        `[SessionManager continue] No current thread ID for session ${sessionId}.`
+      );
+      return { success: false, error: 'No current thread ID', state: session.state };
+    }
+
+    try {
+      this.ctx.logger.info(
+        `[SessionManager continue] Sending DAP 'continue' for session ${sessionId}, threadId ${threadId}.`
+      );
+      // Set RUNNING *before* sending the DAP request so that concurrent
+      // operations (e.g. getStackTrace polling) see the correct state.
+      // If a breakpoint fires during the await, the handleStopped callback
+      // will set state back to PAUSED before the await resolves.
+      this.ctx.updateState(session, SessionState.RUNNING);
+      await session.proxyManager.sendDapRequest('continue', { threadId });
+
+      this.ctx.logger.info(
+        `[SessionManager continue] DAP 'continue' sent, session ${sessionId} state is ${session.state}.`
+      );
+      return { success: true, state: session.state };
+    } catch (error) {
+      // Revert to PAUSED — the VM didn't actually resume
+      this.ctx.updateState(session, SessionState.PAUSED);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.ctx.logger.error(
+        `[SessionManager continue] Error sending 'continue' to proxy for session ${sessionId}: ${errorMessage}`
+      );
+      throw error;
+    }
+  }
+
+  async pause(sessionId: string, threadId?: number): Promise<DebugResult> {
+    const session = this.ctx.getSession(sessionId);
+
+    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
+      throw new SessionTerminatedError(sessionId);
+    }
+
+    this.ctx.logger.info(
+      `[SessionManager pause] Called for session ${sessionId}. Current state: ${session.state}`
+    );
+
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      throw new ProxyNotRunningError(sessionId, 'pause');
+    }
+
+    if (session.state === SessionState.PAUSED) {
+      return {
+        success: true,
+        state: session.state,
+        data: {
+          message: 'Already paused',
+          ...(session.lastStop?.reason ? { stopReason: session.lastStop.reason } : {}),
+          ...(session.lastStop?.rawReason ? { rawStopReason: session.lastStop.rawReason } : {})
+        }
+      };
+    }
+
+    if (session.state !== SessionState.RUNNING) {
+      return { success: false, error: `Cannot pause in state: ${session.state}`, state: session.state };
+    }
+
+    this.ctx.logger.debug(`[SessionManager] pauseExecution: sending DAP pause for session=${sessionId} currentState=${session.state}`);
+    // DAP pause request: threadId 0 should pause all threads per DAP spec,
+    // but some adapters (e.g. netcoredbg) reject threadId=0 with E_INVALIDARG.
+    // When no explicit threadId is provided, discover one via a threads request.
+    let effectiveThreadId = threadId ?? 0;
+    if (effectiveThreadId === 0) {
+      try {
+        const threadsResp = await session.proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {});
+        const threads = threadsResp?.body?.threads;
+        if (Array.isArray(threads) && threads.length > 0 && typeof threads[0]?.id === 'number') {
+          effectiveThreadId = threads[0].id;
+          this.ctx.logger.info(`[SessionManager pause] Auto-discovered threadId=${effectiveThreadId} for pause`);
+        } else if (Array.isArray(threads) && threads.length === 0) {
+          // Tell-tale for child-session adapters (issue #513): on a policy
+          // that routes 'threads' to a child session, an empty list usually
+          // means the request hit the parent (root) session — the pause below
+          // goes through the same routing, where child-required handling
+          // waits for/rejects on the missing child.
+          this.ctx.logger.info(
+            `[SessionManager pause] threads returned empty for session ${sessionId}; proceeding with threadId=0`
+          );
+        }
+      } catch {
+        // threads request failed — fall through with threadId=0
+      }
+    }
+
+    const proxyManager = session.proxyManager;
+
+    // Snapshot the current lastStop so result paths can tell whether the stop
+    // they observe belongs to THIS pause (handleStopped replaces the object)
+    // rather than reporting a stale earlier stop.
+    const lastStopBefore = session.lastStop;
+    // Flag the in-flight pause so policy stop-reason normalization can use it
+    // (e.g. CodeLLDB reports pauses as 'exception'/SIGSTOP). handleStopped
+    // clears it on every stop; clear it here too on error/terminate paths.
+    session.pausePending = true;
+
+    // The pause response only acknowledges the request; the state transition
+    // to PAUSED happens when the asynchronous 'stopped' event is handled by
+    // the core handleStopped listener. Adapters differ on whether the event
+    // arrives before or after the response, so listen for it (registered
+    // BEFORE sending the request) and only settle once the stop is observed.
+    return new Promise<DebugResult>((resolve, reject) => {
+      let settled = false;
+      let stopEventSeen = false;
+
+      const cleanup = () => {
+        proxyManager.off('stopped', onStopped);
+        proxyManager.off('terminated', onEnded);
+        proxyManager.off('exited', onEnded);
+        proxyManager.off('exit', onEnded);
+        clearTimeout(timeout);
+      };
+
+      const settle = (result: DebugResult) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(result);
+      };
+
+      const onStopped = async () => {
+        stopEventSeen = true;
+        // Try to get current location from stack trace
+        let location: { file: string; line: number; column?: number } | undefined;
+        try {
+          // Wait a brief moment for state to settle after stopped event
+          await new Promise(resolve => setTimeout(resolve, 10));
+
+          const stackFrames = await this.ctx.getStackTrace(sessionId);
+          if (stackFrames && stackFrames.length > 0) {
+            const topFrame = stackFrames[0];
+            location = {
+              file: topFrame.file,
+              line: topFrame.line,
+              column: topFrame.column
+            };
+          }
+        } catch (error) {
+          this.ctx.logger.debug(`[SessionManager pause ${sessionId}] Could not capture location:`, error);
+        }
+        this.ctx.logger.info(
+          `[SessionManager pause] Paused session ${sessionId}. Current state: ${session.state}`
+        );
+        const data: {
+          message: string;
+          stopReason?: string;
+          rawStopReason?: string;
+          location?: { file: string; line: number; column?: number };
+        } = { message: 'Paused' };
+        // Only report the stop reason when handleStopped recorded a NEW stop
+        // for this pause — never echo a stale earlier stop.
+        if (session.lastStop && session.lastStop !== lastStopBefore) {
+          data.stopReason = session.lastStop.reason;
+          if (session.lastStop.rawReason) {
+            data.rawStopReason = session.lastStop.rawReason;
+          }
+        }
+        if (location) {
+          data.location = location;
+        }
+        settle({ success: true, state: session.state, data });
+      };
+
+      const onEnded = () => {
+        session.pausePending = false;
+        settle({
+          success: true,
+          state: session.state,
+          data: { message: 'Session ended before pause took effect' }
+        });
+      };
+
+      const timeout = setTimeout(() => {
+        this.ctx.logger.info(
+          `[SessionManager pause] No stopped event within ${this.ctx.tunables.pauseGraceMs}ms grace window in session ${sessionId}; completing asynchronously`
+        );
+        // session.pausePending stays armed on purpose: the pause was
+        // delivered and the stop may land whenever the debuggee next runs
+        // (e.g. an idle server, issue #513) — that late stop must still be
+        // normalized to 'pause'. handleStopped clears the flag on any stop.
+        settle({
+          success: true,
+          state: session.state,
+          data: {
+            message: ErrorMessages.pausePending(this.ctx.tunables.pauseGraceMs / 1000),
+            pending: true,
+          },
+        });
+      }, this.ctx.tunables.pauseGraceMs);
+
+      proxyManager.on('stopped', onStopped);
+      proxyManager.on('terminated', onEnded);
+      proxyManager.on('exited', onEnded);
+      proxyManager.on('exit', onEnded);
+
+      proxyManager
+        .sendDapRequest('pause', { threadId: effectiveThreadId })
+        .then(() => {
+          this.ctx.logger.info(
+            `[SessionManager pause] DAP 'pause' sent for session ${sessionId}. Waiting for stopped event.`
+          );
+          // Guard: if the stopped event fired before the listeners above were
+          // registered (e.g. during the threads-discovery await), the state is
+          // already PAUSED and no further event will arrive.
+          if (session.state === SessionState.PAUSED && !stopEventSeen) {
+            const raceData: { message: string; stopReason?: string; rawStopReason?: string } = { message: 'Paused' };
+            if (session.lastStop && session.lastStop !== lastStopBefore) {
+              raceData.stopReason = session.lastStop.reason;
+              if (session.lastStop.rawReason) {
+                raceData.rawStopReason = session.lastStop.rawReason;
+              }
+            }
+            settle({ success: true, state: session.state, data: raceData });
+          }
+        })
+        .catch((error: unknown) => {
+          session.pausePending = false;
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          this.ctx.logger.error(
+            `[SessionManager pause] Error sending 'pause' for session ${sessionId}: ${errorMessage}`
+          );
+          if (!settled) {
+            settled = true;
+            cleanup();
+            // A pause with no debuggable target to run against (issue #513)
+            // is an actionable state, not a protocol failure — return the
+            // structured shape other unpausable states use
+            if (errorMessage.includes(NO_DEBUG_TARGET_MARKER)) {
+              resolve({ success: false, error: errorMessage, state: session.state });
+              return;
+            }
+            reject(error instanceof Error ? error : new Error(errorMessage));
+          }
+        });
+    });
+  }
+
+  async listThreads(sessionId: string): Promise<Array<{ id: number; name: string }>> {
+    const session = this.ctx.getSession(sessionId);
+
+    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
+      throw new SessionTerminatedError(sessionId);
+    }
+
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      throw new ProxyNotRunningError(sessionId, 'listThreads');
+    }
+
+    const response = await session.proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {});
+    // A failed DAP response must not be flattened into an empty-but-successful
+    // thread list (issue #124): propagate the failure to the caller.
+    if (response?.success === false) {
+      throw new Error(response.message || `DAP 'threads' request failed`);
+    }
+    return (response?.body?.threads ?? []).map(t => ({ id: t.id, name: t.name }));
+  }
+}

--- a/src/session/execution/execution-controller.ts
+++ b/src/session/execution/execution-controller.ts
@@ -10,6 +10,7 @@
  * `pending: true` success rather than a failure, and the operation completes
  * asynchronously afterwards.
  */
+import { getErrorMessage } from '../../errors/debug-errors.js';
 import {
   NO_DEBUG_TARGET_MARKER,
   SessionLifecycleState,

--- a/src/session/inspection/expression-evaluator.ts
+++ b/src/session/inspection/expression-evaluator.ts
@@ -156,7 +156,7 @@ export class ExpressionEvaluator {
           };
         }
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = getErrorMessage(error);
         this.ctx.logger.error(
           `[SM evaluateExpression ${sessionId}] Error getting stack trace for default frame:`,
           error
@@ -252,7 +252,7 @@ export class ExpressionEvaluator {
         return { success: false, error: 'No response body from debug adapter' };
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = getErrorMessage(error);
 
       // Log the error
       this.ctx.logger.error('debug:evaluate', {

--- a/src/session/inspection/expression-evaluator.ts
+++ b/src/session/inspection/expression-evaluator.ts
@@ -7,6 +7,7 @@
  * an arbitrary program value straight to the caller, so the secret-redaction
  * hook (issue #237) runs before anything, including the logs, sees the result.
  */
+import { getErrorMessage } from '../../errors/debug-errors.js';
 import {
   buildRedactionNotice,
   isSensitiveName,

--- a/src/session/inspection/expression-evaluator.ts
+++ b/src/session/inspection/expression-evaluator.ts
@@ -1,0 +1,286 @@
+/**
+ * `evaluate_expression`: run an expression in the paused debuggee's frame.
+ *
+ * Two things distinguish it from a bare DAP round trip. It resolves the frame
+ * itself when the caller does not name one — an agent that just hit a
+ * breakpoint has a thread, not a frame id. And it is the one tool that returns
+ * an arbitrary program value straight to the caller, so the secret-redaction
+ * hook (issue #237) runs before anything, including the logs, sees the result.
+ */
+import {
+  buildRedactionNotice,
+  isSensitiveName,
+  redactSecretsDeep,
+  redactVariableValue,
+  SessionState
+} from '@debugmcp/shared';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import {
+  resolveDapTimeoutOverride,
+  truncateForLog,
+  withTimeoutHint
+} from '../dap-request-helpers.js';
+import type { EvaluateContext } from '../operations-context.js';
+
+/**
+ * Result type for evaluate expression operations
+ */
+export interface EvaluateResult {
+  success: boolean;
+  result?: string;
+  type?: string;
+  variablesReference?: number;
+  namedVariables?: number;
+  indexedVariables?: number;
+  presentationHint?: DebugProtocol.VariablePresentationHint;
+  error?: string;
+  /** Present when secret-shaped content was masked in `result` (issue #237) */
+  redaction?: { rules: string[]; notice: string };
+}
+
+/**
+ * The "variable name" an evaluate expression stands for, for name-based
+ * redaction (issue #237): the whole expression when it is itself a
+ * sensitive name, otherwise its final dot-segment — so `config.password`
+ * is treated like the variable `password`.
+ */
+export function expressionNameForRedaction(expression: string): string {
+  const trimmed = expression.trim();
+  if (isSensitiveName(trimmed)) {
+    return trimmed;
+  }
+  const lastDot = trimmed.lastIndexOf('.');
+  return lastDot >= 0 ? trimmed.slice(lastDot + 1) : trimmed;
+}
+
+export class ExpressionEvaluator {
+  constructor(private readonly ctx: EvaluateContext) {}
+
+  /**
+   * Evaluate an expression in the context of the current debug session.
+   * The debugger must be paused for evaluation to work.
+   * Expressions CAN and SHOULD be able to modify program state (this is a feature).
+   *
+   * @param sessionId - The session ID
+   * @param expression - The expression to evaluate
+   * @param frameId - Optional stack frame ID for context (defaults to current frame)
+   * @param timeoutMs - Optional per-request timeout override (ms) for the DAP
+   *   evaluate request (default 30s, max 600000). Issue #142.
+   * @returns Evaluation result with value, type, and optional variable reference
+   */
+  async evaluateExpression(
+    sessionId: string,
+    expression: string,
+    frameId?: number,
+    timeoutMs?: number
+  ): Promise<EvaluateResult> {
+    const session = this.ctx.getSession(sessionId);
+    // Some debuggers (rdbg) reject the default 'variables' context; let the
+    // adapter policy pick the context its debugger understands.
+    const context = this.ctx.selectPolicy(session.language).getEvaluateContext?.() ?? 'variables';
+    this.ctx.logger.info(
+      `[SM evaluateExpression ${sessionId}] Entered. Expression: "${truncateForLog(
+        expression,
+        100
+      )}", frameId: ${frameId}, context: ${context}, state: ${session.state}`
+    );
+
+    // Basic sanity checks
+    if (!expression || expression.trim().length === 0) {
+      this.ctx.logger.warn(`[SM evaluateExpression ${sessionId}] Empty expression provided`);
+      return { success: false, error: 'Expression cannot be empty' };
+    }
+
+    const timeoutOverride = resolveDapTimeoutOverride(
+      timeoutMs,
+      `SM evaluateExpression ${sessionId}`,
+      this.ctx.logger
+    );
+    if (timeoutOverride.error) {
+      this.ctx.logger.warn(`[SM evaluateExpression ${sessionId}] ${timeoutOverride.error}`);
+      return { success: false, error: timeoutOverride.error };
+    }
+
+    // Validate session state
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      this.ctx.logger.warn(`[SM evaluateExpression ${sessionId}] No active proxy or proxy not running`);
+      return { success: false, error: 'No active debug session' };
+    }
+
+    if (session.state !== SessionState.PAUSED) {
+      this.ctx.logger.warn(
+        `[SM evaluateExpression ${sessionId}] Cannot evaluate: session not paused. State: ${session.state}`
+      );
+      return {
+        success: false,
+        error: 'Cannot evaluate: debugger not paused. Ensure the debugger is stopped at a breakpoint.',
+      };
+    }
+
+    // Handle frameId - get current frame from stack trace if not provided
+    if (frameId === undefined) {
+      try {
+        const threadId = session.proxyManager.getCurrentThreadId();
+        if (typeof threadId !== 'number') {
+          this.ctx.logger.warn(
+            `[SM evaluateExpression ${sessionId}] No current thread ID to get stack trace`
+          );
+          return {
+            success: false,
+            error: 'Unable to find thread for evaluation. Ensure the debugger is paused at a breakpoint.',
+          };
+        }
+
+        this.ctx.logger.info(
+          `[SM evaluateExpression ${sessionId}] No frameId provided, getting current frame from stack trace`
+        );
+        const stackResponse = await session.proxyManager.sendDapRequest<DebugProtocol.StackTraceResponse>(
+          'stackTrace',
+          {
+            threadId,
+            startFrame: 0,
+            levels: 1, // We only need the first frame
+          }
+        );
+
+        if (stackResponse?.body?.stackFrames && stackResponse.body.stackFrames.length > 0) {
+          frameId = stackResponse.body.stackFrames[0].id;
+          this.ctx.logger.info(
+            `[SM evaluateExpression ${sessionId}] Using current frame ID: ${frameId} from stack trace`
+          );
+        } else {
+          this.ctx.logger.warn(`[SM evaluateExpression ${sessionId}] No stack frames available`);
+          return {
+            success: false,
+            error: 'No active stack frame. Ensure the debugger is paused at a breakpoint.',
+          };
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        this.ctx.logger.error(
+          `[SM evaluateExpression ${sessionId}] Error getting stack trace for default frame:`,
+          error
+        );
+        return { success: false, error: `Unable to determine current frame: ${errorMessage}` };
+      }
+    }
+
+    try {
+      // Send DAP evaluate request
+      this.ctx.logger.info(
+        `[SM evaluateExpression ${sessionId}] Sending DAP 'evaluate' request. Expression: "${truncateForLog(
+          expression,
+          100
+        )}", frameId: ${frameId}, context: ${context}`
+      );
+
+      // Conditional 3-arg call: only pass options when an override is present,
+      // so the default path keeps its exact 2-arg contract.
+      const evaluateArgs = { expression, frameId, context };
+      const response = timeoutOverride.timeoutMs !== undefined
+        ? await session.proxyManager.sendDapRequest<DebugProtocol.EvaluateResponse>(
+            'evaluate', evaluateArgs, { timeoutMs: timeoutOverride.timeoutMs })
+        : await session.proxyManager.sendDapRequest<DebugProtocol.EvaluateResponse>(
+            'evaluate', evaluateArgs);
+
+      // Log raw response in debug mode — scrubbed, the raw body carries
+      // unredacted values (issue #237)
+      this.ctx.logger.debug(
+        `[SM evaluateExpression ${sessionId}] DAP evaluate raw response:`,
+        this.ctx.redactionEnabled() ? redactSecretsDeep(response).value : response
+      );
+
+      // Process response
+      if (response && response.body) {
+        const body = response.body;
+
+        // Note: debugpy automatically truncates collections at 300 items for performance
+        const result: EvaluateResult = {
+          success: true,
+          result: body.result || '', // Default to empty string if no result
+          type: body.type, // Optional, can be undefined
+          variablesReference: body.variablesReference || 0, // Default to 0 (no children)
+          namedVariables: body.namedVariables,
+          indexedVariables: body.indexedVariables,
+          presentationHint: body.presentationHint,
+        };
+
+        // Redaction hook (issue #237), placed above the logs below so they
+        // only ever see masked values. The expression's final dot-segment
+        // counts as the "variable name" so `config.password` is treated like
+        // the variable `password` would be.
+        if (this.ctx.redactionEnabled() && result.result) {
+          const redacted = redactVariableValue(
+            expressionNameForRedaction(expression),
+            result.result
+          );
+          if (redacted.redacted) {
+            result.result = redacted.value;
+            result.redaction = {
+              rules: redacted.hits.map(hit => hit.ruleId),
+              notice: buildRedactionNotice(redacted.hits)
+            };
+          }
+        }
+
+        // Log the evaluation result with structured logging
+        this.ctx.logger.info('debug:evaluate', {
+          event: 'expression',
+          sessionId,
+          sessionName: session.name,
+          expression: truncateForLog(expression, 100),
+          frameId,
+          context,
+          result: truncateForLog(result.result || '', 1000),
+          type: result.type,
+          variablesReference: result.variablesReference,
+          namedVariables: result.namedVariables,
+          indexedVariables: result.indexedVariables,
+          timestamp: Date.now(),
+        });
+
+        this.ctx.logger.info(
+          `[SM evaluateExpression ${sessionId}] Evaluation successful. Result: "${truncateForLog(
+            result.result || '',
+            200
+          )}", Type: ${result.type}, VarRef: ${result.variablesReference}`
+        );
+
+        return result;
+      } else {
+        this.ctx.logger.warn(`[SM evaluateExpression ${sessionId}] No body in evaluate response`);
+        return { success: false, error: 'No response body from debug adapter' };
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      // Log the error
+      this.ctx.logger.error('debug:evaluate', {
+        event: 'error',
+        sessionId,
+        sessionName: session.name,
+        expression: truncateForLog(expression, 100),
+        frameId,
+        context,
+        error: errorMessage,
+        timestamp: Date.now(),
+      });
+
+      this.ctx.logger.error(`[SM evaluateExpression ${sessionId}] Error evaluating expression:`, error);
+
+      // Determine error type for better user feedback
+      let userError = errorMessage;
+      if (errorMessage.includes('SyntaxError')) {
+        userError = `Syntax error in expression: ${errorMessage}`;
+      } else if (errorMessage.includes('NameError')) {
+        userError = `Name not found: ${errorMessage}`;
+      } else if (errorMessage.includes('TypeError')) {
+        userError = `Type error: ${errorMessage}`;
+      } else if (errorMessage.includes('frame')) {
+        userError = `Invalid frame context: ${errorMessage}`;
+      }
+
+      return { success: false, error: withTimeoutHint(userError) };
+    }
+  }
+}

--- a/src/session/jvm/redefine-classes-controller.ts
+++ b/src/session/jvm/redefine-classes-controller.ts
@@ -9,6 +9,7 @@
  * is load-bearing and is why this lives next to the breakpoint controller
  * rather than inside it.
  */
+import { getErrorMessage } from '../../errors/debug-errors.js';
 import { resolveDapTimeoutOverride, withTimeoutHint } from '../dap-request-helpers.js';
 import { reresolveAnchors, type AnchorResolution } from '../breakpoints/anchor-resolution.js';
 import type { BreakpointController } from '../breakpoints/breakpoint-controller.js';

--- a/src/session/jvm/redefine-classes-controller.ts
+++ b/src/session/jvm/redefine-classes-controller.ts
@@ -124,7 +124,7 @@ export class RedefineClassesController {
       this.ctx.logger.error(`[SM redefineClasses ${sessionId}] Error: ${error}`);
       return {
         success: false,
-        error: withTimeoutHint(error instanceof Error ? error.message : String(error)),
+        error: withTimeoutHint(getErrorMessage(error)),
       };
     }
   }

--- a/src/session/jvm/redefine-classes-controller.ts
+++ b/src/session/jvm/redefine-classes-controller.ts
@@ -1,0 +1,131 @@
+/**
+ * `redefine_classes`: JVM hot swap (Java only).
+ *
+ * The DAP round trip is the easy half. The interesting half is what a hot swap
+ * does to breakpoints: replacing a class's bytecode invalidates line numbers,
+ * so statement anchors — which are content identities, not line numbers — are
+ * re-resolved against the source now on disk and the affected files re-sent, so
+ * the JDI replant binds against the NEW line table (issue #464). That ordering
+ * is load-bearing and is why this lives next to the breakpoint controller
+ * rather than inside it.
+ */
+import { resolveDapTimeoutOverride, withTimeoutHint } from '../dap-request-helpers.js';
+import { reresolveAnchors, type AnchorResolution } from '../breakpoints/anchor-resolution.js';
+import type { BreakpointController } from '../breakpoints/breakpoint-controller.js';
+import type { HotSwapContext } from '../operations-context.js';
+
+export interface RedefineClassesResult {
+  success: boolean;
+  redefined?: string[];
+  redefinedCount?: number;
+  skippedNotLoaded?: number;
+  failedCount?: number;
+  failed?: Array<{ fqcn: string; error: string }>;
+  scannedFiles?: number;
+  newestTimestamp?: number;
+  /** Breakpoints re-planted after redefine (issue #370). */
+  replantedBreakpoints?: number;
+  /**
+   * Statement-anchored breakpoints re-resolved against the new source after
+   * the hot-swap (issue #464) — same shape restart_debugging returns.
+   */
+  anchorResolution?: AnchorResolution;
+  warning?: string;
+  error?: string;
+}
+
+export class RedefineClassesController {
+  constructor(
+    private readonly ctx: HotSwapContext,
+    private readonly breakpoints: BreakpointController
+  ) {}
+
+  async redefineClasses(
+    sessionId: string,
+    classesDir: string,
+    sinceTimestamp: number = 0,
+    timeoutMs?: number
+  ): Promise<RedefineClassesResult> {
+    const session = this.ctx.getSession(sessionId);
+    this.ctx.logger.info(
+      `[SM redefineClasses ${sessionId}] classesDir: "${classesDir}", since: ${sinceTimestamp}`
+    );
+
+    const timeoutOverride = resolveDapTimeoutOverride(
+      timeoutMs,
+      `SM redefineClasses ${sessionId}`,
+      this.ctx.logger
+    );
+    if (timeoutOverride.error) {
+      this.ctx.logger.warn(`[SM redefineClasses ${sessionId}] ${timeoutOverride.error}`);
+      return { success: false, error: timeoutOverride.error };
+    }
+
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      return { success: false, error: 'No active debug session' };
+    }
+
+    try {
+      const redefineArgs = { classesDir, sinceTimestamp };
+      const response = timeoutOverride.timeoutMs !== undefined
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ? await session.proxyManager.sendDapRequest<any>(
+            'redefineClasses', redefineArgs, { timeoutMs: timeoutOverride.timeoutMs })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        : await session.proxyManager.sendDapRequest<any>(
+            'redefineClasses', redefineArgs);
+
+      const body = response?.body;
+      if (!body) {
+        return { success: false, error: 'No response body from redefineClasses' };
+      }
+
+      // Statement anchors are content identities and a hot-swap invalidates
+      // line numbers (issue #464): re-resolve them against the new source —
+      // which IS what is on disk in the edit -> recompile -> hot-swap loop —
+      // and re-send the affected files so the JDI replant binds the moved
+      // lines against the new line table. Ordered after the redefine
+      // response, i.e. after vm.redefineClasses, by construction.
+      let anchorResolution: AnchorResolution | undefined;
+      const syncWarnings: string[] = [];
+      if ((body.redefinedCount ?? 0) > 0) {
+        anchorResolution = await reresolveAnchors(session, this.ctx);
+        if (anchorResolution && anchorResolution.moved.length > 0) {
+          const movedFiles = [...new Set(anchorResolution.moved.map(m => m.file))];
+          for (const file of movedFiles) {
+            const { warning } = await this.breakpoints.syncBreakpointsForFile(session, file);
+            if (warning) {
+              syncWarnings.push(warning);
+            }
+          }
+        }
+        if (anchorResolution && anchorResolution.stale.length > 0) {
+          syncWarnings.push(
+            `${anchorResolution.stale.length} statement-anchored breakpoint(s) could not be re-resolved ` +
+            `against the new source and keep their previous line — see anchorResolution.stale`
+          );
+        }
+      }
+
+      return {
+        success: true,
+        redefined: body.redefined,
+        redefinedCount: body.redefinedCount,
+        skippedNotLoaded: body.skippedNotLoaded,
+        failedCount: body.failedCount,
+        failed: body.failed,
+        scannedFiles: body.scannedFiles,
+        newestTimestamp: body.newestTimestamp,
+        replantedBreakpoints: body.replantedBreakpoints,
+        ...(anchorResolution ? { anchorResolution } : {}),
+        ...(syncWarnings.length > 0 ? { warning: syncWarnings.join('; ') } : {}),
+      };
+    } catch (error) {
+      this.ctx.logger.error(`[SM redefineClasses ${sessionId}] Error: ${error}`);
+      return {
+        success: false,
+        error: withTimeoutHint(error instanceof Error ? error.message : String(error)),
+      };
+    }
+  }
+}

--- a/src/session/mirror/mirror-controller.ts
+++ b/src/session/mirror/mirror-controller.ts
@@ -1,0 +1,118 @@
+/**
+ * `expose_session` / `unexpose_session`: the read-only DAP mirror an IDE can
+ * attach to while the agent drives the session (issue #217).
+ *
+ * The listener itself lives in the proxy worker; this side owns only the
+ * session's record of it. Both operations are written so the caller's desired
+ * end-state holds either way — exposing twice returns the existing endpoint,
+ * and unexposing something that was never exposed is a success — because the
+ * record and reality can disagree (a dead worker takes its listener with it)
+ * and the worker no-ops safely on a redundant request.
+ */
+import { MIRROR_EXPOSE_COMMAND, MIRROR_UNEXPOSE_COMMAND } from '../../proxy/dap-proxy-interfaces.js';
+import { withTimeoutHint } from '../dap-request-helpers.js';
+import type { SessionState } from '@debugmcp/shared';
+import type { MirrorContext } from '../operations-context.js';
+
+/** Result of expose_session (issue #217). */
+export interface ExposeSessionResult {
+  success: boolean;
+  state: SessionState;
+  host?: string;
+  port?: number;
+  token?: string;
+  error?: string;
+}
+
+/** Result of unexpose_session (issue #217). */
+export interface UnexposeSessionResult {
+  success: boolean;
+  state: SessionState;
+  wasExposed?: boolean;
+  closedClients?: number;
+  error?: string;
+}
+
+export class MirrorController {
+  constructor(private readonly ctx: MirrorContext) {}
+
+  /**
+   * Expose the session's live DAP connection as a read-only mirror endpoint
+   * for IDE attach (issue #217). Idempotent: the worker returns the existing
+   * endpoint (token unrotated) when already exposed. Allowed while RUNNING
+   * as well as PAUSED — a paused-only gate would race the debuggee anyway.
+   */
+  async exposeSession(sessionId: string): Promise<ExposeSessionResult> {
+    const session = this.ctx.getSession(sessionId);
+
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      return {
+        success: false,
+        state: session.state,
+        error: 'No active debug session to expose — start_debugging or attach_to_process first'
+      };
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await session.proxyManager.sendDapRequest<any>(MIRROR_EXPOSE_COMMAND, {});
+      const body = response?.body;
+      if (!body || typeof body.port !== 'number' || typeof body.token !== 'string') {
+        return { success: false, state: session.state, error: 'Malformed mirrorExpose response from debug proxy' };
+      }
+      const host = typeof body.host === 'string' ? body.host : '127.0.0.1';
+      this.ctx.updateSession(sessionId, {
+        exposure: { host, port: body.port, token: body.token, exposedAt: Date.now() }
+      });
+      // The token is an attach capability — log the endpoint, never the token.
+      this.ctx.logger.info(`[SM exposeSession ${sessionId}] Mirror listening on ${host}:${body.port}`);
+      return { success: true, state: session.state, host, port: body.port, token: body.token };
+    } catch (error) {
+      this.ctx.logger.error(`[SM exposeSession ${sessionId}] Error: ${error}`);
+      return {
+        success: false,
+        state: session.state,
+        error: withTimeoutHint(error instanceof Error ? error.message : String(error))
+      };
+    }
+  }
+
+  /**
+   * Close the session's mirror endpoint (issue #217). A no-op success when
+   * not exposed — the caller's desired end-state holds either way.
+   */
+  async unexposeSession(sessionId: string): Promise<UnexposeSessionResult> {
+    const session = this.ctx.getSession(sessionId);
+    const hadRecord = session.exposure !== undefined;
+
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      // Worker gone => listener gone; just clear any stale record.
+      if (hadRecord) {
+        this.ctx.updateSession(sessionId, { exposure: undefined });
+      }
+      return { success: true, state: session.state, wasExposed: false };
+    }
+
+    try {
+      // Always forward even without a parent record — record and reality can
+      // disagree, and the worker no-ops safely.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await session.proxyManager.sendDapRequest<any>(MIRROR_UNEXPOSE_COMMAND, {});
+      this.ctx.updateSession(sessionId, { exposure: undefined });
+      const body = response?.body;
+      return {
+        success: true,
+        state: session.state,
+        wasExposed: body?.closed === true || hadRecord,
+        ...(typeof body?.closedClients === 'number' ? { closedClients: body.closedClients } : {})
+      };
+    } catch (error) {
+      this.ctx.logger.error(`[SM unexposeSession ${sessionId}] Error: ${error}`);
+      return {
+        success: false,
+        state: session.state,
+        error: withTimeoutHint(error instanceof Error ? error.message : String(error))
+      };
+    }
+  }
+}

--- a/src/session/mirror/mirror-controller.ts
+++ b/src/session/mirror/mirror-controller.ts
@@ -9,6 +9,7 @@
  * record and reality can disagree (a dead worker takes its listener with it)
  * and the worker no-ops safely on a redundant request.
  */
+import { getErrorMessage } from '../../errors/debug-errors.js';
 import { MIRROR_EXPOSE_COMMAND, MIRROR_UNEXPOSE_COMMAND } from '../../proxy/dap-proxy-interfaces.js';
 import { withTimeoutHint } from '../dap-request-helpers.js';
 import type { SessionState } from '@debugmcp/shared';

--- a/src/session/mirror/mirror-controller.ts
+++ b/src/session/mirror/mirror-controller.ts
@@ -72,7 +72,7 @@ export class MirrorController {
       return {
         success: false,
         state: session.state,
-        error: withTimeoutHint(error instanceof Error ? error.message : String(error))
+        error: withTimeoutHint(getErrorMessage(error))
       };
     }
   }
@@ -111,7 +111,7 @@ export class MirrorController {
       return {
         success: false,
         state: session.state,
-        error: withTimeoutHint(error instanceof Error ? error.message : String(error))
+        error: withTimeoutHint(getErrorMessage(error))
       };
     }
   }

--- a/src/session/operations-context.ts
+++ b/src/session/operations-context.ts
@@ -114,8 +114,14 @@ export type EvaluateContext = Pick<
   'logger' | 'getSession' | 'selectPolicy' | 'redactionEnabled'
 >;
 
-/** JVM hot swap: a DAP round trip plus breakpoint re-planting. */
-export type HotSwapContext = Pick<OperationsContext, 'logger' | 'getSession'>;
+/**
+ * JVM hot swap: a DAP round trip, anchor re-resolution (hence the filesystem)
+ * and breakpoint re-planting.
+ */
+export type HotSwapContext = Pick<
+  OperationsContext,
+  'logger' | 'fileSystem' | 'getSession'
+>;
 
 /** The read-only DAP mirror endpoint, whose record lives on the session. */
 export type MirrorContext = Pick<

--- a/src/session/operations-context.ts
+++ b/src/session/operations-context.ts
@@ -1,0 +1,124 @@
+/**
+ * The seam between `SessionManagerOperations` and the collaborators the debug
+ * operations are split across.
+ *
+ * Every member is **late bound** over the facade: methods are arrows that call
+ * `this.<method>(...)` when invoked, data members are getters that re-read the
+ * facade field. That is deliberate and load-bearing, not a style choice — tests
+ * reassign `selectPolicy` / `stopProxyPreservingSession` / `closeSession` on a
+ * live SessionManager instance and write the tunables (`attachVerifyTimeoutMs`
+ * and friends) as plain fields. A context built from bound references captured
+ * at construction time would silently ignore all of it.
+ *
+ * The per-slice `Pick<>` aliases below are the actual constructor parameter
+ * types: a collaborator declares the narrowest slice it uses, so what each one
+ * touches is readable from its signature and widening it is a visible edit.
+ */
+import type {
+  AdapterPolicy,
+  DebugLanguage,
+  IAdapterRegistry,
+  IFileSystem,
+  ILogger,
+  SessionState,
+  StackFrame
+} from '@debugmcp/shared';
+import type { ManagedSession } from './session-store.js';
+import type { CustomLaunchRequestArguments } from './session-manager-core.js';
+import type { IProxyManager } from '../proxy/proxy-manager.js';
+import type { IProxyManagerFactory } from '../factories/proxy-manager-factory.js';
+import type { ValidationResultCache } from '../utils/language-availability.js';
+
+/**
+ * The timing windows debug operations wait on. Held on the facade as protected
+ * fields (tests shrink them by assignment), read through here so a collaborator
+ * always sees the current value rather than a construction-time snapshot.
+ */
+export interface OperationsTunables {
+  readonly attachVerifyTimeoutMs: number;
+  readonly attachVerifyIntervalMs: number;
+  readonly attachPauseStopTimeoutMs: number;
+  readonly stepGraceMs: number;
+  readonly pauseGraceMs: number;
+}
+
+/**
+ * Everything the operation collaborators are allowed to reach for. Anything not
+ * listed here stays private to the facade.
+ */
+export interface OperationsContext {
+  readonly logger: ILogger;
+  readonly fileSystem: IFileSystem;
+  readonly adapterRegistry: IAdapterRegistry;
+  readonly proxyManagerFactory: IProxyManagerFactory;
+  readonly launchValidationCache: ValidationResultCache;
+  readonly logDirBase: string;
+  readonly defaultDapLaunchArgs: Partial<CustomLaunchRequestArguments>;
+  readonly dryRunTimeoutMs: number;
+  readonly tunables: OperationsTunables;
+
+  /** `_getSessionById` — throws SessionNotFoundError for an unknown id. */
+  getSession(sessionId: string): ManagedSession;
+  /** `sessionStore.update` — patch stored session fields. */
+  updateSession(sessionId: string, updates: Partial<ManagedSession>): void;
+  /** `_updateSessionState` — legacy state plus the derived dual-state overlay. */
+  updateState(session: ManagedSession, newState: SessionState): void;
+
+  /**
+   * The data layer's policy lookup: total, and overridable by tests.
+   * NOT interchangeable with `selectStorePolicy`.
+   */
+  selectPolicy(language: string | DebugLanguage): AdapterPolicy;
+  /**
+   * The session store's policy lookup, which THROWS for an unknown language.
+   * Distinct from `selectPolicy` on purpose: the launch-time function
+   * breakpoint warning has always read the store's, behind a try/catch.
+   */
+  selectStorePolicy(language: DebugLanguage): AdapterPolicy;
+
+  findFreePort(): Promise<number>;
+  setupProxyEventHandlers(
+    session: ManagedSession,
+    proxyManager: IProxyManager,
+    effectiveLaunchArgs: Partial<CustomLaunchRequestArguments>
+  ): void;
+  cleanupProxyEventHandlers(session: ManagedSession, proxyManager: IProxyManager): void;
+  stopProxyPreservingSession(session: ManagedSession): Promise<void>;
+  closeSession(sessionId: string): Promise<boolean>;
+  getStackTrace(
+    sessionId: string,
+    threadId?: number,
+    includeInternals?: boolean
+  ): Promise<StackFrame[]>;
+  redactionEnabled(): boolean;
+}
+
+/** Anchor re-resolution reads the file from disk and narrates what moved. */
+export type AnchorContext = Pick<OperationsContext, 'logger' | 'fileSystem'>;
+
+/** Breakpoint tooling: the store, the wire, and both policy sources. */
+export type BreakpointContext = Pick<
+  OperationsContext,
+  'logger' | 'fileSystem' | 'getSession' | 'selectPolicy' | 'selectStorePolicy'
+>;
+
+/** Stepping / continue / pause / threads. */
+export type ExecutionContext = Pick<
+  OperationsContext,
+  'logger' | 'getSession' | 'updateState' | 'getStackTrace' | 'tunables'
+>;
+
+/** Expression evaluation, including the redaction hook. */
+export type EvaluateContext = Pick<
+  OperationsContext,
+  'logger' | 'getSession' | 'selectPolicy' | 'redactionEnabled'
+>;
+
+/** JVM hot swap: a DAP round trip plus breakpoint re-planting. */
+export type HotSwapContext = Pick<OperationsContext, 'logger' | 'getSession'>;
+
+/** The read-only DAP mirror endpoint, whose record lives on the session. */
+export type MirrorContext = Pick<
+  OperationsContext,
+  'logger' | 'getSession' | 'updateSession'
+>;

--- a/src/session/operations-context.ts
+++ b/src/session/operations-context.ts
@@ -70,9 +70,13 @@ export interface OperationsContext {
    */
   selectPolicy(language: string | DebugLanguage): AdapterPolicy;
   /**
-   * The session store's policy lookup, which THROWS for an unknown language.
-   * Distinct from `selectPolicy` on purpose: the launch-time function
-   * breakpoint warning has always read the store's, behind a try/catch.
+   * The session store's policy lookup (`sessionStore.selectPolicy`). Both
+   * lookups resolve through `getPolicyForLanguage`, which falls back to the
+   * default policy rather than throwing — the distinction is the SEAM, not the
+   * result: tests override `selectPolicy` on the facade instance and may hand
+   * the store a double without `selectPolicy` at all, so every moved call keeps
+   * the source it always had (the launch-time function-breakpoint warning reads
+   * the store's, behind a try/catch).
    */
   selectStorePolicy(language: DebugLanguage): AdapterPolicy;
 
@@ -99,7 +103,7 @@ export type AnchorContext = Pick<OperationsContext, 'logger' | 'fileSystem'>;
 /** Breakpoint tooling: the store, the wire, and both policy sources. */
 export type BreakpointContext = Pick<
   OperationsContext,
-  'logger' | 'fileSystem' | 'getSession' | 'selectPolicy' | 'selectStorePolicy'
+  'logger' | 'getSession' | 'selectPolicy' | 'selectStorePolicy'
 >;
 
 /** Stepping / continue / pause / threads. */

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -8,10 +8,6 @@ import {
   SessionState,
   SessionLifecycleState,
   sanitizePayloadForLogging,
-  isSensitiveName,
-  redactVariableValue,
-  redactSecretsDeep,
-  buildRedactionNotice,
   type ExceptionBreakMode
 } from '@debugmcp/shared';
 import { ManagedSession, ToolchainValidationState } from './session-store.js';
@@ -26,11 +22,14 @@ import { SessionManagerData } from './session-manager-data.js';
 import type { OperationsContext } from './operations-context.js';
 import {
   resolveDapTimeoutOverride,
-  truncateForLog,
   withTimeoutHint
 } from './dap-request-helpers.js';
 import { BreakpointController } from './breakpoints/breakpoint-controller.js';
 import { ExecutionController } from './execution/execution-controller.js';
+import {
+  ExpressionEvaluator,
+  type EvaluateResult
+} from './inspection/expression-evaluator.js';
 import { reresolveAnchors } from './breakpoints/anchor-resolution.js';
 import {
   buildLogpointDowngradeLaunchWarning,
@@ -52,21 +51,8 @@ import {
 } from '../errors/debug-errors.js';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
 
-/**
- * Result type for evaluate expression operations
- */
-export interface EvaluateResult {
-  success: boolean;
-  result?: string;
-  type?: string;
-  variablesReference?: number;
-  namedVariables?: number;
-  indexedVariables?: number;
-  presentationHint?: DebugProtocol.VariablePresentationHint;
-  error?: string;
-  /** Present when secret-shaped content was masked in `result` (issue #237) */
-  redaction?: { rules: string[]; notice: string };
-}
+/** Result type for evaluate expression operations. */
+export type { EvaluateResult } from './inspection/expression-evaluator.js';
 
 export interface RedefineClassesResult {
   success: boolean;
@@ -246,6 +232,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   protected readonly opsContext: OperationsContext = this.buildOperationsContext();
   protected readonly breakpoints = new BreakpointController(this.opsContext);
   protected readonly execution = new ExecutionController(this.opsContext);
+  protected readonly evaluator = new ExpressionEvaluator(this.opsContext);
 
   protected async startProxyManager(
     session: ManagedSession,
@@ -1503,31 +1490,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   }
 
   /**
-   * The "variable name" an evaluate expression stands for, for name-based
-   * redaction (issue #237): the whole expression when it is itself a
-   * sensitive name, otherwise its final dot-segment — so `config.password`
-   * is treated like the variable `password`.
-   */
-  protected static expressionNameForRedaction(expression: string): string {
-    const trimmed = expression.trim();
-    if (isSensitiveName(trimmed)) {
-      return trimmed;
-    }
-    const lastDot = trimmed.lastIndexOf('.');
-    return lastDot >= 0 ? trimmed.slice(lastDot + 1) : trimmed;
-  }
-
-  /**
-   * Evaluate an expression in the context of the current debug session.
-   * The debugger must be paused for evaluation to work.
-   * Expressions CAN and SHOULD be able to modify program state (this is a feature).
-   *
-   * @param sessionId - The session ID
-   * @param expression - The expression to evaluate
-   * @param frameId - Optional stack frame ID for context (defaults to current frame)
-   * @param timeoutMs - Optional per-request timeout override (ms) for the DAP
-   *   evaluate request (default 30s, max 600000). Issue #142.
-   * @returns Evaluation result with value, type, and optional variable reference
+   * Evaluate an expression in the paused debuggee's frame.
    */
   async evaluateExpression(
     sessionId: string,
@@ -1535,215 +1498,8 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     frameId?: number,
     timeoutMs?: number
   ): Promise<EvaluateResult> {
-    const session = this._getSessionById(sessionId);
-    // Some debuggers (rdbg) reject the default 'variables' context; let the
-    // adapter policy pick the context its debugger understands.
-    const context = this.selectPolicy(session.language).getEvaluateContext?.() ?? 'variables';
-    this.logger.info(
-      `[SM evaluateExpression ${sessionId}] Entered. Expression: "${truncateForLog(
-        expression,
-        100
-      )}", frameId: ${frameId}, context: ${context}, state: ${session.state}`
-    );
-
-    // Basic sanity checks
-    if (!expression || expression.trim().length === 0) {
-      this.logger.warn(`[SM evaluateExpression ${sessionId}] Empty expression provided`);
-      return { success: false, error: 'Expression cannot be empty' };
-    }
-
-    const timeoutOverride = resolveDapTimeoutOverride(
-      timeoutMs,
-      `SM evaluateExpression ${sessionId}`,
-      this.logger
-    );
-    if (timeoutOverride.error) {
-      this.logger.warn(`[SM evaluateExpression ${sessionId}] ${timeoutOverride.error}`);
-      return { success: false, error: timeoutOverride.error };
-    }
-
-    // Validate session state
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      this.logger.warn(`[SM evaluateExpression ${sessionId}] No active proxy or proxy not running`);
-      return { success: false, error: 'No active debug session' };
-    }
-
-    if (session.state !== SessionState.PAUSED) {
-      this.logger.warn(
-        `[SM evaluateExpression ${sessionId}] Cannot evaluate: session not paused. State: ${session.state}`
-      );
-      return {
-        success: false,
-        error: 'Cannot evaluate: debugger not paused. Ensure the debugger is stopped at a breakpoint.',
-      };
-    }
-
-    // Handle frameId - get current frame from stack trace if not provided
-    if (frameId === undefined) {
-      try {
-        const threadId = session.proxyManager.getCurrentThreadId();
-        if (typeof threadId !== 'number') {
-          this.logger.warn(
-            `[SM evaluateExpression ${sessionId}] No current thread ID to get stack trace`
-          );
-          return {
-            success: false,
-            error: 'Unable to find thread for evaluation. Ensure the debugger is paused at a breakpoint.',
-          };
-        }
-
-        this.logger.info(
-          `[SM evaluateExpression ${sessionId}] No frameId provided, getting current frame from stack trace`
-        );
-        const stackResponse = await session.proxyManager.sendDapRequest<DebugProtocol.StackTraceResponse>(
-          'stackTrace',
-          {
-            threadId,
-            startFrame: 0,
-            levels: 1, // We only need the first frame
-          }
-        );
-
-        if (stackResponse?.body?.stackFrames && stackResponse.body.stackFrames.length > 0) {
-          frameId = stackResponse.body.stackFrames[0].id;
-          this.logger.info(
-            `[SM evaluateExpression ${sessionId}] Using current frame ID: ${frameId} from stack trace`
-          );
-        } else {
-          this.logger.warn(`[SM evaluateExpression ${sessionId}] No stack frames available`);
-          return {
-            success: false,
-            error: 'No active stack frame. Ensure the debugger is paused at a breakpoint.',
-          };
-        }
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        this.logger.error(
-          `[SM evaluateExpression ${sessionId}] Error getting stack trace for default frame:`,
-          error
-        );
-        return { success: false, error: `Unable to determine current frame: ${errorMessage}` };
-      }
-    }
-
-    try {
-      // Send DAP evaluate request
-      this.logger.info(
-        `[SM evaluateExpression ${sessionId}] Sending DAP 'evaluate' request. Expression: "${truncateForLog(
-          expression,
-          100
-        )}", frameId: ${frameId}, context: ${context}`
-      );
-
-      // Conditional 3-arg call: only pass options when an override is present,
-      // so the default path keeps its exact 2-arg contract.
-      const evaluateArgs = { expression, frameId, context };
-      const response = timeoutOverride.timeoutMs !== undefined
-        ? await session.proxyManager.sendDapRequest<DebugProtocol.EvaluateResponse>(
-            'evaluate', evaluateArgs, { timeoutMs: timeoutOverride.timeoutMs })
-        : await session.proxyManager.sendDapRequest<DebugProtocol.EvaluateResponse>(
-            'evaluate', evaluateArgs);
-
-      // Log raw response in debug mode — scrubbed, the raw body carries
-      // unredacted values (issue #237)
-      this.logger.debug(
-        `[SM evaluateExpression ${sessionId}] DAP evaluate raw response:`,
-        this.redactionEnabled() ? redactSecretsDeep(response).value : response
-      );
-
-      // Process response
-      if (response && response.body) {
-        const body = response.body;
-
-        // Note: debugpy automatically truncates collections at 300 items for performance
-        const result: EvaluateResult = {
-          success: true,
-          result: body.result || '', // Default to empty string if no result
-          type: body.type, // Optional, can be undefined
-          variablesReference: body.variablesReference || 0, // Default to 0 (no children)
-          namedVariables: body.namedVariables,
-          indexedVariables: body.indexedVariables,
-          presentationHint: body.presentationHint,
-        };
-
-        // Redaction hook (issue #237), placed above the logs below so they
-        // only ever see masked values. The expression's final dot-segment
-        // counts as the "variable name" so `config.password` is treated like
-        // the variable `password` would be.
-        if (this.redactionEnabled() && result.result) {
-          const redacted = redactVariableValue(
-            SessionManagerOperations.expressionNameForRedaction(expression),
-            result.result
-          );
-          if (redacted.redacted) {
-            result.result = redacted.value;
-            result.redaction = {
-              rules: redacted.hits.map(hit => hit.ruleId),
-              notice: buildRedactionNotice(redacted.hits)
-            };
-          }
-        }
-
-        // Log the evaluation result with structured logging
-        this.logger.info('debug:evaluate', {
-          event: 'expression',
-          sessionId,
-          sessionName: session.name,
-          expression: truncateForLog(expression, 100),
-          frameId,
-          context,
-          result: truncateForLog(result.result || '', 1000),
-          type: result.type,
-          variablesReference: result.variablesReference,
-          namedVariables: result.namedVariables,
-          indexedVariables: result.indexedVariables,
-          timestamp: Date.now(),
-        });
-
-        this.logger.info(
-          `[SM evaluateExpression ${sessionId}] Evaluation successful. Result: "${truncateForLog(
-            result.result || '',
-            200
-          )}", Type: ${result.type}, VarRef: ${result.variablesReference}`
-        );
-
-        return result;
-      } else {
-        this.logger.warn(`[SM evaluateExpression ${sessionId}] No body in evaluate response`);
-        return { success: false, error: 'No response body from debug adapter' };
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-
-      // Log the error
-      this.logger.error('debug:evaluate', {
-        event: 'error',
-        sessionId,
-        sessionName: session.name,
-        expression: truncateForLog(expression, 100),
-        frameId,
-        context,
-        error: errorMessage,
-        timestamp: Date.now(),
-      });
-
-      this.logger.error(`[SM evaluateExpression ${sessionId}] Error evaluating expression:`, error);
-
-      // Determine error type for better user feedback
-      let userError = errorMessage;
-      if (errorMessage.includes('SyntaxError')) {
-        userError = `Syntax error in expression: ${errorMessage}`;
-      } else if (errorMessage.includes('NameError')) {
-        userError = `Name not found: ${errorMessage}`;
-      } else if (errorMessage.includes('TypeError')) {
-        userError = `Type error: ${errorMessage}`;
-      } else if (errorMessage.includes('frame')) {
-        userError = `Invalid frame context: ${errorMessage}`;
-      }
-
-      return { success: false, error: withTimeoutHint(userError) };
+    return this.evaluator.evaluateExpression(sessionId, expression, frameId, timeoutMs);
   }
-}
 
   /**
    * Attach to a running process for debugging

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -2,21 +2,17 @@
  * Debug operations for session management including starting, stepping,
  * continuing, and breakpoint management.
  */
-import { v4 as uuidv4 } from 'uuid';
 import {
   Breakpoint,
   FunctionBreakpoint,
   SessionState,
   SessionLifecycleState,
   sanitizePayloadForLogging,
-  toSourceBreakpoint,
-  toFunctionBreakpoint,
   isSensitiveName,
   redactVariableValue,
   redactSecretsDeep,
   buildRedactionNotice,
   NO_DEBUG_TARGET_MARKER,
-  type AdapterPolicy,
   type ExceptionBreakMode
 } from '@debugmcp/shared';
 import { ManagedSession, ToolchainValidationState } from './session-store.js';
@@ -27,15 +23,19 @@ import { MIRROR_EXPOSE_COMMAND, MIRROR_UNEXPOSE_COMMAND } from '../proxy/dap-pro
 import { ErrorMessages } from '../utils/error-messages.js';
 import { checkLaunchToolchain } from '../utils/language-availability.js';
 import { didYouMean } from '../utils/did-you-mean.js';
-import { resolveStatement } from '../utils/breakpoint-resolver.js';
-import { normalizeBreakpointMessage } from '../utils/breakpoint-message.js';
-import { consumeChildSourced } from '../utils/child-origin-events.js';
 import { SessionManagerData } from './session-manager-data.js';
+import type { OperationsContext } from './operations-context.js';
 import {
   resolveDapTimeoutOverride,
   truncateForLog,
   withTimeoutHint
 } from './dap-request-helpers.js';
+import { BreakpointController } from './breakpoints/breakpoint-controller.js';
+import { reresolveAnchors } from './breakpoints/anchor-resolution.js';
+import {
+  buildLogpointDowngradeLaunchWarning,
+  buildUnboundBreakpointExitWarning
+} from './breakpoints/launch-warnings.js';
 import { AdapterLease } from '../adapters/adapter-lease.js';
 import { logProxyFailure } from './launch/proxy-failure-diagnostics.js';
 import { CustomLaunchRequestArguments, DebugResult } from './session-manager-core.js';
@@ -193,6 +193,60 @@ export abstract class SessionManagerOperations extends SessionManagerData {
    */
   protected stepGraceMs = 5000;
   protected pauseGraceMs = 5000;
+
+  /**
+   * The view of this facade that the operation collaborators get. Every member
+   * is late bound (arrows for methods, getters for fields and tunables) so that
+   * reassigning `selectPolicy` or writing `stepGraceMs` on a live instance —
+   * which the tests do — is seen by the collaborators too.
+   */
+  protected buildOperationsContext(): OperationsContext {
+    // An arrow rather than a `this` alias, so each getter below resolves the
+    // facade when it is read instead of closing over a snapshot.
+    const facade = () => this;
+    return {
+      get logger() { return facade().logger; },
+      get fileSystem() { return facade().fileSystem; },
+      get adapterRegistry() { return facade().adapterRegistry; },
+      get proxyManagerFactory() { return facade().proxyManagerFactory; },
+      get launchValidationCache() { return facade().launchValidationCache; },
+      get logDirBase() { return facade().logDirBase; },
+      get defaultDapLaunchArgs() { return facade().defaultDapLaunchArgs; },
+      get dryRunTimeoutMs() { return facade().dryRunTimeoutMs; },
+      tunables: {
+        get attachVerifyTimeoutMs() { return facade().attachVerifyTimeoutMs; },
+        get attachVerifyIntervalMs() { return facade().attachVerifyIntervalMs; },
+        get attachPauseStopTimeoutMs() { return facade().attachPauseStopTimeoutMs; },
+        get stepGraceMs() { return facade().stepGraceMs; },
+        get pauseGraceMs() { return facade().pauseGraceMs; }
+      },
+      getSession: (sessionId) => this._getSessionById(sessionId),
+      updateSession: (sessionId, updates) => this.sessionStore.update(sessionId, updates),
+      updateState: (session, newState) => this._updateSessionState(session, newState),
+      selectPolicy: (language) => this.selectPolicy(language),
+      selectStorePolicy: (language) => this.sessionStore.selectPolicy(language),
+      findFreePort: () => this.findFreePort(),
+      setupProxyEventHandlers: (session, proxyManager, effectiveLaunchArgs) =>
+        this.setupProxyEventHandlers(session, proxyManager, effectiveLaunchArgs),
+      cleanupProxyEventHandlers: (session, proxyManager) =>
+        this.cleanupProxyEventHandlers(session, proxyManager),
+      stopProxyPreservingSession: (session) => this.stopProxyPreservingSession(session),
+      closeSession: (sessionId) => this.closeSession(sessionId),
+      getStackTrace: (sessionId, threadId, includeInternals) =>
+        this.getStackTrace(sessionId, threadId, includeInternals),
+      redactionEnabled: () => this.redactionEnabled()
+    };
+  }
+
+  /**
+   * The collaborators the debug operations are split across. Field
+   * initializers rather than constructor wiring: they carry no state of their
+   * own beyond the context, so there is nothing to sequence. Call sites always
+   * go through the field (`this.breakpoints.syncBreakpointsForFile(...)`) and
+   * never capture a method off it, so a test can spy on any of them.
+   */
+  protected readonly opsContext: OperationsContext = this.buildOperationsContext();
+  protected readonly breakpoints = new BreakpointController(this.opsContext);
 
   protected async startProxyManager(
     session: ManagedSession,
@@ -1110,14 +1164,14 @@ export abstract class SessionManagerOperations extends SessionManagerData {
           (finalState === SessionState.RUNNING || finalState === SessionState.PAUSED)) {
         const files = [...new Set(Array.from(finalSession.breakpoints.values()).map(bp => bp.file))];
         for (const file of files) {
-          await this.syncBreakpointsForFile(finalSession, file);
+          await this.breakpoints.syncBreakpointsForFile(finalSession, file);
         }
       }
       // Same re-sync for function breakpoints (issue #271 phase 3): the
       // worker's initial send's responses never reach this store either.
       if ((finalSession.functionBreakpoints?.size ?? 0) > 0 &&
           (finalState === SessionState.RUNNING || finalState === SessionState.PAUSED)) {
-        await this.syncFunctionBreakpoints(finalSession);
+        await this.breakpoints.syncFunctionBreakpoints(finalSession);
       }
 
       // Unbound-at-launch warning (issue #308): the verified state is fresh
@@ -1125,7 +1179,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       // reported here instead of failing silently at "the program never
       // stopped". Suppressed for bind-late adapters (js/java), where
       // unverified-at-launch is the designed deferral path.
-      const fnBpWarning = this.buildFunctionBreakpointLaunchWarning(finalSession);
+      const fnBpWarning = this.breakpoints.functionBreakpointLaunchWarning(finalSession);
 
       // Ran-to-completion with breakpoints that never bound (issue #467):
       // state "stopped" where the caller expected "paused" is only
@@ -1133,12 +1187,12 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       // per-breakpoint diagnostics right here where the caller is looking.
       const unboundAtExitWarning =
         finalState === SessionState.STOPPED
-          ? this.buildUnboundBreakpointExitWarning(finalSession)
+          ? buildUnboundBreakpointExitWarning(finalSession)
           : undefined;
 
       // Logpoint-downgrade verdict (issue #469): the deferred set_breakpoint
       // warning promised a launch-time answer — deliver it on this response.
-      const logpointWarning = this.buildLogpointDowngradeLaunchWarning(finalSession);
+      const logpointWarning = buildLogpointDowngradeLaunchWarning(finalSession);
 
       // Adapter degradation notes (issue #441) accumulate on the session as
       // annotated output events arrive; joining here is best-effort — a note
@@ -1293,7 +1347,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       // Content anchors re-resolve BEFORE the relaunch snapshots
       // initialBreakpoints, so breakpoints survive the edit that was the
       // point of the session (issue #271).
-      const anchorResolution = await this.reresolveAnchors(session);
+      const anchorResolution = await reresolveAnchors(session, this.opsContext);
 
       const spec = session.lastLaunch;
       this.logger.info(
@@ -1350,101 +1404,9 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   }
 
   /**
-   * Re-resolve statement-anchored breakpoints against the current file
-   * contents (fresh read — deliberately not the server's LineReader cache).
-   * The breakpoint's current line doubles as the nearLine hint so duplicate
-   * statements re-anchor to the nearest occurrence of where the breakpoint
-   * last was. Anchors that no longer match keep their stale line and warn:
-   * failing the restart would block the edit-relaunch loop, and dropping the
-   * breakpoint would destroy user state (issue #271).
+   * Set a line breakpoint. Delegates to the breakpoint controller, which owns
+   * the store and the DAP re-send.
    */
-  private async reresolveAnchors(session: ManagedSession): Promise<
-    | {
-        moved: Array<{ breakpointId: string; file: string; from: number; to: number; statement: string; candidates?: number[] }>;
-        stale: Array<{ breakpointId: string; file: string; line: number; statement: string; reason: string }>;
-      }
-    | undefined
-  > {
-    const anchored = Array.from(session.breakpoints.values()).filter(
-      (bp): bp is Breakpoint & { anchor: { statement: string; nearLine?: number } } => bp.anchor !== undefined
-    );
-    if (anchored.length === 0) {
-      return undefined;
-    }
-
-    const moved: Array<{ breakpointId: string; file: string; from: number; to: number; statement: string; candidates?: number[] }> = [];
-    const stale: Array<{ breakpointId: string; file: string; line: number; statement: string; reason: string }> = [];
-
-    const byFile = new Map<string, typeof anchored>();
-    for (const bp of anchored) {
-      const group = byFile.get(bp.file);
-      if (group) {
-        group.push(bp);
-      } else {
-        byFile.set(bp.file, [bp]);
-      }
-    }
-
-    for (const [file, bps] of byFile) {
-      let lines: string[] | null = null;
-      try {
-        const content = await this.fileSystem.readFile(file, 'utf8');
-        lines = content.split(/\r?\n/);
-      } catch (error) {
-        this.logger.warn(
-          `[SessionManager] Could not re-read ${file} for anchor re-resolution: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
-      }
-
-      for (const bp of bps) {
-        if (!lines) {
-          stale.push({
-            breakpointId: bp.id,
-            file,
-            line: bp.line,
-            statement: bp.anchor.statement,
-            reason: 'file unreadable',
-          });
-          continue;
-        }
-        const resolution = resolveStatement(lines, bp.anchor.statement, file, bp.line);
-        if (resolution.ok) {
-          if (resolution.line !== bp.line) {
-            moved.push({
-              breakpointId: bp.id,
-              file,
-              from: bp.line,
-              to: resolution.line,
-              statement: bp.anchor.statement,
-              // The bp's old line doubles as nearLine here, so the ambiguity
-              // error can never fire on this path — a multi-match proximity
-              // pick must be flagged instead of passing as unambiguous
-              // (issue #379).
-              ...(resolution.candidates !== undefined ? { candidates: resolution.candidates } : {}),
-            });
-            this.logger.info(
-              `[SessionManager] Anchor re-resolved: breakpoint ${bp.id} moved ${bp.line} -> ${resolution.line} ("${bp.anchor.statement}")`
-            );
-            bp.line = resolution.line;
-            bp.requestedLine = resolution.line;
-          }
-        } else {
-          stale.push({
-            breakpointId: bp.id,
-            file,
-            line: bp.line,
-            statement: bp.anchor.statement,
-            reason: 'statement not found',
-          });
-        }
-      }
-    }
-
-    return { moved, stale };
-  }
-
   async setBreakpoint(
     sessionId: string,
     bp: {
@@ -1461,190 +1423,11 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       anchor?: { statement: string; nearLine?: number };
     }
   ): Promise<{ breakpoint: Breakpoint; warning?: string }> {
-    const session = this._getSessionById(sessionId);
-
-    // Check if session is terminated
-    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
-      throw new SessionTerminatedError(sessionId);
-    }
-
-    const bpId = uuidv4();
-
-    this.logger.info(
-      `[SessionManager setBreakpoint] Using validated file path "${bp.file}" for session ${sessionId}`
-    );
-
-    const newBreakpoint: Breakpoint = {
-      id: bpId,
-      file: bp.file,
-      line: bp.line,
-      condition: bp.condition,
-      suspendPolicy: bp.suspendPolicy,
-      logMessage: bp.logMessage,
-      verified: false
-    };
-    if (bp.requestedLine !== undefined) {
-      newBreakpoint.requestedLine = bp.requestedLine;
-    }
-    if (bp.anchor !== undefined) {
-      newBreakpoint.anchor = bp.anchor;
-    }
-
-    if (!session.breakpoints) session.breakpoints = new Map();
-    session.breakpoints.set(bpId, newBreakpoint);
-    this.logger.info(
-      `[SessionManager] Breakpoint ${bpId} queued for ${bp.file}:${bp.line} in session ${sessionId}.`
-    );
-
-    const sync = await this.syncBreakpointsForFile(session, bp.file);
-    return { breakpoint: newBreakpoint, warning: sync.warning };
-  }
-
-  /**
-   * Re-send the session's full breakpoint set for one file to the adapter
-   * (DAP setBreakpoints is replace-all per file) and merge the response back
-   * into the stored breakpoints (positional match). No-op unless the proxy is
-   * live and the session is RUNNING or PAUSED. Never throws: a DAP failure is
-   * logged and reported via `warning` — the store remains the source of truth
-   * and the set is re-applied on the next launch.
-   */
-  protected async syncBreakpointsForFile(
-    session: ManagedSession,
-    file: string,
-    options?: { forceFreshEcho?: boolean }
-  ): Promise<{ synced: boolean; warning?: string }> {
-    const sessionId = session.id;
-    if (
-      !session.proxyManager ||
-      !session.proxyManager.isRunning() ||
-      (session.state !== SessionState.RUNNING && session.state !== SessionState.PAUSED)
-    ) {
-      return { synced: false };
-    }
-
-    // Collect ALL breakpoints for this source file (DAP setBreakpoints is replace-all)
-    const allBpsForFile = Array.from(session.breakpoints.values())
-      .filter(bp => bp.file === file);
-
-    try {
-      this.logger.info(
-        `[SessionManager] Active proxy for session ${sessionId}, sending ${allBpsForFile.length} breakpoint(s) for ${file}.`
-      );
-      const response =
-        await session.proxyManager.sendDapRequest<DebugProtocol.SetBreakpointsResponse>(
-          'setBreakpoints',
-          {
-            source: { path: file },
-            breakpoints: allBpsForFile.map(toSourceBreakpoint),
-            // Reserved key, stripped by the proxy before the adapter sees
-            // it: asks a child-mirroring proxy for an authoritative echo
-            // even when the set is unchanged (issue #500).
-            ...(options?.forceFreshEcho === true ? { __mcpForceFreshEcho: true } : {}),
-          }
-        );
-      if (
-        response &&
-        response.body &&
-        response.body.breakpoints
-      ) {
-        const responseBps = response.body.breakpoints;
-        // For child-mirroring adapters (js-debug), setBreakpoints responses
-        // come from the parent session, which owns no runtime: its verified
-        // flags are pessimistic and its ids belong to a different id space
-        // than the child events that carry the real verification. Treat the
-        // child as authoritative — never let a parent response downgrade
-        // verified state or clobber child adapter ids.
-        const childAuthoritative =
-          !!this.selectPolicy(session.language)?.getDapClientBehavior?.().mirrorBreakpointsToChild;
-        // A response the proxy marked child-sourced (issue #500) carries the
-        // child session's own answer — the authoritative one — so it stamps
-        // fully instead of upgrade-only.
-        const childSourced = consumeChildSourced(response);
-        // Update ALL breakpoints from response (positional match)
-        for (let i = 0; i < Math.min(responseBps.length, allBpsForFile.length); i++) {
-          const bpInfo = responseBps[i];
-          const keepChildState =
-            childAuthoritative && !childSourced && allBpsForFile[i].verified === true;
-          if (childAuthoritative && childSourced) {
-            allBpsForFile[i].verified = bpInfo.verified;
-            // Only a VERIFIED child id enters the store: stub ids are
-            // unstable across the pending→bound transition (issue #495).
-            if (bpInfo.verified === true && typeof bpInfo.id === 'number') {
-              allBpsForFile[i].adapterId = bpInfo.id;
-            }
-          } else if (childAuthoritative) {
-            allBpsForFile[i].verified = allBpsForFile[i].verified || bpInfo.verified;
-          } else {
-            allBpsForFile[i].verified = bpInfo.verified;
-            allBpsForFile[i].adapterId = bpInfo.id ?? allBpsForFile[i].adapterId;
-          }
-          allBpsForFile[i].line = bpInfo.line || allBpsForFile[i].line;
-          if (!keepChildState) {
-            // Normalize before storing (issue #471): raw l10n keys like
-            // js-debug's "breakpoint.provisionalBreakpoint" must never sit in
-            // the store, and a provisional note must not survive verification.
-            allBpsForFile[i].message = normalizeBreakpointMessage(
-              bpInfo.message,
-              allBpsForFile[i].verified
-            );
-          }
-          // Enhance "no symbols" message for .NET with PDB format guidance
-          if (bpInfo.message && session.language === 'dotnet' &&
-              bpInfo.message.toLowerCase().includes('no symbols')) {
-            allBpsForFile[i].message += ' (Hint: netcoredbg requires Portable PDB format. Compile with /debug:portable or convert with Pdb2Pdb.)';
-          }
-          this.logger.info(
-            `[SessionManager] Breakpoint ${allBpsForFile[i].id} response received. Verified: ${allBpsForFile[i].verified}${
-              bpInfo.message ? `, Message: ${bpInfo.message}` : ''
-            }`
-          );
-
-          // Log breakpoint verification with structured logging
-          if (allBpsForFile[i].verified) {
-            this.logger.info('debug:breakpoint', {
-              event: 'verified',
-              sessionId: sessionId,
-              sessionName: session.name,
-              breakpointId: allBpsForFile[i].id,
-              file: allBpsForFile[i].file,
-              line: allBpsForFile[i].line,
-              verified: true,
-              timestamp: Date.now(),
-            });
-          }
-        }
-      }
-      return { synced: true };
-    } catch (error) {
-      this.logger.error(
-        `[SessionManager] Error sending setBreakpoints to proxy for session ${sessionId}:`,
-        error
-      );
-      const message = error instanceof Error ? error.message : String(error);
-      return { synced: false, warning: this.buildLiveSyncWarning(session, message) };
-    }
-  }
-
-  /**
-   * Compose the live-sync failure warning. For ruby attach sessions whose
-   * error is rdbg's "<path> is not available", append topology guidance
-   * (issue #357): the path was rejected on the debug TARGET's filesystem
-   * (e.g. container server + host rdbg, or vice versa) — expected behavior,
-   * not a debugger fault. Same hint-append style as the netcoredbg
-   * no-symbols guidance above.
-   */
-  private buildLiveSyncWarning(session: ManagedSession, message: string): string {
-    let warning = `Breakpoint state updated, but live sync failed: ${message}`;
-    if (session.attachMode && session.language === 'ruby' && /is not available/.test(message)) {
-      warning += ' (Hint: attach sessions send breakpoint paths to the remote debugger verbatim; the path must be valid on the debug target\'s filesystem. Use target-side paths, or pass localfsMap in the attach config to map local paths to remote ones.)';
-    }
-    return warning;
+    return this.breakpoints.setBreakpoint(sessionId, bp);
   }
 
   /**
    * Set a function (symbol-addressed) breakpoint (issue #271 phase 3).
-   * Session-global — no file. Queued like line breakpoints when no debuggee
-   * is live; synced immediately otherwise.
    */
   async setFunctionBreakpoint(
     sessionId: string,
@@ -1653,330 +1436,38 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       condition?: string;
     }
   ): Promise<{ breakpoint: FunctionBreakpoint; warning?: string }> {
-    const session = this._getSessionById(sessionId);
-
-    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
-      throw new SessionTerminatedError(sessionId);
-    }
-
-    const newBreakpoint: FunctionBreakpoint = {
-      id: uuidv4(),
-      functionName: bp.functionName,
-      condition: bp.condition,
-      verified: false
-    };
-
-    if (!session.functionBreakpoints) session.functionBreakpoints = new Map();
-    session.functionBreakpoints.set(newBreakpoint.id, newBreakpoint);
-    this.logger.info(
-      `[SessionManager] Function breakpoint ${newBreakpoint.id} queued for ${bp.functionName} in session ${sessionId}.`
-    );
-
-    const sync = await this.syncFunctionBreakpoints(session);
-    return { breakpoint: newBreakpoint, warning: sync.warning };
-  }
-
-  /**
-   * Re-send the session's FULL function-breakpoint set to the adapter (DAP
-   * setFunctionBreakpoints is replace-all for the whole session, not per
-   * file). Same live-session guard and never-throws contract as
-   * syncBreakpointsForFile.
-   */
-  protected async syncFunctionBreakpoints(
-    session: ManagedSession
-  ): Promise<{ synced: boolean; warning?: string }> {
-    const sessionId = session.id;
-    if (
-      !session.proxyManager ||
-      !session.proxyManager.isRunning() ||
-      (session.state !== SessionState.RUNNING && session.state !== SessionState.PAUSED)
-    ) {
-      return { synced: false };
-    }
-
-    const allFnBps = Array.from(session.functionBreakpoints.values());
-
-    try {
-      this.logger.info(
-        `[SessionManager] Active proxy for session ${sessionId}, sending ${allFnBps.length} function breakpoint(s).`
-      );
-      const response =
-        await session.proxyManager.sendDapRequest<DebugProtocol.SetFunctionBreakpointsResponse>(
-          'setFunctionBreakpoints',
-          { breakpoints: allFnBps.map(toFunctionBreakpoint) }
-        );
-      const responseBps = response?.body?.breakpoints;
-      if (responseBps) {
-        // Positional match, same DAP guarantee as setBreakpoints
-        for (let i = 0; i < Math.min(responseBps.length, allFnBps.length); i++) {
-          const bpInfo = responseBps[i];
-          allFnBps[i].verified = bpInfo.verified;
-          allFnBps[i].adapterId = bpInfo.id ?? allFnBps[i].adapterId;
-          allFnBps[i].message = bpInfo.message;
-          if (typeof bpInfo.line === 'number') {
-            allFnBps[i].boundLine = bpInfo.line;
-          }
-          if (bpInfo.source?.path) {
-            allFnBps[i].boundFile = bpInfo.source.path;
-          }
-          if (allFnBps[i].verified) {
-            this.logger.info('debug:breakpoint', {
-              event: 'verified',
-              sessionId,
-              sessionName: session.name,
-              breakpointId: allFnBps[i].id,
-              functionName: allFnBps[i].functionName,
-              line: allFnBps[i].boundLine,
-              verified: true,
-              timestamp: Date.now(),
-            });
-          }
-        }
-      }
-      return { synced: true };
-    } catch (error) {
-      this.logger.error(
-        `[SessionManager] Error sending setFunctionBreakpoints to proxy for session ${sessionId}:`,
-        error
-      );
-      const message = error instanceof Error ? error.message : String(error);
-      return { synced: false, warning: this.buildLiveSyncWarning(session, message) };
-    }
-  }
-
-  /**
-   * Launch-time unbound-function-breakpoint warning (issue #308). Called
-   * after the post-launch re-sync, when verified state is fresh. Returns
-   * undefined for bind-late policies (js/java) — unverified-at-launch is
-   * their designed deferral, not a failure.
-   */
-  /**
-   * Ran-to-completion unbound-breakpoint warning (issue #467). Built only
-   * when the launch ends in STOPPED: at that point an unverified breakpoint
-   * never bound and never will, for bind-late adapters too — so this is a
-   * zero-false-positive moment to surface the per-breakpoint diagnostics the
-   * store already holds (e.g. the path-remap suggestion CodeLLDB puts in
-   * `message`).
-   */
-  protected buildUnboundBreakpointExitWarning(session: ManagedSession): string | undefined {
-    const unbound = Array.from(session.breakpoints.values()).filter(bp => !bp.verified);
-    if (unbound.length === 0) {
-      return undefined;
-    }
-    const parts = unbound.map(bp => {
-      // Some stamp paths store the raw js-debug l10n key — translate it
-      // rather than showing 'breakpoint.provisionalBreakpoint' (issue #471).
-      const message = normalizeBreakpointMessage(bp.message, bp.verified);
-      return `${path.basename(bp.file)}:${bp.line}${message ? ` (${message})` : ''}`;
-    });
-    return (
-      `${unbound.length} breakpoint(s) never bound during this run: ${parts.join('; ')}. ` +
-      `The program ran to completion without stopping there — check the file path and line, ` +
-      `or list_breakpoints for the full per-breakpoint state`
-    );
-  }
-
-  /**
-   * Launch-time logpoint-downgrade warning (issue #469). A logpoint accepted
-   * pre-launch under unknown policy support ("it will be validated against
-   * the adapter's capabilities at launch") gets its promised verdict here:
-   * when the live adapter does not advertise supportsLogPoints, the logpoint
-   * has been silently downgraded to a pausing breakpoint — say so in the
-   * start_debugging response instead of only in the server log.
-   */
-  protected buildLogpointDowngradeLaunchWarning(session: ManagedSession): string | undefined {
-    const caps = session.adapterCapabilities;
-    if (!caps || caps.supportsLogPoints === true) {
-      return undefined;
-    }
-    const downgraded: string[] = [];
-    for (const bp of session.breakpoints.values()) {
-      if (bp.logMessage !== undefined) {
-        downgraded.push(`${path.basename(bp.file)}:${bp.line}`);
-      }
-    }
-    if (downgraded.length === 0) {
-      return undefined;
-    }
-    return (
-      `Logpoint(s) at ${downgraded.join(', ')} were downgraded to pausing breakpoints: ` +
-      `the ${session.language} adapter does not advertise supportsLogPoints, so the ` +
-      `logMessage will not be logged and the program will PAUSE at those lines instead ` +
-      `of running through them`
-    );
-  }
-
-  protected buildFunctionBreakpointLaunchWarning(session: ManagedSession): string | undefined {
-    if ((session.functionBreakpoints?.size ?? 0) === 0) {
-      return undefined;
-    }
-    let policy: AdapterPolicy | undefined;
-    try {
-      policy = this.sessionStore.selectPolicy(session.language);
-    } catch {
-      policy = undefined;
-    }
-    if (policy?.functionBreakpointsBindLate === true) {
-      return undefined;
-    }
-    const parts: string[] = [];
-    for (const bp of session.functionBreakpoints.values()) {
-      if (bp.verified) {
-        continue;
-      }
-      const hint = policy?.functionBreakpointNameHint?.(bp.functionName) ?? bp.message;
-      parts.push(`'${bp.functionName}'${hint ? ` (${hint})` : ''}`);
-    }
-    if (parts.length === 0) {
-      return undefined;
-    }
-    return (
-      `Function breakpoint(s) not bound at launch: ${parts.join('; ')}. ` +
-      `The adapter could not resolve the name, so the program will not stop there — ` +
-      `check the symbol name; list_breakpoints shows the current state`
-    );
+    return this.breakpoints.setFunctionBreakpoint(sessionId, bp);
   }
 
   /**
    * Remove one breakpoint by its id (the id returned by setBreakpoint).
-   * The removal always takes effect in the session's breakpoint store; if the
-   * debuggee is live the file's remaining set is re-sent immediately.
-   * Deliberately works after the debuggee exits — the surviving set is
-   * re-applied on the next launch. Checks line and function breakpoints
-   * alike (shared UUID namespace).
    */
   async removeBreakpoint(
     sessionId: string,
     breakpointId: string
   ): Promise<{ removed?: Breakpoint | FunctionBreakpoint; warning?: string }> {
-    const session = this._getSessionById(sessionId);
-
-    const functionBreakpoint = session.functionBreakpoints?.get(breakpointId);
-    if (functionBreakpoint) {
-      session.functionBreakpoints.delete(breakpointId);
-      this.logger.info('debug:breakpoint', {
-        event: 'removed',
-        sessionId,
-        sessionName: session.name,
-        breakpointId,
-        functionName: functionBreakpoint.functionName,
-        timestamp: Date.now(),
-      });
-      const { warning } = await this.syncFunctionBreakpoints(session);
-      return { removed: functionBreakpoint, warning };
-    }
-
-    const breakpoint = session.breakpoints.get(breakpointId);
-    if (!breakpoint) {
-      return { removed: undefined };
-    }
-
-    session.breakpoints.delete(breakpointId);
-    this.logger.info('debug:breakpoint', {
-      event: 'removed',
-      sessionId,
-      sessionName: session.name,
-      breakpointId,
-      file: breakpoint.file,
-      line: breakpoint.line,
-      timestamp: Date.now(),
-    });
-
-    const { warning } = await this.syncBreakpointsForFile(session, breakpoint.file);
-    return { removed: breakpoint, warning };
+    return this.breakpoints.removeBreakpoint(sessionId, breakpointId);
   }
 
   /**
-   * Remove ALL breakpoints at a file:line location (duplicates at one line —
-   * e.g. with different conditions — are removed together; DAP replace-all
-   * semantics cannot distinguish them anyway). Same lifecycle behavior as
-   * removeBreakpoint.
+   * Remove ALL breakpoints at a file:line location.
    */
   async removeBreakpointsByLocation(
     sessionId: string,
     file: string,
     line: number
   ): Promise<{ removed: Breakpoint[]; warning?: string }> {
-    const session = this._getSessionById(sessionId);
-
-    const removed = Array.from(session.breakpoints.values())
-      .filter(bp => bp.file === file && bp.line === line);
-    if (removed.length === 0) {
-      return { removed: [] };
-    }
-
-    for (const bp of removed) {
-      session.breakpoints.delete(bp.id);
-      this.logger.info('debug:breakpoint', {
-        event: 'removed',
-        sessionId,
-        sessionName: session.name,
-        breakpointId: bp.id,
-        file: bp.file,
-        line: bp.line,
-        timestamp: Date.now(),
-      });
-    }
-
-    const { warning } = await this.syncBreakpointsForFile(session, file);
-    return { removed, warning };
+    return this.breakpoints.removeBreakpointsByLocation(sessionId, file, line);
   }
 
   /**
    * Remove all of the session's breakpoints, or all breakpoints in one file.
-   * Clearing zero breakpoints is success, not an error. Works in every
-   * lifecycle state; live sessions get one empty/remaining setBreakpoints
-   * re-send per affected file.
    */
   async clearBreakpoints(
     sessionId: string,
     file?: string
   ): Promise<{ cleared: number; files: string[]; warning?: string }> {
-    const session = this._getSessionById(sessionId);
-
-    const toClear = Array.from(session.breakpoints.values())
-      .filter(bp => file === undefined || bp.file === file);
-    const files = [...new Set(toClear.map(bp => bp.file))];
-
-    // Function breakpoints are not file-scoped: only an unscoped clear
-    // touches them (issue #271 phase 3).
-    const fnToClear = file === undefined
-      ? Array.from(session.functionBreakpoints?.values() ?? [])
-      : [];
-
-    for (const bp of toClear) {
-      session.breakpoints.delete(bp.id);
-    }
-    for (const bp of fnToClear) {
-      session.functionBreakpoints.delete(bp.id);
-    }
-    if (toClear.length > 0 || fnToClear.length > 0) {
-      this.logger.info('debug:breakpoint', {
-        event: 'cleared',
-        sessionId,
-        sessionName: session.name,
-        cleared: toClear.length + fnToClear.length,
-        files,
-        functionBreakpoints: fnToClear.length,
-        timestamp: Date.now(),
-      });
-    }
-
-    const warnings: string[] = [];
-    for (const clearedFile of files) {
-      const { warning } = await this.syncBreakpointsForFile(session, clearedFile);
-      if (warning) warnings.push(warning);
-    }
-    if (fnToClear.length > 0) {
-      const { warning } = await this.syncFunctionBreakpoints(session);
-      if (warning) warnings.push(warning);
-    }
-
-    return {
-      cleared: toClear.length + fnToClear.length,
-      files,
-      ...(warnings.length > 0 ? { warning: warnings.join('; ') } : {})
-    };
+    return this.breakpoints.clearBreakpoints(sessionId, file);
   }
 
   async stepOver(sessionId: string): Promise<DebugResult> {
@@ -3111,16 +2602,16 @@ export abstract class SessionManagerOperations extends SessionManagerData {
           // empty echo, and pre-attach breakpoints were already registered
           // via its pending-target queue — without a fresh echo their
           // verified state is unrecoverable (issue #500).
-          await this.syncBreakpointsForFile(session, file, { forceFreshEcho: true });
+          await this.breakpoints.syncBreakpointsForFile(session, file, { forceFreshEcho: true });
         }
       }
       if ((session.functionBreakpoints?.size ?? 0) > 0) {
-        await this.syncFunctionBreakpoints(session);
+        await this.breakpoints.syncFunctionBreakpoints(session);
       }
       // Unverified-at-attach function breakpoints get the same launch-style
       // warning (issue #308); bind-late adapters (js/java) stay suppressed
       // inside the builder.
-      const attachFnBpWarning = this.buildFunctionBreakpointLaunchWarning(session);
+      const attachFnBpWarning = this.breakpoints.functionBreakpointLaunchWarning(session);
 
       const attachData: Record<string, unknown> = {
         message: attachConfig.processId
@@ -3333,11 +2824,11 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       let anchorResolution: RedefineClassesResult['anchorResolution'];
       const syncWarnings: string[] = [];
       if ((body.redefinedCount ?? 0) > 0) {
-        anchorResolution = await this.reresolveAnchors(session);
+        anchorResolution = await reresolveAnchors(session, this.opsContext);
         if (anchorResolution && anchorResolution.moved.length > 0) {
           const movedFiles = [...new Set(anchorResolution.moved.map(m => m.file))];
           for (const file of movedFiles) {
-            const { warning } = await this.syncBreakpointsForFile(session, file);
+            const { warning } = await this.breakpoints.syncBreakpointsForFile(session, file);
             if (warning) {
               syncWarnings.push(warning);
             }

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -1,6 +1,8 @@
 /**
- * Debug operations for session management including starting, stepping,
- * continuing, and breakpoint management.
+ * Session operations facade. Launch, attach and detach live here; breakpoint,
+ * execution, evaluation, JVM hot-swap and DAP-mirror operations delegate to the
+ * collaborators under src/session/{breakpoints,execution,inspection,jvm,mirror}/
+ * through OperationsContext (see operations-context.ts).
  */
 import {
   Breakpoint,

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -31,6 +31,11 @@ import { resolveStatement } from '../utils/breakpoint-resolver.js';
 import { normalizeBreakpointMessage } from '../utils/breakpoint-message.js';
 import { consumeChildSourced } from '../utils/child-origin-events.js';
 import { SessionManagerData } from './session-manager-data.js';
+import {
+  resolveDapTimeoutOverride,
+  truncateForLog,
+  withTimeoutHint
+} from './dap-request-helpers.js';
 import { AdapterLease } from '../adapters/adapter-lease.js';
 import { logProxyFailure } from './launch/proxy-failure-diagnostics.js';
 import { CustomLaunchRequestArguments, DebugResult } from './session-manager-core.js';
@@ -2510,14 +2515,6 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   }
 
   /**
-   * Helper method to truncate long strings for logging
-   */
-  private truncateForLog(value: string, maxLength: number = 1000): string {
-    if (!value) return '';
-    return value.length > maxLength ? value.substring(0, maxLength) + '... (truncated)' : value;
-  }
-
-  /**
    * The "variable name" an evaluate expression stands for, for name-based
    * redaction (issue #237): the whole expression when it is itself a
    * sensitive name, otherwise its final dot-segment — so `config.password`
@@ -2530,44 +2527,6 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     }
     const lastDot = trimmed.lastIndexOf('.');
     return lastDot >= 0 ? trimmed.slice(lastDot + 1) : trimmed;
-  }
-
-  /** Upper bound for caller-supplied per-request DAP timeouts (10 minutes). */
-  private static readonly MAX_DAP_TIMEOUT_MS = 600000;
-
-  /**
-   * Validate and clamp a caller-supplied per-request DAP timeout override (ms).
-   * Returns { error } for invalid values, { timeoutMs } with the (possibly
-   * clamped) override, or {} when no override was given.
-   */
-  private resolveDapTimeoutOverride(
-    timeoutMs: number | undefined,
-    logContext: string
-  ): { error?: string; timeoutMs?: number } {
-    if (timeoutMs === undefined) {
-      return {};
-    }
-    if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-      return {
-        error: `Invalid 'timeout': must be a positive number of milliseconds (got ${timeoutMs})`
-      };
-    }
-    if (timeoutMs > SessionManagerOperations.MAX_DAP_TIMEOUT_MS) {
-      this.logger.warn(
-        `[${logContext}] 'timeout' ${timeoutMs}ms exceeds the maximum; clamping to ${SessionManagerOperations.MAX_DAP_TIMEOUT_MS}ms`
-      );
-      return { timeoutMs: SessionManagerOperations.MAX_DAP_TIMEOUT_MS };
-    }
-    return { timeoutMs };
-  }
-
-  /** Append the 'timeout' tool-arg hint to DAP timeout failures. */
-  private withTimeoutHint(errorMessage: string): string {
-    if (!/timed out|did not respond/i.test(errorMessage)) {
-      return errorMessage;
-    }
-    const separator = errorMessage.trimEnd().endsWith('.') ? ' ' : '. ';
-    return `${errorMessage}${separator}${ErrorMessages.dapRequestTimeoutHint()}`;
   }
 
   /**
@@ -2593,7 +2552,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     // adapter policy pick the context its debugger understands.
     const context = this.selectPolicy(session.language).getEvaluateContext?.() ?? 'variables';
     this.logger.info(
-      `[SM evaluateExpression ${sessionId}] Entered. Expression: "${this.truncateForLog(
+      `[SM evaluateExpression ${sessionId}] Entered. Expression: "${truncateForLog(
         expression,
         100
       )}", frameId: ${frameId}, context: ${context}, state: ${session.state}`
@@ -2605,9 +2564,10 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       return { success: false, error: 'Expression cannot be empty' };
     }
 
-    const timeoutOverride = this.resolveDapTimeoutOverride(
+    const timeoutOverride = resolveDapTimeoutOverride(
       timeoutMs,
-      `SM evaluateExpression ${sessionId}`
+      `SM evaluateExpression ${sessionId}`,
+      this.logger
     );
     if (timeoutOverride.error) {
       this.logger.warn(`[SM evaluateExpression ${sessionId}] ${timeoutOverride.error}`);
@@ -2681,7 +2641,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     try {
       // Send DAP evaluate request
       this.logger.info(
-        `[SM evaluateExpression ${sessionId}] Sending DAP 'evaluate' request. Expression: "${this.truncateForLog(
+        `[SM evaluateExpression ${sessionId}] Sending DAP 'evaluate' request. Expression: "${truncateForLog(
           expression,
           100
         )}", frameId: ${frameId}, context: ${context}`
@@ -2741,10 +2701,10 @@ export abstract class SessionManagerOperations extends SessionManagerData {
           event: 'expression',
           sessionId,
           sessionName: session.name,
-          expression: this.truncateForLog(expression, 100),
+          expression: truncateForLog(expression, 100),
           frameId,
           context,
-          result: this.truncateForLog(result.result || '', 1000),
+          result: truncateForLog(result.result || '', 1000),
           type: result.type,
           variablesReference: result.variablesReference,
           namedVariables: result.namedVariables,
@@ -2753,7 +2713,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         });
 
         this.logger.info(
-          `[SM evaluateExpression ${sessionId}] Evaluation successful. Result: "${this.truncateForLog(
+          `[SM evaluateExpression ${sessionId}] Evaluation successful. Result: "${truncateForLog(
             result.result || '',
             200
           )}", Type: ${result.type}, VarRef: ${result.variablesReference}`
@@ -2772,7 +2732,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         event: 'error',
         sessionId,
         sessionName: session.name,
-        expression: this.truncateForLog(expression, 100),
+        expression: truncateForLog(expression, 100),
         frameId,
         context,
         error: errorMessage,
@@ -2793,7 +2753,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
         userError = `Invalid frame context: ${errorMessage}`;
       }
 
-      return { success: false, error: this.withTimeoutHint(userError) };
+      return { success: false, error: withTimeoutHint(userError) };
   }
 }
 
@@ -3335,9 +3295,10 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       `[SM redefineClasses ${sessionId}] classesDir: "${classesDir}", since: ${sinceTimestamp}`
     );
 
-    const timeoutOverride = this.resolveDapTimeoutOverride(
+    const timeoutOverride = resolveDapTimeoutOverride(
       timeoutMs,
-      `SM redefineClasses ${sessionId}`
+      `SM redefineClasses ${sessionId}`,
+      this.logger
     );
     if (timeoutOverride.error) {
       this.logger.warn(`[SM redefineClasses ${sessionId}] ${timeoutOverride.error}`);
@@ -3407,7 +3368,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       this.logger.error(`[SM redefineClasses ${sessionId}] Error: ${error}`);
       return {
         success: false,
-        error: this.withTimeoutHint(error instanceof Error ? error.message : String(error)),
+        error: withTimeoutHint(error instanceof Error ? error.message : String(error)),
       };
     }
   }
@@ -3448,7 +3409,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       return {
         success: false,
         state: session.state,
-        error: this.withTimeoutHint(error instanceof Error ? error.message : String(error))
+        error: withTimeoutHint(error instanceof Error ? error.message : String(error))
       };
     }
   }
@@ -3487,7 +3448,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       return {
         success: false,
         state: session.state,
-        error: this.withTimeoutHint(error instanceof Error ? error.message : String(error))
+        error: withTimeoutHint(error instanceof Error ? error.message : String(error))
       };
     }
   }

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -12,7 +12,6 @@ import {
   redactVariableValue,
   redactSecretsDeep,
   buildRedactionNotice,
-  NO_DEBUG_TARGET_MARKER,
   type ExceptionBreakMode
 } from '@debugmcp/shared';
 import { ManagedSession, ToolchainValidationState } from './session-store.js';
@@ -31,6 +30,7 @@ import {
   withTimeoutHint
 } from './dap-request-helpers.js';
 import { BreakpointController } from './breakpoints/breakpoint-controller.js';
+import { ExecutionController } from './execution/execution-controller.js';
 import { reresolveAnchors } from './breakpoints/anchor-resolution.js';
 import {
   buildLogpointDowngradeLaunchWarning,
@@ -47,8 +47,6 @@ import {
   type LanguageSpecificLaunchConfig
 } from '@debugmcp/shared';
 import {
-  SessionTerminatedError,
-  ProxyNotRunningError,
   DebugSessionCreationError,
   PythonNotFoundError
 } from '../errors/debug-errors.js';
@@ -247,6 +245,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
    */
   protected readonly opsContext: OperationsContext = this.buildOperationsContext();
   protected readonly breakpoints = new BreakpointController(this.opsContext);
+  protected readonly execution = new ExecutionController(this.opsContext);
 
   protected async startProxyManager(
     session: ManagedSession,
@@ -1470,539 +1469,37 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     return this.breakpoints.clearBreakpoints(sessionId, file);
   }
 
+  /** Step over the current line. */
   async stepOver(sessionId: string): Promise<DebugResult> {
-    const session = this._getSessionById(sessionId);
-
-    // Check if session is terminated
-    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
-      throw new SessionTerminatedError(sessionId);
-    }
-
-    const threadId = session.proxyManager?.getCurrentThreadId();
-    this.logger.info(
-      `[SM stepOver ${sessionId}] Entered. Current state: ${session.state}, ThreadID: ${threadId}`
-    );
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      throw new ProxyNotRunningError(sessionId, 'step over');
-    }
-    if (session.state !== SessionState.PAUSED) {
-      this.logger.warn(`[SM stepOver ${sessionId}] Not paused. State: ${session.state}`);
-      return { success: false, error: 'Not paused', state: session.state };
-    }
-    if (typeof threadId !== 'number') {
-      this.logger.warn(`[SM stepOver ${sessionId}] No current thread ID.`);
-      return { success: false, error: 'No current thread ID', state: session.state };
-    }
-
-    this.logger.info(`[SM stepOver ${sessionId}] Sending DAP 'next' for threadId ${threadId}`);
-
-    try {
-      return await this._executeStepOperation(session, sessionId, {
-        command: 'next',
-        threadId,
-        logTag: 'stepOver',
-        successMessage: 'Step completed.',
-      });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`[SM stepOver ${sessionId}] Error during step:`, error);
-      this._updateSessionState(session, SessionState.ERROR);
-      return { success: false, error: errorMessage, state: session.state };
-    }
+    return this.execution.stepOver(sessionId);
   }
 
+  /** Step into the call on the current line. */
   async stepInto(sessionId: string): Promise<DebugResult> {
-    const session = this._getSessionById(sessionId);
-
-    // Check if session is terminated
-    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
-      throw new SessionTerminatedError(sessionId);
-    }
-
-    const threadId = session.proxyManager?.getCurrentThreadId();
-    this.logger.info(
-      `[SM stepInto ${sessionId}] Entered. Current state: ${session.state}, ThreadID: ${threadId}`
-    );
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      throw new ProxyNotRunningError(sessionId, 'step into');
-    }
-    if (session.state !== SessionState.PAUSED) {
-      this.logger.warn(`[SM stepInto ${sessionId}] Not paused. State: ${session.state}`);
-      return { success: false, error: 'Not paused', state: session.state };
-    }
-    if (typeof threadId !== 'number') {
-      this.logger.warn(`[SM stepInto ${sessionId}] No current thread ID.`);
-      return { success: false, error: 'No current thread ID', state: session.state };
-    }
-
-    this.logger.info(`[SM stepInto ${sessionId}] Sending DAP 'stepIn' for threadId ${threadId}`);
-
-    try {
-      return await this._executeStepOperation(session, sessionId, {
-        command: 'stepIn',
-        threadId,
-        logTag: 'stepInto',
-        successMessage: 'Step into completed.',
-      });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`[SM stepInto ${sessionId}] Error during step:`, error);
-      this._updateSessionState(session, SessionState.ERROR);
-      return { success: false, error: errorMessage, state: session.state };
-    }
+    return this.execution.stepInto(sessionId);
   }
 
+  /** Step out of the current frame. */
   async stepOut(sessionId: string): Promise<DebugResult> {
-    const session = this._getSessionById(sessionId);
-
-    // Check if session is terminated
-    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
-      throw new SessionTerminatedError(sessionId);
-    }
-
-    const threadId = session.proxyManager?.getCurrentThreadId();
-    this.logger.info(
-      `[SM stepOut ${sessionId}] Entered. Current state: ${session.state}, ThreadID: ${threadId}`
-    );
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      throw new ProxyNotRunningError(sessionId, 'step out');
-    }
-    if (session.state !== SessionState.PAUSED) {
-      this.logger.warn(`[SM stepOut ${sessionId}] Not paused. State: ${session.state}`);
-      return { success: false, error: 'Not paused', state: session.state };
-    }
-    if (typeof threadId !== 'number') {
-      this.logger.warn(`[SM stepOut ${sessionId}] No current thread ID.`);
-      return { success: false, error: 'No current thread ID', state: session.state };
-    }
-
-    this.logger.info(`[SM stepOut ${sessionId}] Sending DAP 'stepOut' for threadId ${threadId}`);
-
-    try {
-      return await this._executeStepOperation(session, sessionId, {
-        command: 'stepOut',
-        threadId,
-        logTag: 'stepOut',
-        successMessage: 'Step out completed.',
-      });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`[SM stepOut ${sessionId}] Error during step:`, error);
-      this._updateSessionState(session, SessionState.ERROR);
-      return { success: false, error: errorMessage, state: session.state };
-    }
+    return this.execution.stepOut(sessionId);
   }
 
-  private _executeStepOperation(
-    session: ManagedSession,
-    sessionId: string,
-    options: {
-      command: 'next' | 'stepIn' | 'stepOut';
-      threadId: number;
-      logTag: string;
-      successMessage: string;
-      terminatedMessage?: string;
-      exitedMessage?: string;
-    }
-  ): Promise<DebugResult> {
-    const proxyManager = session.proxyManager;
-
-    if (!proxyManager) {
-      return Promise.resolve({
-        success: false,
-        error: 'Proxy manager unavailable',
-        state: session.state,
-      });
-    }
-
-    const terminatedMessage =
-      options.terminatedMessage ?? 'Step completed as session terminated.';
-    const exitedMessage = options.exitedMessage ?? 'Step completed as session exited.';
-
-    return new Promise((resolve) => {
-      let settled = false;
-
-      const cleanup = () => {
-        proxyManager.off('stopped', onStopped);
-        proxyManager.off('terminated', onTerminated);
-        proxyManager.off('exited', onExited);
-        proxyManager.off('exit', onExit);
-        clearTimeout(timeout);
-      };
-
-      const settle = (result: DebugResult) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        resolve(result);
-      };
-
-      const success = (message: string, location?: { file: string; line: number; column?: number }) => {
-        this.logger.info(`[SM ${options.logTag} ${sessionId}] ${message} Current state: ${session.state}`);
-        const data: { message: string; location?: { file: string; line: number; column?: number } } = { message };
-        if (location) {
-          data.location = location;
-        }
-        settle({
-          success: true,
-          state: session.state,
-          data,
-        });
-      };
-
-      const onStopped = async () => {
-        // Try to get current location from stack trace
-        let location: { file: string; line: number; column?: number } | undefined;
-        try {
-          // Wait a brief moment for state to settle after stopped event
-          await new Promise(resolve => setTimeout(resolve, 10));
-
-          const stackFrames = await this.getStackTrace(sessionId);
-          if (stackFrames && stackFrames.length > 0) {
-            const topFrame = stackFrames[0];
-            location = {
-              file: topFrame.file,
-              line: topFrame.line,
-              column: topFrame.column
-            };
-            this.logger.debug(`[SM ${options.logTag} ${sessionId}] Captured location: ${location.file}:${location.line}`);
-          }
-        } catch (error) {
-          // Log but don't fail the step operation if we can't get location
-          this.logger.debug(`[SM ${options.logTag} ${sessionId}] Could not capture location:`, error);
-        }
-        success(options.successMessage, location);
-      };
-
-      const onTerminated = () => success(terminatedMessage);
-      const onExited = () => success(exitedMessage);
-      const onExit = () => success(exitedMessage);
-
-      const timeout = setTimeout(() => {
-        this.logger.info(
-          `[SM ${options.logTag} ${sessionId}] Step still running after ${this.stepGraceMs}ms grace window; completing asynchronously`
-        );
-        settle({
-          success: true,
-          state: session.state,
-          data: {
-            message: ErrorMessages.stepStillRunning(this.stepGraceMs / 1000),
-            pending: true,
-          },
-        });
-      }, this.stepGraceMs);
-
-      proxyManager.on('stopped', onStopped);
-      proxyManager.on('terminated', onTerminated);
-      proxyManager.on('exited', onExited);
-      proxyManager.on('exit', onExit);
-
-      this._updateSessionState(session, SessionState.RUNNING);
-
-      proxyManager
-        .sendDapRequest(options.command, { threadId: options.threadId })
-        .catch((error: unknown) => {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          this.logger.error(
-            `[SM ${options.logTag} ${sessionId}] Error during step request:`,
-            error
-          );
-          this._updateSessionState(session, SessionState.ERROR);
-          settle({ success: false, error: errorMessage, state: session.state });
-        });
-    });
-  }
-
+  /**
+   * Resume the debuggee. Stays a facade method because the core's
+   * auto-continue path calls it directly.
+   */
   async continue(sessionId: string): Promise<DebugResult> {
-    const session = this._getSessionById(sessionId);
-
-    // Check if session is terminated
-    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
-      throw new SessionTerminatedError(sessionId);
-    }
-
-    const threadId = session.proxyManager?.getCurrentThreadId();
-    this.logger.info(
-      `[SessionManager continue] Called for session ${sessionId}. Current state: ${session.state}, ThreadID: ${threadId}`
-    );
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      throw new ProxyNotRunningError(sessionId, 'continue');
-    }
-    if (session.state !== SessionState.PAUSED) {
-      this.logger.warn(
-        `[SessionManager continue] Session ${sessionId} not paused. State: ${session.state}.`
-      );
-      return { success: false, error: 'Not paused', state: session.state };
-    }
-    if (typeof threadId !== 'number') {
-      this.logger.warn(
-        `[SessionManager continue] No current thread ID for session ${sessionId}.`
-      );
-      return { success: false, error: 'No current thread ID', state: session.state };
-    }
-
-    try {
-      this.logger.info(
-        `[SessionManager continue] Sending DAP 'continue' for session ${sessionId}, threadId ${threadId}.`
-      );
-      // Set RUNNING *before* sending the DAP request so that concurrent
-      // operations (e.g. getStackTrace polling) see the correct state.
-      // If a breakpoint fires during the await, the handleStopped callback
-      // will set state back to PAUSED before the await resolves.
-      this._updateSessionState(session, SessionState.RUNNING);
-      await session.proxyManager.sendDapRequest('continue', { threadId });
-
-      this.logger.info(
-        `[SessionManager continue] DAP 'continue' sent, session ${sessionId} state is ${session.state}.`
-      );
-      return { success: true, state: session.state };
-    } catch (error) {
-      // Revert to PAUSED — the VM didn't actually resume
-      this._updateSessionState(session, SessionState.PAUSED);
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(
-        `[SessionManager continue] Error sending 'continue' to proxy for session ${sessionId}: ${errorMessage}`
-      );
-      throw error;
-    }
+    return this.execution.continue(sessionId);
   }
 
+  /** Pause a running debuggee. */
   async pause(sessionId: string, threadId?: number): Promise<DebugResult> {
-    const session = this._getSessionById(sessionId);
-
-    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
-      throw new SessionTerminatedError(sessionId);
-    }
-
-    this.logger.info(
-      `[SessionManager pause] Called for session ${sessionId}. Current state: ${session.state}`
-    );
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      throw new ProxyNotRunningError(sessionId, 'pause');
-    }
-
-    if (session.state === SessionState.PAUSED) {
-      return {
-        success: true,
-        state: session.state,
-        data: {
-          message: 'Already paused',
-          ...(session.lastStop?.reason ? { stopReason: session.lastStop.reason } : {}),
-          ...(session.lastStop?.rawReason ? { rawStopReason: session.lastStop.rawReason } : {})
-        }
-      };
-    }
-
-    if (session.state !== SessionState.RUNNING) {
-      return { success: false, error: `Cannot pause in state: ${session.state}`, state: session.state };
-    }
-
-    this.logger.debug(`[SessionManager] pauseExecution: sending DAP pause for session=${sessionId} currentState=${session.state}`);
-    // DAP pause request: threadId 0 should pause all threads per DAP spec,
-    // but some adapters (e.g. netcoredbg) reject threadId=0 with E_INVALIDARG.
-    // When no explicit threadId is provided, discover one via a threads request.
-    let effectiveThreadId = threadId ?? 0;
-    if (effectiveThreadId === 0) {
-      try {
-        const threadsResp = await session.proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {});
-        const threads = threadsResp?.body?.threads;
-        if (Array.isArray(threads) && threads.length > 0 && typeof threads[0]?.id === 'number') {
-          effectiveThreadId = threads[0].id;
-          this.logger.info(`[SessionManager pause] Auto-discovered threadId=${effectiveThreadId} for pause`);
-        } else if (Array.isArray(threads) && threads.length === 0) {
-          // Tell-tale for child-session adapters (issue #513): on a policy
-          // that routes 'threads' to a child session, an empty list usually
-          // means the request hit the parent (root) session — the pause below
-          // goes through the same routing, where child-required handling
-          // waits for/rejects on the missing child.
-          this.logger.info(
-            `[SessionManager pause] threads returned empty for session ${sessionId}; proceeding with threadId=0`
-          );
-        }
-      } catch {
-        // threads request failed — fall through with threadId=0
-      }
-    }
-
-    const proxyManager = session.proxyManager;
-
-    // Snapshot the current lastStop so result paths can tell whether the stop
-    // they observe belongs to THIS pause (handleStopped replaces the object)
-    // rather than reporting a stale earlier stop.
-    const lastStopBefore = session.lastStop;
-    // Flag the in-flight pause so policy stop-reason normalization can use it
-    // (e.g. CodeLLDB reports pauses as 'exception'/SIGSTOP). handleStopped
-    // clears it on every stop; clear it here too on error/terminate paths.
-    session.pausePending = true;
-
-    // The pause response only acknowledges the request; the state transition
-    // to PAUSED happens when the asynchronous 'stopped' event is handled by
-    // the core handleStopped listener. Adapters differ on whether the event
-    // arrives before or after the response, so listen for it (registered
-    // BEFORE sending the request) and only settle once the stop is observed.
-    return new Promise<DebugResult>((resolve, reject) => {
-      let settled = false;
-      let stopEventSeen = false;
-
-      const cleanup = () => {
-        proxyManager.off('stopped', onStopped);
-        proxyManager.off('terminated', onEnded);
-        proxyManager.off('exited', onEnded);
-        proxyManager.off('exit', onEnded);
-        clearTimeout(timeout);
-      };
-
-      const settle = (result: DebugResult) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        resolve(result);
-      };
-
-      const onStopped = async () => {
-        stopEventSeen = true;
-        // Try to get current location from stack trace
-        let location: { file: string; line: number; column?: number } | undefined;
-        try {
-          // Wait a brief moment for state to settle after stopped event
-          await new Promise(resolve => setTimeout(resolve, 10));
-
-          const stackFrames = await this.getStackTrace(sessionId);
-          if (stackFrames && stackFrames.length > 0) {
-            const topFrame = stackFrames[0];
-            location = {
-              file: topFrame.file,
-              line: topFrame.line,
-              column: topFrame.column
-            };
-          }
-        } catch (error) {
-          this.logger.debug(`[SessionManager pause ${sessionId}] Could not capture location:`, error);
-        }
-        this.logger.info(
-          `[SessionManager pause] Paused session ${sessionId}. Current state: ${session.state}`
-        );
-        const data: {
-          message: string;
-          stopReason?: string;
-          rawStopReason?: string;
-          location?: { file: string; line: number; column?: number };
-        } = { message: 'Paused' };
-        // Only report the stop reason when handleStopped recorded a NEW stop
-        // for this pause — never echo a stale earlier stop.
-        if (session.lastStop && session.lastStop !== lastStopBefore) {
-          data.stopReason = session.lastStop.reason;
-          if (session.lastStop.rawReason) {
-            data.rawStopReason = session.lastStop.rawReason;
-          }
-        }
-        if (location) {
-          data.location = location;
-        }
-        settle({ success: true, state: session.state, data });
-      };
-
-      const onEnded = () => {
-        session.pausePending = false;
-        settle({
-          success: true,
-          state: session.state,
-          data: { message: 'Session ended before pause took effect' }
-        });
-      };
-
-      const timeout = setTimeout(() => {
-        this.logger.info(
-          `[SessionManager pause] No stopped event within ${this.pauseGraceMs}ms grace window in session ${sessionId}; completing asynchronously`
-        );
-        // session.pausePending stays armed on purpose: the pause was
-        // delivered and the stop may land whenever the debuggee next runs
-        // (e.g. an idle server, issue #513) — that late stop must still be
-        // normalized to 'pause'. handleStopped clears the flag on any stop.
-        settle({
-          success: true,
-          state: session.state,
-          data: {
-            message: ErrorMessages.pausePending(this.pauseGraceMs / 1000),
-            pending: true,
-          },
-        });
-      }, this.pauseGraceMs);
-
-      proxyManager.on('stopped', onStopped);
-      proxyManager.on('terminated', onEnded);
-      proxyManager.on('exited', onEnded);
-      proxyManager.on('exit', onEnded);
-
-      proxyManager
-        .sendDapRequest('pause', { threadId: effectiveThreadId })
-        .then(() => {
-          this.logger.info(
-            `[SessionManager pause] DAP 'pause' sent for session ${sessionId}. Waiting for stopped event.`
-          );
-          // Guard: if the stopped event fired before the listeners above were
-          // registered (e.g. during the threads-discovery await), the state is
-          // already PAUSED and no further event will arrive.
-          if (session.state === SessionState.PAUSED && !stopEventSeen) {
-            const raceData: { message: string; stopReason?: string; rawStopReason?: string } = { message: 'Paused' };
-            if (session.lastStop && session.lastStop !== lastStopBefore) {
-              raceData.stopReason = session.lastStop.reason;
-              if (session.lastStop.rawReason) {
-                raceData.rawStopReason = session.lastStop.rawReason;
-              }
-            }
-            settle({ success: true, state: session.state, data: raceData });
-          }
-        })
-        .catch((error: unknown) => {
-          session.pausePending = false;
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          this.logger.error(
-            `[SessionManager pause] Error sending 'pause' for session ${sessionId}: ${errorMessage}`
-          );
-          if (!settled) {
-            settled = true;
-            cleanup();
-            // A pause with no debuggable target to run against (issue #513)
-            // is an actionable state, not a protocol failure — return the
-            // structured shape other unpausable states use
-            if (errorMessage.includes(NO_DEBUG_TARGET_MARKER)) {
-              resolve({ success: false, error: errorMessage, state: session.state });
-              return;
-            }
-            reject(error instanceof Error ? error : new Error(errorMessage));
-          }
-        });
-    });
+    return this.execution.pause(sessionId, threadId);
   }
 
+  /** List the debuggee's threads. */
   async listThreads(sessionId: string): Promise<Array<{ id: number; name: string }>> {
-    const session = this._getSessionById(sessionId);
-
-    if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
-      throw new SessionTerminatedError(sessionId);
-    }
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      throw new ProxyNotRunningError(sessionId, 'listThreads');
-    }
-
-    const response = await session.proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {});
-    // A failed DAP response must not be flattened into an empty-but-successful
-    // thread list (issue #124): propagate the failure to the caller.
-    if (response?.success === false) {
-      throw new Error(response.message || `DAP 'threads' request failed`);
-    }
-    return (response?.body?.threads ?? []).map(t => ({ id: t.id, name: t.name }));
+    return this.execution.listThreads(sessionId);
   }
 
   /**

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -20,16 +20,17 @@ import { checkLaunchToolchain } from '../utils/language-availability.js';
 import { didYouMean } from '../utils/did-you-mean.js';
 import { SessionManagerData } from './session-manager-data.js';
 import type { OperationsContext } from './operations-context.js';
-import {
-  resolveDapTimeoutOverride,
-  withTimeoutHint
-} from './dap-request-helpers.js';
+import { withTimeoutHint } from './dap-request-helpers.js';
 import { BreakpointController } from './breakpoints/breakpoint-controller.js';
 import { ExecutionController } from './execution/execution-controller.js';
 import {
   ExpressionEvaluator,
   type EvaluateResult
 } from './inspection/expression-evaluator.js';
+import {
+  RedefineClassesController,
+  type RedefineClassesResult
+} from './jvm/redefine-classes-controller.js';
 import { reresolveAnchors } from './breakpoints/anchor-resolution.js';
 import {
   buildLogpointDowngradeLaunchWarning,
@@ -54,28 +55,8 @@ import { McpError } from '@modelcontextprotocol/sdk/types.js';
 /** Result type for evaluate expression operations. */
 export type { EvaluateResult } from './inspection/expression-evaluator.js';
 
-export interface RedefineClassesResult {
-  success: boolean;
-  redefined?: string[];
-  redefinedCount?: number;
-  skippedNotLoaded?: number;
-  failedCount?: number;
-  failed?: Array<{ fqcn: string; error: string }>;
-  scannedFiles?: number;
-  newestTimestamp?: number;
-  /** Breakpoints re-planted after redefine (issue #370). */
-  replantedBreakpoints?: number;
-  /**
-   * Statement-anchored breakpoints re-resolved against the new source after
-   * the hot-swap (issue #464) — same shape restart_debugging returns.
-   */
-  anchorResolution?: {
-    moved: Array<{ breakpointId: string; file: string; from: number; to: number; statement: string; candidates?: number[] }>;
-    stale: Array<{ breakpointId: string; file: string; line: number; statement: string; reason: string }>;
-  };
-  warning?: string;
-  error?: string;
-}
+/** Result type for redefine_classes (JVM hot swap). */
+export type { RedefineClassesResult } from './jvm/redefine-classes-controller.js';
 
 /** Result of expose_session (issue #217). */
 export interface ExposeSessionResult {
@@ -233,6 +214,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   protected readonly breakpoints = new BreakpointController(this.opsContext);
   protected readonly execution = new ExecutionController(this.opsContext);
   protected readonly evaluator = new ExpressionEvaluator(this.opsContext);
+  protected readonly hotSwap = new RedefineClassesController(this.opsContext, this.breakpoints);
 
   protected async startProxyManager(
     session: ManagedSession,
@@ -2028,93 +2010,16 @@ export abstract class SessionManagerOperations extends SessionManagerData {
     }
   }
 
+  /**
+   * Hot-swap changed classes into a running JVM (Java only).
+   */
   async redefineClasses(
     sessionId: string,
     classesDir: string,
     sinceTimestamp: number = 0,
     timeoutMs?: number
   ): Promise<RedefineClassesResult> {
-    const session = this._getSessionById(sessionId);
-    this.logger.info(
-      `[SM redefineClasses ${sessionId}] classesDir: "${classesDir}", since: ${sinceTimestamp}`
-    );
-
-    const timeoutOverride = resolveDapTimeoutOverride(
-      timeoutMs,
-      `SM redefineClasses ${sessionId}`,
-      this.logger
-    );
-    if (timeoutOverride.error) {
-      this.logger.warn(`[SM redefineClasses ${sessionId}] ${timeoutOverride.error}`);
-      return { success: false, error: timeoutOverride.error };
-    }
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      return { success: false, error: 'No active debug session' };
-    }
-
-    try {
-      const redefineArgs = { classesDir, sinceTimestamp };
-      const response = timeoutOverride.timeoutMs !== undefined
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ? await session.proxyManager.sendDapRequest<any>(
-            'redefineClasses', redefineArgs, { timeoutMs: timeoutOverride.timeoutMs })
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        : await session.proxyManager.sendDapRequest<any>(
-            'redefineClasses', redefineArgs);
-
-      const body = response?.body;
-      if (!body) {
-        return { success: false, error: 'No response body from redefineClasses' };
-      }
-
-      // Statement anchors are content identities and a hot-swap invalidates
-      // line numbers (issue #464): re-resolve them against the new source —
-      // which IS what is on disk in the edit -> recompile -> hot-swap loop —
-      // and re-send the affected files so the JDI replant binds the moved
-      // lines against the new line table. Ordered after the redefine
-      // response, i.e. after vm.redefineClasses, by construction.
-      let anchorResolution: RedefineClassesResult['anchorResolution'];
-      const syncWarnings: string[] = [];
-      if ((body.redefinedCount ?? 0) > 0) {
-        anchorResolution = await reresolveAnchors(session, this.opsContext);
-        if (anchorResolution && anchorResolution.moved.length > 0) {
-          const movedFiles = [...new Set(anchorResolution.moved.map(m => m.file))];
-          for (const file of movedFiles) {
-            const { warning } = await this.breakpoints.syncBreakpointsForFile(session, file);
-            if (warning) {
-              syncWarnings.push(warning);
-            }
-          }
-        }
-        if (anchorResolution && anchorResolution.stale.length > 0) {
-          syncWarnings.push(
-            `${anchorResolution.stale.length} statement-anchored breakpoint(s) could not be re-resolved ` +
-            `against the new source and keep their previous line — see anchorResolution.stale`
-          );
-        }
-      }
-
-      return {
-        success: true,
-        redefined: body.redefined,
-        redefinedCount: body.redefinedCount,
-        skippedNotLoaded: body.skippedNotLoaded,
-        failedCount: body.failedCount,
-        failed: body.failed,
-        scannedFiles: body.scannedFiles,
-        newestTimestamp: body.newestTimestamp,
-        replantedBreakpoints: body.replantedBreakpoints,
-        ...(anchorResolution ? { anchorResolution } : {}),
-        ...(syncWarnings.length > 0 ? { warning: syncWarnings.join('; ') } : {}),
-      };
-    } catch (error) {
-      this.logger.error(`[SM redefineClasses ${sessionId}] Error: ${error}`);
-      return {
-        success: false,
-        error: withTimeoutHint(error instanceof Error ? error.message : String(error)),
-      };
-    }
+    return this.hotSwap.redefineClasses(sessionId, classesDir, sinceTimestamp, timeoutMs);
   }
 
   /**

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -14,13 +14,11 @@ import { ManagedSession, ToolchainValidationState } from './session-store.js';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import path from 'path';
 import { ProxyConfig } from '../proxy/proxy-config.js';
-import { MIRROR_EXPOSE_COMMAND, MIRROR_UNEXPOSE_COMMAND } from '../proxy/dap-proxy-interfaces.js';
 import { ErrorMessages } from '../utils/error-messages.js';
 import { checkLaunchToolchain } from '../utils/language-availability.js';
 import { didYouMean } from '../utils/did-you-mean.js';
 import { SessionManagerData } from './session-manager-data.js';
 import type { OperationsContext } from './operations-context.js';
-import { withTimeoutHint } from './dap-request-helpers.js';
 import { BreakpointController } from './breakpoints/breakpoint-controller.js';
 import { ExecutionController } from './execution/execution-controller.js';
 import {
@@ -31,6 +29,11 @@ import {
   RedefineClassesController,
   type RedefineClassesResult
 } from './jvm/redefine-classes-controller.js';
+import {
+  MirrorController,
+  type ExposeSessionResult,
+  type UnexposeSessionResult
+} from './mirror/mirror-controller.js';
 import { reresolveAnchors } from './breakpoints/anchor-resolution.js';
 import {
   buildLogpointDowngradeLaunchWarning,
@@ -58,24 +61,11 @@ export type { EvaluateResult } from './inspection/expression-evaluator.js';
 /** Result type for redefine_classes (JVM hot swap). */
 export type { RedefineClassesResult } from './jvm/redefine-classes-controller.js';
 
-/** Result of expose_session (issue #217). */
-export interface ExposeSessionResult {
-  success: boolean;
-  state: SessionState;
-  host?: string;
-  port?: number;
-  token?: string;
-  error?: string;
-}
-
-/** Result of unexpose_session (issue #217). */
-export interface UnexposeSessionResult {
-  success: boolean;
-  state: SessionState;
-  wasExposed?: boolean;
-  closedClients?: number;
-  error?: string;
-}
+/** Result types for expose_session / unexpose_session (issue #217). */
+export type {
+  ExposeSessionResult,
+  UnexposeSessionResult
+} from './mirror/mirror-controller.js';
 
 /**
  * The seven positional arguments `startProxyManager` has always taken, named.
@@ -215,6 +205,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   protected readonly execution = new ExecutionController(this.opsContext);
   protected readonly evaluator = new ExpressionEvaluator(this.opsContext);
   protected readonly hotSwap = new RedefineClassesController(this.opsContext, this.breakpoints);
+  protected readonly mirror = new MirrorController(this.opsContext);
 
   protected async startProxyManager(
     session: ManagedSession,
@@ -2023,82 +2014,16 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   }
 
   /**
-   * Expose the session's live DAP connection as a read-only mirror endpoint
-   * for IDE attach (issue #217). Idempotent: the worker returns the existing
-   * endpoint (token unrotated) when already exposed. Allowed while RUNNING
-   * as well as PAUSED — a paused-only gate would race the debuggee anyway.
+   * Open a read-only DAP mirror endpoint for IDE attach (issue #217).
    */
   async exposeSession(sessionId: string): Promise<ExposeSessionResult> {
-    const session = this._getSessionById(sessionId);
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      return {
-        success: false,
-        state: session.state,
-        error: 'No active debug session to expose — start_debugging or attach_to_process first'
-      };
-    }
-
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = await session.proxyManager.sendDapRequest<any>(MIRROR_EXPOSE_COMMAND, {});
-      const body = response?.body;
-      if (!body || typeof body.port !== 'number' || typeof body.token !== 'string') {
-        return { success: false, state: session.state, error: 'Malformed mirrorExpose response from debug proxy' };
-      }
-      const host = typeof body.host === 'string' ? body.host : '127.0.0.1';
-      this.sessionStore.update(sessionId, {
-        exposure: { host, port: body.port, token: body.token, exposedAt: Date.now() }
-      });
-      // The token is an attach capability — log the endpoint, never the token.
-      this.logger.info(`[SM exposeSession ${sessionId}] Mirror listening on ${host}:${body.port}`);
-      return { success: true, state: session.state, host, port: body.port, token: body.token };
-    } catch (error) {
-      this.logger.error(`[SM exposeSession ${sessionId}] Error: ${error}`);
-      return {
-        success: false,
-        state: session.state,
-        error: withTimeoutHint(error instanceof Error ? error.message : String(error))
-      };
-    }
+    return this.mirror.exposeSession(sessionId);
   }
 
   /**
-   * Close the session's mirror endpoint (issue #217). A no-op success when
-   * not exposed — the caller's desired end-state holds either way.
+   * Close the session's mirror endpoint (issue #217).
    */
   async unexposeSession(sessionId: string): Promise<UnexposeSessionResult> {
-    const session = this._getSessionById(sessionId);
-    const hadRecord = session.exposure !== undefined;
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      // Worker gone => listener gone; just clear any stale record.
-      if (hadRecord) {
-        this.sessionStore.update(sessionId, { exposure: undefined });
-      }
-      return { success: true, state: session.state, wasExposed: false };
-    }
-
-    try {
-      // Always forward even without a parent record — record and reality can
-      // disagree, and the worker no-ops safely.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = await session.proxyManager.sendDapRequest<any>(MIRROR_UNEXPOSE_COMMAND, {});
-      this.sessionStore.update(sessionId, { exposure: undefined });
-      const body = response?.body;
-      return {
-        success: true,
-        state: session.state,
-        wasExposed: body?.closed === true || hadRecord,
-        ...(typeof body?.closedClients === 'number' ? { closedClients: body.closedClients } : {})
-      };
-    } catch (error) {
-      this.logger.error(`[SM unexposeSession ${sessionId}] Error: ${error}`);
-      return {
-        success: false,
-        state: session.state,
-        error: withTimeoutHint(error instanceof Error ? error.message : String(error))
-      };
-    }
+    return this.mirror.unexposeSession(sessionId);
   }
 }

--- a/tests/core/unit/session/session-manager-logpoint-warning.test.ts
+++ b/tests/core/unit/session/session-manager-logpoint-warning.test.ts
@@ -5,7 +5,8 @@
  * response when the live adapter cannot do logpoints.
  */
 import { describe, it, expect } from 'vitest';
-import { SessionManager } from '../../../../src/session/session-manager.js';
+import { buildLogpointDowngradeLaunchWarning } from '../../../../src/session/breakpoints/launch-warnings.js';
+import type { ManagedSession } from '../../../../src/session/session-store.js';
 
 type BuilderSession = {
   language: string;
@@ -14,11 +15,11 @@ type BuilderSession = {
 };
 
 function build(session: BuilderSession): string | undefined {
-  // The builder reads only session state, so invoking it off the prototype
-  // with a bare receiver keeps this a pure unit test.
-  return (SessionManager.prototype as unknown as {
-    buildLogpointDowngradeLaunchWarning(s: BuilderSession): string | undefined;
-  }).buildLogpointDowngradeLaunchWarning.call({}, session);
+  // The builder is a free function over session state, so a bare literal
+  // standing in for the three fields it reads keeps this a pure unit test.
+  return buildLogpointDowngradeLaunchWarning(
+    session as unknown as Pick<ManagedSession, 'breakpoints' | 'adapterCapabilities' | 'language'>
+  );
 }
 
 const logpoint = { file: '/proj/examples/ruby/fizzbuzz.rb', line: 16, logMessage: 'value={value}' };

--- a/tests/core/unit/session/session-manager-unbound-exit-warning.test.ts
+++ b/tests/core/unit/session/session-manager-unbound-exit-warning.test.ts
@@ -5,16 +5,18 @@
  * store already holds.
  */
 import { describe, it, expect } from 'vitest';
-import { SessionManager } from '../../../../src/session/session-manager.js';
+import { buildUnboundBreakpointExitWarning } from '../../../../src/session/breakpoints/launch-warnings.js';
+import type { ManagedSession } from '../../../../src/session/session-store.js';
 
 type BuilderSession = {
   breakpoints: Map<string, { file: string; line: number; verified: boolean; message?: string }>;
 };
 
 function build(session: BuilderSession): string | undefined {
-  return (SessionManager.prototype as unknown as {
-    buildUnboundBreakpointExitWarning(s: BuilderSession): string | undefined;
-  }).buildUnboundBreakpointExitWarning.call({}, session);
+  // The builder is a free function over the breakpoint store alone.
+  return buildUnboundBreakpointExitWarning(
+    session as unknown as Pick<ManagedSession, 'breakpoints'>
+  );
 }
 
 describe('buildUnboundBreakpointExitWarning', () => {

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -22,6 +22,15 @@ import {
   DebugSessionCreationError
 } from '../../src/errors/debug-errors';
 import { createEnvironmentMock } from '../test-utils/mocks/environment';
+import type { ExecutionController } from '../../src/session/execution/execution-controller';
+
+/**
+ * The collaborators the operations facade delegates to. They are protected
+ * fields, so reaching them from a test needs the usual cast.
+ */
+function internals(ops: SessionManagerOperations): { execution: ExecutionController } {
+  return ops as unknown as { execution: ExecutionController };
+}
 
 describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () => {
   let operations: SessionManagerOperations;
@@ -484,7 +493,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
     it('handles stepOut when internal execution rejects', async () => {
       mockSession.state = SessionState.PAUSED;
-      const execSpy = vi.spyOn(operations as any, '_executeStepOperation').mockRejectedValue(new Error('internal failure'));
+      const execSpy = vi.spyOn(internals(operations).execution, 'executeStep').mockRejectedValue(new Error('internal failure'));
 
       const result = await operations.stepOut('test-session');
 
@@ -1464,11 +1473,11 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     });
   });
 
-  describe('_executeStepOperation behaviour', () => {
+  describe('executeStep behaviour', () => {
     it('returns failure when proxy manager unavailable', async () => {
       const session = { ...mockSession, proxyManager: undefined, state: SessionState.PAUSED } as any;
 
-      const result = await (operations as any)._executeStepOperation(session, session.id, {
+      const result = await internals(operations).execution.executeStep(session, session.id, {
         command: 'next',
         threadId: 1,
         logTag: 'stepOver',
@@ -1491,7 +1500,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       };
       const session = { ...mockSession, proxyManager: proxyStub, state: SessionState.PAUSED } as any;
 
-      const promise = (operations as any)._executeStepOperation(session, session.id, {
+      const promise = internals(operations).execution.executeStep(session, session.id, {
         command: 'next',
         threadId: 1,
         logTag: 'stepOver',
@@ -1504,7 +1513,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       const result = await promise;
 
       expect(result.success).toBe(true);
-      expect(result.data?.message).toBe('Step completed.');
+      expect((result.data as { message?: string }).message).toBe('Step completed.');
       expect(proxyStub.off).toHaveBeenCalledWith('stopped', expect.any(Function));
       expect(proxyStub.sendDapRequest).toHaveBeenCalledWith('next', { threadId: 1 });
       expect(mockSessionStore.updateState).toHaveBeenCalledWith(session.id, SessionState.RUNNING);


### PR DESCRIPTION
## Summary

Pure refactor, zero behavior change (`no-changelog`). Fifth PR of the structural-refactor series (after #563–#566).

`src/session/session-manager-operations.ts` was 3,494 lines — the other churn epicenter (88 commits in the last 250) — with every method seeing all of the manager's state. This PR introduces an explicit `OperationsContext` and moves the **leaf** slices out behind it; `SessionManagerOperations` becomes a facade for those slices. Launch and attach deliberately stay on the facade for the next PR.

```
src/session/operations-context.ts            OperationsContext + per-slice Pick<> aliases (BreakpointContext, ExecutionContext, …)
src/session/dap-request-helpers.ts           resolveDapTimeoutOverride, withTimeoutHint, truncateForLog as free functions
src/session/breakpoints/breakpoint-controller.ts   set/remove/clear + syncBreakpointsForFile + syncFunctionBreakpoints
src/session/breakpoints/anchor-resolution.ts       reresolveAnchors (shared by restart and redefine_classes)
src/session/breakpoints/launch-warnings.ts         the three PURE warning builders, now plain exported functions
src/session/execution/execution-controller.ts      step*/continue/pause/listThreads; steps are table-driven; executeStep is public
src/session/inspection/expression-evaluator.ts     evaluateExpression
src/session/jvm/redefine-classes-controller.ts
src/session/mirror/mirror-controller.ts            expose/unexpose
```

**Why this keeps ~50 test files green untouched:** every context member that maps to a facade method is a *late-bound arrow* (`selectPolicy: (l) => this.selectPolicy(l)`), never a captured reference, so tests that spy on or reassign those methods on the instance still intercept; tunables stay as facade fields exposed through getters; the two policy sources (`selectPolicy` — data layer, test-overridable — vs `sessionStore.selectPolicy`) are kept distinct and every moved call uses its original one; collaborator→collaborator dependencies are constructor arguments invoked at call time (no `.bind`, no destructuring), so `vi.spyOn(collaborator, 'method')` works. The 19 public method signatures are byte-identical; `handleAutoContinue` still calls `this.continue`.

**Verified, not asserted:** the review's independent string-literal set comparison (old file vs. facade + nine new modules) found no user-facing message, log literal, DAP command or error-text difference — 17 of 17 moved bodies diff clean under `this.` → `this.ctx.` normalisation; the public surface diff is empty; the ratchet baseline is unchanged. One disclosed ordering nuance (the store-policy lookup in the function-breakpoint launch warning now precedes an early return) was shown to be a no-op: the lookup was already inside `try/catch`, the store's lookup is pure, and no test observes its call count.

Facade: 3,494 → 2,029 lines (the remainder is the launch/attach pipeline, next PR).

## Test plan

- [x] `pnpm run typecheck` 0; `pnpm run typecheck:all` exit 0 (baseline unchanged 751/92); `npm run lint`
- [x] `npx vitest run tests/core/unit/session tests/unit/session-manager-operations-coverage.test.ts` 30 files / 552 tests; server guard 24 files / 362; `--project unit` 241 files / 4,577
- [x] `npm run build` (declaration emit)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eq9fRrPuacc6ScMEkEGX9T
