### PR TITLE
refactor: type DebugResult.data, finish the FakeDebugAdapter migration, share adapter disposal

### DIFF
--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -255,20 +255,47 @@ default window, the window is caller-configurable (issue #143):
 
 ### DebugResult Pattern
 
-Most operations return a standardized `DebugResult`:
+Most operations return a standardized `DebugResult`, generic over the shape of
+its `data` bag (`src/session/session-manager-core.ts`):
 
 ```typescript
-interface DebugResult {
+// An open bag with the fields every reader actually touches named.
+// ProxyFailureDiagnostics (src/session/launch/proxy-failure-diagnostics.ts)
+// contributes the pointers a failed launch or attach returns.
+type DebugResultData = ProxyFailureDiagnostics & {
+  message?: string;
+  warning?: string;
+  /** Still running; the operation completes asynchronously (step and pause). */
+  pending?: boolean;
+  [key: string]: unknown;
+};
+
+interface DebugResult<TData extends DebugResultData = DebugResultData> {
   success: boolean;
   state: SessionState;
   error?: string;
-  data?: unknown;
+  data?: TData;
   canContinue?: boolean;
   // Machine-readable error identity for tests and callers (avoid string assertions)
   errorType?: string; // e.g., 'PythonNotFoundError'
   errorCode?: number; // e.g., -32602 (MCP InvalidParams)
 }
 ```
+
+An operation with a richer bag names it and instantiates the parameter —
+`StepResultData` (`location`), `PauseResultData` (`stopReason`,
+`rawStopReason`), `AttachResultData` (`attachConfig`) — so callers read the
+fields straight off the result:
+
+```typescript
+const result = await sessionManager.pause(sessionId);
+const reason = result.data?.stopReason;   // typed; no cast
+```
+
+`data` used to be `unknown`, which meant every server handler cast it back into
+a shape it invented on the spot — a cast the compiler could not check and that
+silently outlived the field it named. Add a `…ResultData` type for a new
+payload rather than widening the bag.
 
 Example usage:
 

--- a/src/adapters/adapter-disposal.ts
+++ b/src/adapters/adapter-disposal.ts
@@ -1,0 +1,49 @@
+/**
+ * The one way to dispose an adapter you are done with.
+ *
+ * Two call sites own an adapter's registry slot and have to give it back:
+ * `AdapterLease.release()` (the setup window) and `ProxyManager.cleanup()`
+ * (after the transfer). Both ran their own dispose-with-warn block, and the
+ * two blocks disagreed in the way that matters: the lease awaited inside a
+ * `try`, while `ProxyManager` fire-and-forgot with `dispose().catch(...)` — a
+ * `dispose()` that throws *synchronously* produces no promise, so that
+ * `.catch` never runs and the throw escaped into `cleanup()` mid-teardown.
+ *
+ * Awaiting inside the guard covers both failure modes with one warn shape.
+ * Neither site has anywhere to report a failure to give a slot back — the
+ * lease is a `finally` guarding the error the caller is about to report, and
+ * cleanup runs on the exit path — so this is deliberately total: a rejection,
+ * a synchronous throw, an adapter that turns out not to have `dispose` at all,
+ * and a logger that throws while reporting one of those all end here.
+ *
+ * `context` is the per-site prefix, and it carries the whole difference
+ * between the two messages, which are pinned by their respective tests.
+ */
+import type { IDebugAdapter, ILogger } from '@debugmcp/shared';
+import { getErrorMessage } from '../errors/debug-errors.js';
+
+/**
+ * Dispose `adapter`, reporting any failure as `"<context>: <message>"` and
+ * never throwing.
+ *
+ * The duck-typed `typeof adapter.dispose === 'function'` guard both sites used
+ * to carry is gone: `IDebugAdapter.dispose()` is required, and the guard only
+ * ever protected hand-rolled test doubles that omitted it. A double that still
+ * does is now reported as a failed disposal rather than silently skipped,
+ * which is the honest answer — the registry slot was not returned.
+ */
+export async function disposeAdapterQuietly(
+  adapter: IDebugAdapter,
+  logger: ILogger,
+  context: string
+): Promise<void> {
+  try {
+    await adapter.dispose();
+  } catch (disposeError: unknown) {
+    try {
+      logger.warn(`${context}: ${getErrorMessage(disposeError)}`);
+    } catch {
+      // Deliberately empty — see above.
+    }
+  }
+}

--- a/src/adapters/adapter-lease.ts
+++ b/src/adapters/adapter-lease.ts
@@ -26,12 +26,12 @@
  *
  * The lease covers only the setup window. After a transfer the ProxyManager is
  * the owner, and disposal happens through its teardown — `ProxyManager.cleanup()`
- * calls `adapter.dispose()`, which the callers' catches reach by stopping
- * `session.proxyManager` — exactly as before.
+ * disposes through the same `disposeAdapterQuietly` helper, which the callers'
+ * catches reach by stopping `session.proxyManager` — exactly as before.
  */
 import type { AdapterConfig, IAdapterRegistry, IDebugAdapter } from '@debugmcp/shared';
 import type { ILogger, IProxyManagerFactory } from '../interfaces/external-dependencies.js';
-import { getErrorMessage } from '../errors/debug-errors.js';
+import { disposeAdapterQuietly } from './adapter-disposal.js';
 import type { IProxyManager } from '../proxy/proxy-manager.js';
 
 /**
@@ -98,11 +98,9 @@ export class AdapterLease {
    * **Never throws, and that is load-bearing**: this is the `finally` of
    * `ProxyLauncher.start`, so anything escaping here replaces the setup error
    * that sent us there with a teardown error — hiding the cause the caller was
-   * about to report. So every step is inside the guard, not just the call:
-   * a missing or nullish adapter (a partial registry double), a `dispose()`
-   * that throws *synchronously* (no promise ever exists, so `.catch()` on the
-   * result would never run), a rejected `dispose()`, and a logger that throws
-   * while reporting one of those.
+   * about to report. `disposeAdapterQuietly` is what makes that true (issue
+   * #573); the state flips to 'released' before it runs, so a failed disposal
+   * still ends the lease rather than leaving it to be retried.
    */
   async release(): Promise<void> {
     if (this.state !== 'held') {
@@ -110,34 +108,10 @@ export class AdapterLease {
     }
     this.state = 'released';
 
-    try {
-      // Duck-typed for parity with ProxyManager.cleanup(), whose adapter handle
-      // is likewise optional-shaped — and read inside the guard, because the
-      // property access itself throws if the adapter is nullish.
-      const disposable = this.adapter as { dispose?: () => Promise<void> } | undefined;
-      if (typeof disposable?.dispose !== 'function') {
-        return;
-      }
-      await disposable.dispose();
-    } catch (disposeError: unknown) {
-      this.warnDisposeFailed(disposeError);
-    }
-  }
-
-  /**
-   * Report a failed disposal. Guarded in turn: a logger that throws must not
-   * become the failure `release()` promises never to raise, and there is
-   * nowhere left to report it.
-   */
-  private warnDisposeFailed(disposeError: unknown): void {
-    try {
-      this.logger.warn(
-        `[SessionManager] Failed to dispose adapter after launch setup error for session ${
-          this.sessionId
-        }: ${getErrorMessage(disposeError)}`
-      );
-    } catch {
-      // Deliberately empty — see above.
-    }
+    await disposeAdapterQuietly(
+      this.adapter,
+      this.logger,
+      `[SessionManager] Failed to dispose adapter after launch setup error for session ${this.sessionId}`
+    );
   }
 }

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -27,6 +27,7 @@ import type {
   ProxyDapResponseMessage,
   ProxyMessage
 } from '../dap-core/types.js';
+import { disposeAdapterQuietly } from '../adapters/adapter-disposal.js';
 import { ErrorMessages, ProxyInitProgress } from '../utils/error-messages.js';
 import { ProxyConfig } from './proxy-config.js';
 import type { BreakpointSyncResult, FunctionBreakpointSyncResult } from './dap-proxy-interfaces.js';
@@ -1482,11 +1483,18 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // Clear adapter-provided launch barriers
     this.clearActiveLaunchBarrier();
 
-    // Dispose the adapter so AdapterRegistry releases the instance slot
-    if (this.adapter && typeof this.adapter.dispose === 'function') {
-      this.adapter.dispose().catch(err => {
-        this.logger.warn(`[ProxyManager] Error disposing adapter during cleanup: ${err instanceof Error ? err.message : String(err)}`);
-      });
+    // Dispose the adapter so AdapterRegistry releases the instance slot.
+    // Fire-and-forget because cleanup() is synchronous and runs on the exit
+    // path, but through the shared helper, which AWAITS dispose() inside its
+    // own guard: the `dispose().catch(...)` this replaces could not see a
+    // dispose that threw synchronously, and that throw escaped mid-teardown
+    // (issue #573).
+    if (this.adapter) {
+      void disposeAdapterQuietly(
+        this.adapter,
+        this.logger,
+        '[ProxyManager] Error disposing adapter during cleanup'
+      );
       this.adapter = null;
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import {
   ProxyNotRunningError
 } from './errors/debug-errors.js';
 import { SessionManager, SessionManagerConfig } from './session/session-manager.js';
+import type { DebugResult, StepResultData } from './session/session-manager-core.js';
 import { StackTraceResult } from './session/session-manager-data.js';
 import { VariableTruncationSummary } from './session/variable-caps.js';
 import { createProductionDependencies } from './container/dependencies.js';
@@ -234,7 +235,7 @@ export class DebugMcpServer implements ToolContext {
     dryRunSpawn?: boolean,
     adapterLaunchConfig?: Record<string, unknown>,
     breakOnExceptions?: ExceptionBreakMode
-  ): Promise<{ success: boolean; state: string; error?: string; data?: unknown; errorType?: string; errorCode?: number; }> {
+  ): Promise<DebugResult> {
     this.validateSession(sessionId);
 
     // Check script file exists for immediate feedback
@@ -258,7 +259,7 @@ export class DebugMcpServer implements ToolContext {
     return result;
   }
 
-  public async restartDebugging(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown }> {
+  public async restartDebugging(sessionId: string): Promise<DebugResult> {
     // Deliberately no validateSession(): a finished debuggee is
     // lifecycle-TERMINATED, and restarting after exit is the primary use
     // case (cf. handleGetOutput). Session existence is still enforced.
@@ -565,7 +566,7 @@ export class DebugMcpServer implements ToolContext {
     return true;
   }
 
-  public async stepOver(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }> {
+  public async stepOver(sessionId: string): Promise<DebugResult<StepResultData>> {
     this.validateSession(sessionId);
     const result = await this.sessionManager.stepOver(sessionId);
     if (!result.success) {
@@ -574,7 +575,7 @@ export class DebugMcpServer implements ToolContext {
     return result;
   }
 
-  public async stepInto(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }> {
+  public async stepInto(sessionId: string): Promise<DebugResult<StepResultData>> {
     this.validateSession(sessionId);
     const result = await this.sessionManager.stepInto(sessionId);
     if (!result.success) {
@@ -583,7 +584,7 @@ export class DebugMcpServer implements ToolContext {
     return result;
   }
 
-  public async stepOut(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }> {
+  public async stepOut(sessionId: string): Promise<DebugResult<StepResultData>> {
     this.validateSession(sessionId);
     const result = await this.sessionManager.stepOut(sessionId);
     if (!result.success) {

--- a/src/server/handlers/debuggee-tools.ts
+++ b/src/server/handlers/debuggee-tools.ts
@@ -34,7 +34,7 @@ export const startDebuggingTool: ToolHandler = async (ctx, args) => {
     const responsePayload: Record<string, unknown> = {
       success: debugResult.success,
       state: debugResult.state,
-      message: debugResult.error ? debugResult.error : (debugResult.data as Record<string, unknown>)?.message || `Operation status for ${args.scriptPath}`,
+      message: debugResult.error ? debugResult.error : debugResult.data?.message || `Operation status for ${args.scriptPath}`,
     };
     if (debugResult.data) {
       responsePayload.data = debugResult.data;
@@ -42,7 +42,7 @@ export const startDebuggingTool: ToolHandler = async (ctx, args) => {
     // Top-level warning join (set_breakpoint pattern): intake
     // normalization notes (issue #305) plus any session-manager
     // warning (unbound function breakpoints, issue #308).
-    const dataWarning = (debugResult.data as { warning?: string } | undefined)?.warning;
+    const dataWarning = debugResult.data?.warning;
     const startWarnings = [...intake.warnings, dataWarning].filter(Boolean);
     if (debugResult.success && startWarnings.length > 0) {
       responsePayload.warning = startWarnings.join('; ');
@@ -69,7 +69,7 @@ export const restartDebuggingTool: ToolHandler = async (ctx, args) => {
       state: debugResult.state,
       message: debugResult.error
         ? debugResult.error
-        : (debugResult.data as Record<string, unknown>)?.message || 'Debugging restarted',
+        : debugResult.data?.message || 'Debugging restarted',
     };
     if (debugResult.error) {
       responsePayload.error = debugResult.error;
@@ -79,7 +79,7 @@ export const restartDebuggingTool: ToolHandler = async (ctx, args) => {
       // Surface the merged restart warning (stale anchors and/or
       // unbound function breakpoints) at the top level too —
       // same discoverability as set_breakpoint/start_debugging.
-      const restartWarning = (debugResult.data as { warning?: string }).warning;
+      const restartWarning = debugResult.data.warning;
       if (debugResult.success && restartWarning) {
         responsePayload.warning = restartWarning;
       }
@@ -120,7 +120,7 @@ export const attachToProcessTool: ToolHandler = async (ctx, args) => {
       success: attachResult.success,
       state: attachResult.state,
       message: attachResult.error ||
-        (attachResult.data as Record<string, unknown>)?.message ||
+        attachResult.data?.message ||
         'Attach operation completed'
     };
 
@@ -160,7 +160,7 @@ export const detachFromProcessTool: ToolHandler = async (ctx, args) => {
       success: detachResult.success,
       state: detachResult.state,
       message: detachResult.error ||
-        (detachResult.data as Record<string, unknown>)?.message ||
+        detachResult.data?.message ||
         'Detach operation completed'
     };
 

--- a/src/server/handlers/debuggee-tools.ts
+++ b/src/server/handlers/debuggee-tools.ts
@@ -4,7 +4,7 @@
  */
 import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolHandler } from '../tool-context.js';
-import { attachWarning } from './shared.js';
+import { successWarning } from './shared.js';
 import {
   assertPlainObjectArg,
   normalizeStartDebuggingArgs,
@@ -79,8 +79,8 @@ export const restartDebuggingTool: ToolHandler = async (ctx, args) => {
       // Surface the merged restart warning (stale anchors and/or
       // unbound function breakpoints) at the top level too —
       // same discoverability as set_breakpoint/start_debugging.
-      const restartWarning = debugResult.data.warning;
-      if (debugResult.success && restartWarning) {
+      const restartWarning = successWarning(debugResult);
+      if (restartWarning) {
         responsePayload.warning = restartWarning;
       }
     }
@@ -129,7 +129,7 @@ export const attachToProcessTool: ToolHandler = async (ctx, args) => {
       // Surface the dropped-adapterConfig-keys warning (issue
       // #450) at the top level too — same discoverability as
       // set_breakpoint/start_debugging/restart_debugging.
-      const warning = attachWarning(attachResult);
+      const warning = successWarning(attachResult);
       if (warning) {
         responsePayload.warning = warning;
       }

--- a/src/server/handlers/execution-tools.ts
+++ b/src/server/handlers/execution-tools.ts
@@ -3,6 +3,7 @@
  * keyed by toolName), continue_execution, pause_execution, list_threads.
  */
 import type { ToolContext, ToolHandler } from '../tool-context.js';
+import type { DebugResult, StepResultData } from '../../session/session-manager-core.js';
 import { requireSessionId } from '../tool-validation.js';
 import { readLineContext } from './shared.js';
 import {
@@ -17,7 +18,7 @@ export const stepTool: ToolHandler = async (ctx, args, toolName) => {
   requireSessionId(args);
 
   try {
-    let stepResult: { success: boolean; state: string; error?: string; data?: unknown; };
+    let stepResult: DebugResult<StepResultData>;
     if (toolName === 'step_over') {
       stepResult = await ctx.stepOver(args.sessionId);
     } else if (toolName === 'step_into') {
@@ -28,7 +29,7 @@ export const stepTool: ToolHandler = async (ctx, args, toolName) => {
 
     // Build response with location and line context if available
     const stepType = toolName.replace('step_', '').replace('_', ' ');
-    const resultData = stepResult.data as { message?: string; location?: { file: string; line: number; column?: number }; pending?: boolean } | undefined;
+    const resultData = stepResult.data;
     const response: Record<string, unknown> = {
       success: stepResult.success,
       message: `Stepped ${stepType}`,

--- a/src/server/handlers/session-tools.ts
+++ b/src/server/handlers/session-tools.ts
@@ -9,7 +9,7 @@ import { checkLaunchToolchain } from '../../utils/language-availability.js';
 import { isContainerRuntime } from '../../utils/container-path-utils.js';
 import type { ToolContext, ToolHandler } from '../tool-context.js';
 import { assertPlainObjectArg, requireSessionId } from '../tool-validation.js';
-import { attachWarning } from './shared.js';
+import { successWarning } from './shared.js';
 import { failureResult, jsonResult, rethrowAsMcpError, type ToolResult } from '../tool-result.js';
 
 export const createDebugSessionTool: ToolHandler = async (ctx, args) => {
@@ -110,7 +110,7 @@ export const createDebugSessionTool: ToolHandler = async (ctx, args) => {
       // proxyLogPath, issue #551) and the dropped-adapterConfig
       // warning (issue #450) must reach this entry point too.
       const attachData = attachResult.data;
-      const warning = attachWarning(attachResult);
+      const warning = successWarning(attachResult);
       return jsonResult({
         success: attachResult.success,
         sessionId: sessionInfo.id,

--- a/src/server/handlers/shared.ts
+++ b/src/server/handlers/shared.ts
@@ -7,6 +7,7 @@ import { REDACTION_NOTICE, Variable } from '@debugmcp/shared';
 import type { LineContext } from '../../utils/line-reader.js';
 import { buildTruncationNotice, VariableTruncationSummary } from '../../session/variable-caps.js';
 import type { ToolContext } from '../tool-context.js';
+import type { DebugResult } from '../../session/session-manager-core.js';
 
 /** The line-context slice the breakpoint and step payloads embed. */
 export type EmbeddedLineContext = Pick<LineContext, 'lineContent' | 'surrounding'>;
@@ -92,9 +93,7 @@ export function variablePayloadExtras(
  * successful attach, where it is advisory rather than the failure itself.
  */
 export function attachWarning(
-  attachResult: { success: boolean; data?: unknown }
+  attachResult: Pick<DebugResult, 'success' | 'data'>
 ): string | undefined {
-  return attachResult.success
-    ? (attachResult.data as { warning?: string } | undefined)?.warning
-    : undefined;
+  return attachResult.success ? attachResult.data?.warning : undefined;
 }

--- a/src/server/handlers/shared.ts
+++ b/src/server/handlers/shared.ts
@@ -88,12 +88,18 @@ export function variablePayloadExtras(
 }
 
 /**
- * The attach warning (dropped adapterConfig keys, issue #450) both attach
- * entry points lift to the top level of their response — reported only for a
- * successful attach, where it is advisory rather than the failure itself.
+ * The advisory warning an operation's result carries, lifted to the top level
+ * of the tool response — reported only on success, where it is advice rather
+ * than the failure itself. On a failure the error is the message, and echoing
+ * a warning beside it just competes with it.
+ *
+ * Shared by the two attach entry points (dropped adapterConfig keys, issue
+ * #450) and by restart_debugging (stale anchors and unbound function
+ * breakpoints), which is why it is named for the rule it applies rather than
+ * for the first caller that needed it.
  */
-export function attachWarning(
-  attachResult: Pick<DebugResult, 'success' | 'data'>
+export function successWarning(
+  result: Pick<DebugResult, 'success' | 'data'>
 ): string | undefined {
-  return attachResult.success ? attachResult.data?.warning : undefined;
+  return result.success ? result.data?.warning : undefined;
 }

--- a/src/server/tool-context.ts
+++ b/src/server/tool-context.ts
@@ -24,6 +24,7 @@ import type {
   Variable
 } from '@debugmcp/shared';
 import type { SessionManager } from '../session/session-manager.js';
+import type { DebugResult, StepResultData } from '../session/session-manager-core.js';
 import type { StackTraceResult } from '../session/session-manager-data.js';
 import type { VariableTruncationSummary } from '../session/variable-caps.js';
 import type { SimpleFileChecker, FileExistenceResult } from '../utils/simple-file-checker.js';
@@ -85,8 +86,8 @@ export interface ToolContext {
     dryRunSpawn?: boolean,
     adapterLaunchConfig?: Record<string, unknown>,
     breakOnExceptions?: ExceptionBreakMode
-  ): Promise<{ success: boolean; state: string; error?: string; data?: unknown; errorType?: string; errorCode?: number; }>;
-  restartDebugging(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown }>;
+  ): Promise<DebugResult>;
+  restartDebugging(sessionId: string): Promise<DebugResult>;
   closeDebugSession(sessionId: string): Promise<boolean>;
   setFunctionBreakpoint(
     sessionId: string,
@@ -113,9 +114,9 @@ export interface ToolContext {
     truncation?: VariableTruncationSummary;
   }>;
   continueExecution(sessionId: string): Promise<boolean>;
-  stepOver(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }>;
-  stepInto(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }>;
-  stepOut(sessionId: string): Promise<{ success: boolean; state: string; error?: string; data?: unknown; }>;
+  stepOver(sessionId: string): Promise<DebugResult<StepResultData>>;
+  stepInto(sessionId: string): Promise<DebugResult<StepResultData>>;
+  stepOut(sessionId: string): Promise<DebugResult<StepResultData>>;
 }
 
 /**

--- a/src/session/attach/attach-controller.ts
+++ b/src/session/attach/attach-controller.ts
@@ -48,7 +48,7 @@ export class AttachController {
       breakOnExceptions?: ExceptionBreakMode;
       adapterConfig?: Record<string, unknown>;
     }
-  ): Promise<DebugResult> {
+  ): Promise<DebugResult<AttachResultData>> {
     const session = this.ctx.getSession(sessionId);
     this.ctx.logger.info(
       `[SessionManager] Attempting to attach to process for session ${sessionId}`,

--- a/src/session/attach/attach-controller.ts
+++ b/src/session/attach/attach-controller.ts
@@ -17,7 +17,7 @@ import {
   type ExceptionBreakMode
 } from '@debugmcp/shared';
 import { ErrorMessages } from '../../utils/error-messages.js';
-import type { CustomLaunchRequestArguments, DebugResult } from '../session-manager-core.js';
+import type { AttachResultData, CustomLaunchRequestArguments, DebugResult } from '../session-manager-core.js';
 import type { AttachContext } from '../operations-context.js';
 import type { BreakpointController } from '../breakpoints/breakpoint-controller.js';
 import { failProxySetup, sessionRemovedDuringTeardown } from '../launch/proxy-failure-diagnostics.js';
@@ -272,7 +272,7 @@ export class AttachController {
       // inside the builder.
       const attachFnBpWarning = this.breakpoints.functionBreakpointLaunchWarning(session);
 
-      const attachData: Record<string, unknown> = {
+      const attachData: AttachResultData = {
         message: attachConfig.processId
           ? `Attached to process PID ${attachConfig.processId}`
           : `Attached to process at ${attachConfig.host || 'localhost'}:${attachConfig.port}`,

--- a/src/session/execution/execution-controller.ts
+++ b/src/session/execution/execution-controller.ts
@@ -20,7 +20,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import { ProxyNotRunningError, SessionTerminatedError } from '../../errors/debug-errors.js';
 import { ErrorMessages } from '../../utils/error-messages.js';
 import type { ManagedSession } from '../session-store.js';
-import type { DebugResult, StepResultData } from '../session-manager-core.js';
+import type { DebugResult, PauseResultData, StepResultData } from '../session-manager-core.js';
 import type { ExecutionContext } from '../operations-context.js';
 
 /** What distinguishes the three step flavours: everything else is shared. */
@@ -303,7 +303,7 @@ export class ExecutionController {
     }
   }
 
-  async pause(sessionId: string, threadId?: number): Promise<DebugResult> {
+  async pause(sessionId: string, threadId?: number): Promise<DebugResult<PauseResultData>> {
     const session = this.ctx.getSession(sessionId);
 
     if (session.sessionLifecycle === SessionLifecycleState.TERMINATED) {
@@ -377,7 +377,7 @@ export class ExecutionController {
     // the core handleStopped listener. Adapters differ on whether the event
     // arrives before or after the response, so listen for it (registered
     // BEFORE sending the request) and only settle once the stop is observed.
-    return new Promise<DebugResult>((resolve, reject) => {
+    return new Promise<DebugResult<PauseResultData>>((resolve, reject) => {
       let settled = false;
       let stopEventSeen = false;
 
@@ -389,7 +389,7 @@ export class ExecutionController {
         clearTimeout(timeout);
       };
 
-      const settle = (result: DebugResult) => {
+      const settle = (result: DebugResult<PauseResultData>) => {
         if (settled) {
           return;
         }
@@ -421,12 +421,7 @@ export class ExecutionController {
         this.ctx.logger.info(
           `[SessionManager pause] Paused session ${sessionId}. Current state: ${session.state}`
         );
-        const data: {
-          message: string;
-          stopReason?: string;
-          rawStopReason?: string;
-          location?: { file: string; line: number; column?: number };
-        } = { message: 'Paused' };
+        const data: PauseResultData = { message: 'Paused' };
         // Only report the stop reason when handleStopped recorded a NEW stop
         // for this pause — never echo a stale earlier stop.
         if (session.lastStop && session.lastStop !== lastStopBefore) {
@@ -483,7 +478,7 @@ export class ExecutionController {
           // registered (e.g. during the threads-discovery await), the state is
           // already PAUSED and no further event will arrive.
           if (session.state === SessionState.PAUSED && !stopEventSeen) {
-            const raceData: { message: string; stopReason?: string; rawStopReason?: string } = { message: 'Paused' };
+            const raceData: PauseResultData = { message: 'Paused' };
             if (session.lastStop && session.lastStop !== lastStopBefore) {
               raceData.stopReason = session.lastStop.reason;
               if (session.lastStop.rawReason) {

--- a/src/session/execution/execution-controller.ts
+++ b/src/session/execution/execution-controller.ts
@@ -20,7 +20,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import { ProxyNotRunningError, SessionTerminatedError } from '../../errors/debug-errors.js';
 import { ErrorMessages } from '../../utils/error-messages.js';
 import type { ManagedSession } from '../session-store.js';
-import type { DebugResult } from '../session-manager-core.js';
+import type { DebugResult, StepResultData } from '../session-manager-core.js';
 import type { ExecutionContext } from '../operations-context.js';
 
 /** What distinguishes the three step flavours: everything else is shared. */
@@ -70,15 +70,15 @@ export interface StepOperationOptions {
 export class ExecutionController {
   constructor(private readonly ctx: ExecutionContext) {}
 
-  async stepOver(sessionId: string): Promise<DebugResult> {
+  async stepOver(sessionId: string): Promise<DebugResult<StepResultData>> {
     return this.step(sessionId, 'stepOver');
   }
 
-  async stepInto(sessionId: string): Promise<DebugResult> {
+  async stepInto(sessionId: string): Promise<DebugResult<StepResultData>> {
     return this.step(sessionId, 'stepInto');
   }
 
-  async stepOut(sessionId: string): Promise<DebugResult> {
+  async stepOut(sessionId: string): Promise<DebugResult<StepResultData>> {
     return this.step(sessionId, 'stepOut');
   }
 
@@ -86,7 +86,7 @@ export class ExecutionController {
    * The preamble the three step flavours share: liveness and paused-ness
    * checks, the current thread, and the error handling around the wait.
    */
-  private async step(sessionId: string, kind: StepKindName): Promise<DebugResult> {
+  private async step(sessionId: string, kind: StepKindName): Promise<DebugResult<StepResultData>> {
     const { command, operation, logTag, successMessage } = STEP_KINDS[kind];
     const session = this.ctx.getSession(sessionId);
 
@@ -137,7 +137,7 @@ export class ExecutionController {
     session: ManagedSession,
     sessionId: string,
     options: StepOperationOptions
-  ): Promise<DebugResult> {
+  ): Promise<DebugResult<StepResultData>> {
     const proxyManager = session.proxyManager;
 
     if (!proxyManager) {
@@ -163,7 +163,7 @@ export class ExecutionController {
         clearTimeout(timeout);
       };
 
-      const settle = (result: DebugResult) => {
+      const settle = (result: DebugResult<StepResultData>) => {
         if (settled) {
           return;
         }
@@ -174,7 +174,7 @@ export class ExecutionController {
 
       const success = (message: string, location?: { file: string; line: number; column?: number }) => {
         this.ctx.logger.info(`[SM ${options.logTag} ${sessionId}] ${message} Current state: ${session.state}`);
-        const data: { message: string; location?: { file: string; line: number; column?: number } } = { message };
+        const data: StepResultData = { message };
         if (location) {
           data.location = location;
         }

--- a/src/session/execution/execution-controller.ts
+++ b/src/session/execution/execution-controller.ts
@@ -20,7 +20,12 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import { ProxyNotRunningError, SessionTerminatedError } from '../../errors/debug-errors.js';
 import { ErrorMessages } from '../../utils/error-messages.js';
 import type { ManagedSession } from '../session-store.js';
-import type { DebugResult, PauseResultData, StepResultData } from '../session-manager-core.js';
+import type {
+  DebugResult,
+  PauseResultData,
+  StepResultData,
+  StopLocation
+} from '../session-manager-core.js';
 import type { ExecutionContext } from '../operations-context.js';
 
 /** What distinguishes the three step flavours: everything else is shared. */
@@ -172,7 +177,7 @@ export class ExecutionController {
         resolve(result);
       };
 
-      const success = (message: string, location?: { file: string; line: number; column?: number }) => {
+      const success = (message: string, location?: StopLocation) => {
         this.ctx.logger.info(`[SM ${options.logTag} ${sessionId}] ${message} Current state: ${session.state}`);
         const data: StepResultData = { message };
         if (location) {
@@ -187,7 +192,7 @@ export class ExecutionController {
 
       const onStopped = async () => {
         // Try to get current location from stack trace
-        let location: { file: string; line: number; column?: number } | undefined;
+        let location: StopLocation | undefined;
         try {
           // Wait a brief moment for state to settle after stopped event
           await new Promise(resolve => setTimeout(resolve, 10));
@@ -401,7 +406,7 @@ export class ExecutionController {
       const onStopped = async () => {
         stopEventSeen = true;
         // Try to get current location from stack trace
-        let location: { file: string; line: number; column?: number } | undefined;
+        let location: StopLocation | undefined;
         try {
           // Wait a brief moment for state to settle after stopped event
           await new Promise(resolve => setTimeout(resolve, 10));

--- a/src/session/launch/debug-launcher.ts
+++ b/src/session/launch/debug-launcher.ts
@@ -565,7 +565,7 @@ export class DebugLauncher {
         }
         // Join rather than clobber: startDebugging may already have set a
         // warning (unbound function breakpoints, issue #308).
-        const priorWarning = (result.data as { warning?: string } | undefined)?.warning;
+        const priorWarning = result.data?.warning;
         const staleWarning = staleCount > 0
           ? `${staleCount} statement anchor(s) no longer match the current file; those breakpoints kept their previous lines — re-set them if the target moved.`
           : undefined;
@@ -575,7 +575,7 @@ export class DebugLauncher {
           : undefined;
         const warnings = [priorWarning, staleWarning, ambiguousWarning].filter(Boolean);
         result.data = {
-          ...((result.data as object) ?? {}),
+          ...(result.data ?? {}),
           breakpointsReapplied: this.ctx.getSession(sessionId).breakpoints.size,
           // Each launch starts a fresh output buffer: tell the caller to
           // reset its get_output cursor to since=0.

--- a/src/session/launch/proxy-failure-diagnostics.ts
+++ b/src/session/launch/proxy-failure-diagnostics.ts
@@ -33,11 +33,17 @@ const PROXY_LOG_TAIL_LINES = 80;
  */
 const PROXY_LOG_TAIL_CHARS = 64 * 1024;
 
-/** The pointers a failed launch/attach returns to the caller (issue #493 / #551). */
-export interface ProxyFailureDiagnostics {
+/**
+ * The pointers a failed launch/attach returns to the caller (issue #493 / #551).
+ *
+ * A `type` rather than an `interface` because these pointers are returned *as*
+ * a `DebugResult.data` bag: only a type alias gets the implicit index signature
+ * that makes it assignable to `DebugResultData`.
+ */
+export type ProxyFailureDiagnostics = {
   initProgress?: ProxyInitProgress;
   proxyLogPath?: string;
-}
+};
 
 /**
  * What `logProxyFailure` needs. Declared here, as the narrowest possible slice,

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -28,6 +28,7 @@ import { normalizeBreakpointMessage } from '../utils/breakpoint-message.js';
 import { consumeChildOrigin } from '../utils/child-origin-events.js';
 import { isPidAlive } from '../utils/jvm-orphan-reaper.js';
 import { IAdapterRegistry } from '@debugmcp/shared';
+import type { ProxyFailureDiagnostics } from './launch/proxy-failure-diagnostics.js';
 
 // Custom launch arguments interface extending DebugProtocol.LaunchRequestArguments
 export interface CustomLaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
@@ -35,11 +36,47 @@ export interface CustomLaunchRequestArguments extends DebugProtocol.LaunchReques
   justMyCode?: boolean;
 }
 
-export interface DebugResult {
+/**
+ * The `data` bag a debug operation returns alongside its state.
+ *
+ * An open bag with typed common fields rather than a discriminated union:
+ * `startDebugging` alone returns three shapes (dry run, launch, toolchain
+ * refusal) and `restartDebugging` spreads whatever the launch produced, so a
+ * union would force narrowing at every server read for no gain. Naming the
+ * fields every reader actually touches — `message`, `warning`, and the proxy
+ * failure pointers — is what lets the server handlers read them directly
+ * instead of casting.
+ *
+ * Written as a `type`, not an `interface`, on purpose: only a type alias gets
+ * the implicit index signature that makes a `ProxyFailureDiagnostics` value
+ * assignable here.
+ */
+export type DebugResultData = ProxyFailureDiagnostics & {
+  /** Human-readable status for the tool result. */
+  message?: string;
+  /** Advisory notes joined by the operation (unbound breakpoints, dropped keys, ...). */
+  warning?: string;
+  [key: string]: unknown;
+};
+
+/** What a step operation returns: `message` is always set, plus where it landed. */
+export type StepResultData = DebugResultData & {
+  message: string;
+  location?: { file: string; line: number; column?: number };
+  /** The debuggee is still running; the step completes asynchronously. */
+  pending?: boolean;
+};
+
+/** What a successful attach returns on top of the common fields. */
+export type AttachResultData = DebugResultData & {
+  attachConfig?: unknown;
+};
+
+export interface DebugResult<TData extends DebugResultData = DebugResultData> {
   success: boolean;
   state: SessionState;
   error?: string;
-  data?: unknown;
+  data?: TData;
   canContinue?: boolean;
   // Machine-readable error identity for tests and callers (avoid string assertions)
   errorType?: string; // e.g., 'PythonNotFoundError'

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -56,6 +56,12 @@ export type DebugResultData = ProxyFailureDiagnostics & {
   message?: string;
   /** Advisory notes joined by the operation (unbound breakpoints, dropped keys, ...). */
   warning?: string;
+  /**
+   * The debuggee is still running and the operation completes asynchronously.
+   * Shared rather than step-specific: `pause` reports it too when its grace
+   * window elapses before a `stopped` event arrives.
+   */
+  pending?: boolean;
   [key: string]: unknown;
 };
 
@@ -63,8 +69,18 @@ export type DebugResultData = ProxyFailureDiagnostics & {
 export type StepResultData = DebugResultData & {
   message: string;
   location?: { file: string; line: number; column?: number };
-  /** The debuggee is still running; the step completes asynchronously. */
-  pending?: boolean;
+};
+
+/**
+ * What a pause returns. `stopReason`/`rawStopReason` are present only when
+ * this pause's own stop was recorded (never a stale earlier one), and
+ * `location` only when the stack was readable by the time it settled.
+ */
+export type PauseResultData = DebugResultData & {
+  message: string;
+  stopReason?: string;
+  rawStopReason?: string;
+  location?: { file: string; line: number; column?: number };
 };
 
 /** What a successful attach returns on top of the common fields. */

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -7,6 +7,7 @@ import {
   SessionState, SessionLifecycleState, DebugLanguage, DebugSessionInfo, mapLegacyState,
   AdapterPolicy, SessionOutputEntry, redactSecretsInString
 } from '@debugmcp/shared';
+import type { StackFrame } from '@debugmcp/shared';
 import { isRedactionEnabled } from '../utils/redaction-mode.js';
 import { ValidationResultCache } from '../utils/language-availability.js';
 import { SessionStore, ManagedSession } from './session-store.js';
@@ -46,10 +47,6 @@ export interface CustomLaunchRequestArguments extends DebugProtocol.LaunchReques
  * fields every reader actually touches — `message`, `warning`, and the proxy
  * failure pointers — is what lets the server handlers read them directly
  * instead of casting.
- *
- * Written as a `type`, not an `interface`, on purpose: only a type alias gets
- * the implicit index signature that makes a `ProxyFailureDiagnostics` value
- * assignable here.
  */
 export type DebugResultData = ProxyFailureDiagnostics & {
   /** Human-readable status for the tool result. */
@@ -65,10 +62,20 @@ export type DebugResultData = ProxyFailureDiagnostics & {
   [key: string]: unknown;
 };
 
+/**
+ * Where the debuggee is stopped, as a result payload reports it.
+ *
+ * Always derived from the top `StackFrame`, so it is defined as that frame's
+ * location fields rather than restated: `column` is optional on `StackFrame`
+ * too, so the wire shape is exactly what the five hand-copied literals this
+ * replaces produced.
+ */
+export type StopLocation = Pick<StackFrame, 'file' | 'line' | 'column'>;
+
 /** What a step operation returns: `message` is always set, plus where it landed. */
 export type StepResultData = DebugResultData & {
   message: string;
-  location?: { file: string; line: number; column?: number };
+  location?: StopLocation;
 };
 
 /**
@@ -80,7 +87,7 @@ export type PauseResultData = DebugResultData & {
   message: string;
   stopReason?: string;
   rawStopReason?: string;
-  location?: { file: string; line: number; column?: number };
+  location?: StopLocation;
 };
 
 /** What a successful attach returns on top of the common fields. */

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -35,7 +35,12 @@ import {
 import { ProxyLauncher } from './launch/proxy-launcher.js';
 import { DebugLauncher } from './launch/debug-launcher.js';
 import { AttachController } from './attach/attach-controller.js';
-import { CustomLaunchRequestArguments, DebugResult, StepResultData } from './session-manager-core.js';
+import {
+  CustomLaunchRequestArguments,
+  DebugResult,
+  PauseResultData,
+  StepResultData
+} from './session-manager-core.js';
 
 /** Result types for function-breakpoint name resolution and by-name removal (issue #559). */
 export type {
@@ -309,7 +314,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   }
 
   /** Pause a running debuggee. */
-  async pause(sessionId: string, threadId?: number): Promise<DebugResult> {
+  async pause(sessionId: string, threadId?: number): Promise<DebugResult<PauseResultData>> {
     return this.execution.pause(sessionId, threadId);
   }
 

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -36,6 +36,7 @@ import { ProxyLauncher } from './launch/proxy-launcher.js';
 import { DebugLauncher } from './launch/debug-launcher.js';
 import { AttachController } from './attach/attach-controller.js';
 import {
+  AttachResultData,
   CustomLaunchRequestArguments,
   DebugResult,
   PauseResultData,
@@ -353,7 +354,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
       breakOnExceptions?: ExceptionBreakMode;
       adapterConfig?: Record<string, unknown>;
     }
-  ): Promise<DebugResult> {
+  ): Promise<DebugResult<AttachResultData>> {
     return this.attach.attachToProcess(sessionId, attachConfig);
   }
 

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -35,7 +35,7 @@ import {
 import { ProxyLauncher } from './launch/proxy-launcher.js';
 import { DebugLauncher } from './launch/debug-launcher.js';
 import { AttachController } from './attach/attach-controller.js';
-import { CustomLaunchRequestArguments, DebugResult } from './session-manager-core.js';
+import { CustomLaunchRequestArguments, DebugResult, StepResultData } from './session-manager-core.js';
 
 /** Result types for function-breakpoint name resolution and by-name removal (issue #559). */
 export type {
@@ -286,17 +286,17 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   }
 
   /** Step over the current line. */
-  async stepOver(sessionId: string): Promise<DebugResult> {
+  async stepOver(sessionId: string): Promise<DebugResult<StepResultData>> {
     return this.execution.stepOver(sessionId);
   }
 
   /** Step into the call on the current line. */
-  async stepInto(sessionId: string): Promise<DebugResult> {
+  async stepInto(sessionId: string): Promise<DebugResult<StepResultData>> {
     return this.execution.stepInto(sessionId);
   }
 
   /** Step out of the current frame. */
-  async stepOut(sessionId: string): Promise<DebugResult> {
+  async stepOut(sessionId: string): Promise<DebugResult<StepResultData>> {
     return this.execution.stepOut(sessionId);
   }
 

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -18,7 +18,8 @@ export type {
   DebugResultData,
   StepResultData,
   PauseResultData,
-  AttachResultData
+  AttachResultData,
+  StopLocation
 } from './session-manager-core.js';
 
 export type { EvaluateResult } from './session-manager-operations.js';

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -14,7 +14,10 @@ export type {
   SessionManagerDependencies, 
   SessionManagerConfig,
   CustomLaunchRequestArguments,
-  DebugResult
+  DebugResult,
+  DebugResultData,
+  StepResultData,
+  AttachResultData
 } from './session-manager-core.js';
 
 export type { EvaluateResult } from './session-manager-operations.js';

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -17,6 +17,7 @@ export type {
   DebugResult,
   DebugResultData,
   StepResultData,
+  PauseResultData,
   AttachResultData
 } from './session-manager-core.js';
 

--- a/tests/core/unit/server/handlers/shared.test.ts
+++ b/tests/core/unit/server/handlers/shared.test.ts
@@ -7,7 +7,7 @@ import {
   readLineContext,
   redactionSummary,
   variablePayloadExtras,
-  attachWarning
+  successWarning
 } from '../../../../../src/server/handlers/shared.js';
 import { createMockToolContext } from '../server-test-helpers.js';
 
@@ -68,15 +68,15 @@ describe('redactionSummary', () => {
   });
 });
 
-describe('attachWarning', () => {
+describe('successWarning', () => {
   it('reports the data warning of a successful attach', () => {
-    expect(attachWarning({ success: true, data: { warning: 'dropped foo' } })).toBe('dropped foo');
+    expect(successWarning({ success: true, data: { warning: 'dropped foo' } })).toBe('dropped foo');
   });
 
   it('stays silent on failure, and when there is no data or no warning', () => {
-    expect(attachWarning({ success: false, data: { warning: 'dropped foo' } })).toBeUndefined();
-    expect(attachWarning({ success: true })).toBeUndefined();
-    expect(attachWarning({ success: true, data: {} })).toBeUndefined();
+    expect(successWarning({ success: false, data: { warning: 'dropped foo' } })).toBeUndefined();
+    expect(successWarning({ success: true })).toBeUndefined();
+    expect(successWarning({ success: true, data: {} })).toBeUndefined();
   });
 });
 

--- a/tests/core/unit/server/server-restart-tool.test.ts
+++ b/tests/core/unit/server/server-restart-tool.test.ts
@@ -83,6 +83,49 @@ describe('restart_debugging tool', () => {
     expect(mockSessionManager.restartDebugging).toHaveBeenCalledWith('test-session');
   });
 
+  it('lifts the restart warning to the top level of a successful result', async () => {
+    mockSessionManager.getSession.mockReturnValue({
+      id: 'test-session',
+      sessionLifecycle: 'terminated'
+    });
+    mockSessionManager.restartDebugging.mockResolvedValue({
+      success: true,
+      state: 'paused',
+      data: { breakpointsReapplied: 1, warning: '1 statement anchor(s) no longer match' }
+    });
+
+    const result = await callToolHandler({
+      method: 'tools/call',
+      params: { name: 'restart_debugging', arguments: { sessionId: 'test-session' } }
+    });
+
+    const content = JSON.parse(result.content[0].text);
+    expect(content.warning).toBe('1 statement anchor(s) no longer match');
+    expect(content.data.warning).toBe('1 statement anchor(s) no longer match');
+  });
+
+  it('withholds the warning on a failed restart, where the error is the message', async () => {
+    mockSessionManager.getSession.mockReturnValue({
+      id: 'test-session',
+      sessionLifecycle: 'active'
+    });
+    mockSessionManager.restartDebugging.mockResolvedValue({
+      success: false,
+      state: 'error',
+      error: 'relaunch failed',
+      data: { warning: 'advice that must not compete with the error' }
+    });
+
+    const result = await callToolHandler({
+      method: 'tools/call',
+      params: { name: 'restart_debugging', arguments: { sessionId: 'test-session' } }
+    });
+
+    const content = JSON.parse(result.content[0].text);
+    expect(content.warning).toBeUndefined();
+    expect(content.error).toBe('relaunch failed');
+  });
+
   it('surfaces SessionManager refusals as failed results', async () => {
     mockSessionManager.getSession.mockReturnValue({
       id: 'test-session',

--- a/tests/core/unit/session/session-manager-attach-modes.test.ts
+++ b/tests/core/unit/session/session-manager-attach-modes.test.ts
@@ -7,11 +7,20 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionManagerOperations } from '../../../../src/session/session-manager-operations.js';
-import { SessionLifecycleState, SessionState } from '@debugmcp/shared';
+import { DebugLanguage, SessionLifecycleState, SessionState } from '@debugmcp/shared';
 import { DebugSessionCreationError } from '../../../../src/errors/debug-errors.js';
 import { createEnvironmentMock } from '../../../test-utils/mocks/environment.js';
+import {
+  FakeDebugAdapter,
+  type DefinedAttachMembers
+} from '../../../test-utils/fakes/fake-debug-adapter.js';
 import type { ManagedSession } from '../../../../src/session/session-store.js';
-import type { ExceptionBreakMode, LanguageSpecificLaunchConfig } from '@debugmcp/shared';
+import type {
+  ExceptionBreakMode,
+  GenericAttachConfig,
+  LanguageSpecificAttachConfig,
+  LanguageSpecificLaunchConfig
+} from '@debugmcp/shared';
 
 class TestableSessionManagerOperations extends SessionManagerOperations {
   protected async handleAutoContinue(_sessionId: string): Promise<void> {
@@ -41,6 +50,31 @@ interface ProxyLauncherView {
 /** The proxy launcher is a protected collaborator; reaching it needs the usual cast. */
 function internals(ops: SessionManagerOperations): { proxyLauncher: ProxyLauncherView } {
   return ops as unknown as { proxyLauncher: ProxyLauncherView };
+}
+
+/**
+ * The adapter shape most of these tests want: Ruby-flavoured, attach-capable and
+ * direct-connect, so the launcher skips executable resolution and builds no adapter
+ * command. Built on the conformant fake, so every member is the one `IDebugAdapter`
+ * declares -- the hand-rolled literals this replaces were only ever checked by the
+ * `any`-typed registry mock they were handed to.
+ */
+function makeDirectConnectRubyAdapter(
+  overrides: {
+    transform?: (cfg: GenericAttachConfig) => LanguageSpecificAttachConfig;
+    supportedAttachKeys?: readonly string[];
+    resolveExecutablePath?: (preferredPath?: string) => Promise<string>;
+  } = {}
+): FakeDebugAdapter & DefinedAttachMembers {
+  return new FakeDebugAdapter({
+    language: DebugLanguage.RUBY,
+    getDefaultExecutableName: () => 'ruby',
+    resolveExecutablePath: overrides.resolveExecutablePath
+  }).withAttachSupport({
+    directConnect: true,
+    transform: overrides.transform,
+    supportedAttachKeys: overrides.supportedAttachKeys
+  });
 }
 
 describe('SessionManagerOperations attach modes', () => {
@@ -108,11 +142,7 @@ describe('SessionManagerOperations attach modes', () => {
       environment: createEnvironmentMock(),
       networkManager: { findFreePort: vi.fn().mockResolvedValue(9000) },
       adapterRegistry: {
-        create: vi.fn(),
-        getAdapterPolicy: vi.fn().mockReturnValue({
-          name: 'default',
-          getInitializationBehavior: () => ({})
-        })
+        create: vi.fn()
       }
     };
 
@@ -127,14 +157,11 @@ describe('SessionManagerOperations attach modes', () => {
   });
 
   it('skips executable resolution for direct-connect attach and builds no adapter command', async () => {
-    const adapterStub = {
-      resolveExecutablePath: vi.fn().mockRejectedValue(new Error('ruby not found')),
-      buildAdapterCommand: vi.fn(),
-      usesDirectConnectForAttach: vi.fn().mockReturnValue(true),
-      supportsAttach: vi.fn().mockReturnValue(true),
-      transformAttachConfig: vi.fn().mockImplementation((cfg: unknown) => cfg),
-      getDefaultExecutableName: vi.fn().mockReturnValue('ruby')
-    };
+    const adapterStub = makeDirectConnectRubyAdapter({
+      resolveExecutablePath: async () => {
+        throw new Error('ruby not found');
+      }
+    });
     mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
     await internals(operations).proxyLauncher.start(
@@ -153,12 +180,11 @@ describe('SessionManagerOperations attach modes', () => {
 
   it('still resolves the local toolchain for spawn-mode attach', async () => {
     mockSession.language = 'java';
-    const adapterStub = {
-      resolveExecutablePath: vi.fn().mockResolvedValue('java'),
-      buildAdapterCommand: vi.fn().mockReturnValue({ command: 'java', args: [] }),
-      supportsAttach: vi.fn().mockReturnValue(true),
-      transformAttachConfig: vi.fn().mockImplementation((cfg: unknown) => cfg)
-    };
+    const adapterStub = new FakeDebugAdapter({
+      language: DebugLanguage.JAVA,
+      resolveExecutablePath: async () => 'java',
+      buildAdapterCommand: () => ({ command: 'java', args: [] })
+    }).withAttachSupport();
     mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
     await internals(operations).proxyLauncher.start(
@@ -198,14 +224,7 @@ describe('SessionManagerOperations attach modes', () => {
     mockDependencies.adapterRegistry.getFactoryMetadata = vi
       .fn()
       .mockResolvedValue({ modes: { launch: true, attach: 'direct-connect' } });
-    const adapterStub = {
-      resolveExecutablePath: vi.fn(),
-      buildAdapterCommand: vi.fn(),
-      usesDirectConnectForAttach: vi.fn().mockReturnValue(true),
-      supportsAttach: vi.fn().mockReturnValue(true),
-      transformAttachConfig: vi.fn().mockImplementation((cfg: unknown) => cfg),
-      getDefaultExecutableName: vi.fn().mockReturnValue('ruby')
-    };
+    const adapterStub = makeDirectConnectRubyAdapter();
     mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
     // Only the gate is under test — let the post-start attach verification fail fast
     mockProxyManager.start.mockRejectedValue(new Error('stop here'));
@@ -223,22 +242,11 @@ describe('SessionManagerOperations attach modes', () => {
   });
 
   describe('adapterConfig passthrough (issue #336)', () => {
-    function makeDirectConnectAdapter() {
-      return {
-        resolveExecutablePath: vi.fn(),
-        buildAdapterCommand: vi.fn(),
-        usesDirectConnectForAttach: vi.fn().mockReturnValue(true),
-        supportsAttach: vi.fn().mockReturnValue(true),
-        transformAttachConfig: vi.fn().mockImplementation((cfg: unknown) => cfg),
-        getDefaultExecutableName: vi.fn().mockReturnValue('ruby')
-      };
-    }
-
     it('attachToProcess merges adapterConfig into the config handed to transformAttachConfig', async () => {
       mockDependencies.adapterRegistry.getFactoryMetadata = vi
         .fn()
         .mockResolvedValue({ modes: { launch: true, attach: 'direct-connect' } });
-      const adapterStub = makeDirectConnectAdapter();
+      const adapterStub = makeDirectConnectRubyAdapter();
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       const result = await operations.attachToProcess('test-session', {
@@ -274,7 +282,7 @@ describe('SessionManagerOperations attach modes', () => {
       mockDependencies.adapterRegistry.getFactoryMetadata = vi
         .fn()
         .mockResolvedValue({ modes: { launch: true, attach: 'direct-connect' } });
-      const adapterStub = makeDirectConnectAdapter();
+      const adapterStub = makeDirectConnectRubyAdapter();
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       await operations.attachToProcess('test-session', {
@@ -291,12 +299,13 @@ describe('SessionManagerOperations attach modes', () => {
     });
 
     it('strips request/__attachMode from launch-path adapterLaunchConfig too', async () => {
-      const adapterStub = {
-        resolveExecutablePath: vi.fn().mockResolvedValue('ruby'),
-        buildAdapterCommand: vi.fn().mockReturnValue({ command: 'rdbg', args: [] }),
-        supportsAttach: vi.fn().mockReturnValue(false),
-        transformLaunchConfig: vi.fn().mockImplementation(async (cfg: unknown) => cfg)
-      };
+      const adapterStub = new FakeDebugAdapter({
+        language: DebugLanguage.RUBY,
+        resolveExecutablePath: async () => 'ruby',
+        buildAdapterCommand: () => ({ command: 'rdbg', args: [] }),
+        // Declared but answering "no": not the same as never being asked.
+        supportsAttach: () => false
+      });
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       await internals(operations).proxyLauncher.start(
@@ -308,7 +317,9 @@ describe('SessionManagerOperations attach modes', () => {
         { request: 'attach', __attachMode: true, foo: 1 }
       );
 
-      const cfg = adapterStub.transformLaunchConfig.mock.calls[0][0];
+      // The launcher merges the caller's adapter extras into the generic config,
+      // so the recorded argument carries keys GenericLaunchConfig does not name.
+      const cfg = adapterStub.transformLaunchConfig.mock.calls[0][0] as Record<string, unknown>;
       expect(cfg.foo).toBe(1);
       expect(cfg.request).not.toBe('attach');
       expect(cfg.__attachMode).toBeUndefined();
@@ -320,18 +331,10 @@ describe('SessionManagerOperations attach modes', () => {
 
   describe('dropped adapterConfig keys warning (issue #450)', () => {
     function makeDirectConnectAdapter(
-      transform: (cfg: unknown) => unknown,
+      transform: (cfg: GenericAttachConfig) => LanguageSpecificAttachConfig,
       supportedAttachKeys?: readonly string[]
     ) {
-      return {
-        resolveExecutablePath: vi.fn(),
-        buildAdapterCommand: vi.fn(),
-        usesDirectConnectForAttach: vi.fn().mockReturnValue(true),
-        supportsAttach: vi.fn().mockReturnValue(true),
-        transformAttachConfig: vi.fn().mockImplementation(transform),
-        getDefaultExecutableName: vi.fn().mockReturnValue('ruby'),
-        ...(supportedAttachKeys ? { supportedAttachKeys } : {})
-      };
+      return makeDirectConnectRubyAdapter({ transform, supportedAttachKeys });
     }
 
     beforeEach(() => {
@@ -355,7 +358,7 @@ describe('SessionManagerOperations attach modes', () => {
       });
 
       expect(result.success).toBe(true);
-      const warning = (result.data as { warning?: string }).warning;
+      const warning = result.data?.warning;
       expect(warning).toContain('localRoot');
       expect(warning).toContain('remoteRoot');
       expect(warning).not.toContain('keepMe');
@@ -376,7 +379,7 @@ describe('SessionManagerOperations attach modes', () => {
       });
 
       expect(result.success).toBe(true);
-      expect((result.data as { warning?: string }).warning).toBeUndefined();
+      expect(result.data?.warning).toBeUndefined();
     });
 
     it('ignores dropped top-level attach params — only adapterConfig keys are the caller contract', async () => {
@@ -395,7 +398,7 @@ describe('SessionManagerOperations attach modes', () => {
       });
 
       expect(result.success).toBe(true);
-      expect((result.data as { warning?: string }).warning).toBeUndefined();
+      expect(result.data?.warning).toBeUndefined();
     });
 
     it('forwards keys outside supportedAttachKeys with a did-you-mean warning (issue #466)', async () => {
@@ -413,7 +416,7 @@ describe('SessionManagerOperations attach modes', () => {
       });
 
       expect(result.success).toBe(true);
-      const warning = (result.data as { warning?: string }).warning;
+      const warning = result.data?.warning;
       expect(warning).toContain('not recognized by mcp-debugger were forwarded to the ruby adapter as-is');
       expect(warning).toContain('pathMapping (did you mean pathMappings?)');
       expect(warning).not.toContain('were ignored');
@@ -439,7 +442,7 @@ describe('SessionManagerOperations attach modes', () => {
       });
 
       expect(result.success).toBe(true);
-      const warning = (result.data as { warning?: string }).warning;
+      const warning = result.data?.warning;
       expect(warning).toContain('were ignored: alsoSupported');
       expect(warning).not.toContain('keepMe');
     });
@@ -462,7 +465,7 @@ describe('SessionManagerOperations attach modes', () => {
       });
 
       expect(result.success).toBe(true);
-      const warning = (result.data as { warning?: string }).warning ?? '';
+      const warning = result.data?.warning ?? '';
       expect(warning).toContain('were ignored: localRoot');
       expect(warning).toContain('forwarded to the ruby adapter as-is: mystery');
       expect(warning.indexOf('; ')).toBeGreaterThan(0);
@@ -479,7 +482,7 @@ describe('SessionManagerOperations attach modes', () => {
         stopOnEntry: false,
         adapterConfig: { localRoot: 'C:\\x' }
       });
-      expect((first.data as { warning?: string }).warning).toContain('localRoot');
+      expect(first.data?.warning).toContain('localRoot');
 
       // Simulate detach + re-attach with a clean adapterConfig
       mockSession.proxyManager = undefined;
@@ -492,27 +495,16 @@ describe('SessionManagerOperations attach modes', () => {
         port: 12345,
         stopOnEntry: false
       });
-      expect((second.data as { warning?: string }).warning).toBeUndefined();
+      expect(second.data?.warning).toBeUndefined();
     });
   });
 
   describe('post-attach breakpoint re-sync (issue #500)', () => {
-    function makeDirectConnectAdapter() {
-      return {
-        resolveExecutablePath: vi.fn(),
-        buildAdapterCommand: vi.fn(),
-        usesDirectConnectForAttach: vi.fn().mockReturnValue(true),
-        supportsAttach: vi.fn().mockReturnValue(true),
-        transformAttachConfig: vi.fn().mockImplementation((cfg: unknown) => cfg),
-        getDefaultExecutableName: vi.fn().mockReturnValue('ruby')
-      };
-    }
-
     beforeEach(() => {
       mockDependencies.adapterRegistry.getFactoryMetadata = vi
         .fn()
         .mockResolvedValue({ modes: { launch: true, attach: 'direct-connect' } });
-      mockDependencies.adapterRegistry.create.mockResolvedValue(makeDirectConnectAdapter());
+      mockDependencies.adapterRegistry.create.mockResolvedValue(makeDirectConnectRubyAdapter());
     });
 
     it('re-sends every queued breakpoint file with forceFreshEcho after a successful attach', async () => {
@@ -577,12 +569,12 @@ describe('SessionManagerOperations attach modes', () => {
   });
 
   it('appends an attach hint when launch executable resolution fails on an attach-capable adapter', async () => {
-    const adapterStub = {
-      resolveExecutablePath: vi.fn().mockRejectedValue(new Error('ruby not found')),
-      buildAdapterCommand: vi.fn(),
-      supportsAttach: vi.fn().mockReturnValue(true),
-      transformLaunchConfig: vi.fn().mockImplementation(async (cfg: unknown) => cfg)
-    };
+    const adapterStub = new FakeDebugAdapter({
+      language: DebugLanguage.RUBY,
+      resolveExecutablePath: async () => {
+        throw new Error('ruby not found');
+      }
+    }).withAttachSupport();
     mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
     await expect(
@@ -592,11 +584,12 @@ describe('SessionManagerOperations attach modes', () => {
 
   it('omits the attach hint when the adapter has no attach support', async () => {
     mockSession.language = 'go';
-    const adapterStub = {
-      resolveExecutablePath: vi.fn().mockRejectedValue(new Error('go not found')),
-      buildAdapterCommand: vi.fn(),
-      transformLaunchConfig: vi.fn().mockImplementation(async (cfg: unknown) => cfg)
-    };
+    const adapterStub = new FakeDebugAdapter({
+      language: DebugLanguage.GO,
+      resolveExecutablePath: async () => {
+        throw new Error('go not found');
+      }
+    });
     mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
     const failure = await internals(operations).proxyLauncher

--- a/tests/test-utils/fakes/fake-debug-adapter.ts
+++ b/tests/test-utils/fakes/fake-debug-adapter.ts
@@ -193,26 +193,32 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
    * behaviour through `options` rather than through the constructor.
    */
   withAttachSupport(options: FakeAttachSupportOptions = {}): this & DefinedAttachMembers {
-    this.supportsAttach = vi.fn<Impl<'supportsAttach'>>(() => true);
-    this.supportsDetach = vi.fn<Impl<'supportsDetach'>>(() => options.detach ?? true);
-    this.usesDirectConnectForAttach = vi.fn<Impl<'usesDirectConnectForAttach'>>(
-      () => options.directConnect ?? false
-    );
-    this.transformAttachConfig = vi.fn<Impl<'transformAttachConfig'>>(
-      options.transform ??
-        ((config: GenericAttachConfig): LanguageSpecificAttachConfig => ({ ...config }))
-    );
-    this.getDefaultAttachConfig = vi.fn<Impl<'getDefaultAttachConfig'>>(
-      (): Partial<GenericAttachConfig> => ({})
-    );
+    // Built as one object typed `DefinedAttachMembers`, then assigned — the shape
+    // `withExtras` uses. The five members are optional on the class (a fake that
+    // never opted in must not define them), so the return type has to say they are
+    // present now, or callers need a non-null assertion to read
+    // `adapter.transformAttachConfig.mock`. Stating that with `as` would assert
+    // exactly what the assignments do, and would keep compiling if one were
+    // dropped; naming the object's type instead makes a missing member a TS2741
+    // here rather than an `undefined` at the call site.
+    const members: DefinedAttachMembers = {
+      supportsAttach: vi.fn<Impl<'supportsAttach'>>(() => true),
+      supportsDetach: vi.fn<Impl<'supportsDetach'>>(() => options.detach ?? true),
+      usesDirectConnectForAttach: vi.fn<Impl<'usesDirectConnectForAttach'>>(
+        () => options.directConnect ?? false
+      ),
+      transformAttachConfig: vi.fn<Impl<'transformAttachConfig'>>(
+        options.transform ??
+          ((config: GenericAttachConfig): LanguageSpecificAttachConfig => ({ ...config }))
+      ),
+      getDefaultAttachConfig: vi.fn<Impl<'getDefaultAttachConfig'>>(
+        (): Partial<GenericAttachConfig> => ({})
+      )
+    };
     if (options.supportedAttachKeys !== undefined) {
       this.supportedAttachKeys = options.supportedAttachKeys;
     }
-    // The five members above are optional on the class because a fake that never
-    // opted in must not define them. They are defined now, and saying so is what
-    // lets a caller read `adapter.transformAttachConfig.mock` without a non-null
-    // assertion that would silently survive the builder being dropped.
-    return this as this & DefinedAttachMembers;
+    return Object.assign(this, members);
   }
 
   /**

--- a/tests/test-utils/fakes/fake-debug-adapter.ts
+++ b/tests/test-utils/fakes/fake-debug-adapter.ts
@@ -192,7 +192,7 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
    * The builder wins: it replaces any same-member constructor override, so pass attach
    * behaviour through `options` rather than through the constructor.
    */
-  withAttachSupport(options: FakeAttachSupportOptions = {}): this {
+  withAttachSupport(options: FakeAttachSupportOptions = {}): this & DefinedAttachMembers {
     this.supportsAttach = vi.fn<Impl<'supportsAttach'>>(() => true);
     this.supportsDetach = vi.fn<Impl<'supportsDetach'>>(() => options.detach ?? true);
     this.usesDirectConnectForAttach = vi.fn<Impl<'usesDirectConnectForAttach'>>(
@@ -208,7 +208,11 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
     if (options.supportedAttachKeys !== undefined) {
       this.supportedAttachKeys = options.supportedAttachKeys;
     }
-    return this;
+    // The five members above are optional on the class because a fake that never
+    // opted in must not define them. They are defined now, and saying so is what
+    // lets a caller read `adapter.transformAttachConfig.mock` without a non-null
+    // assertion that would silently survive the builder being dropped.
+    return this as this & DefinedAttachMembers;
   }
 
   /**
@@ -262,3 +266,15 @@ export class FakeDebugAdapter extends EventEmitter implements IDebugAdapter {
     }
   }
 }
+
+/** The attach members {@link FakeDebugAdapter.withAttachSupport} defines. */
+export type DefinedAttachMembers = Required<
+  Pick<
+    FakeDebugAdapter,
+    | 'supportsAttach'
+    | 'supportsDetach'
+    | 'usesDirectConnectForAttach'
+    | 'transformAttachConfig'
+    | 'getDefaultAttachConfig'
+  >
+>;

--- a/tests/typecheck-baseline.json
+++ b/tests/typecheck-baseline.json
@@ -77,7 +77,7 @@
   "tests/unit/proxy/minimal-dap.test.ts": 2,
   "tests/unit/proxy/proxy-manager.handshake.test.ts": 1,
   "tests/unit/proxy/proxy-manager.start.test.ts": 39,
-  "tests/unit/session-manager-operations-coverage.test.ts": 30,
+  "tests/unit/session-manager-operations-coverage.test.ts": 26,
   "tests/unit/shared/adapter-policy-dotnet.test.ts": 49,
   "tests/unit/shared/adapter-policy-go.test.ts": 59,
   "tests/unit/shared/adapter-policy-js.test.ts": 24,

--- a/tests/unit/adapters/adapter-lease.test.ts
+++ b/tests/unit/adapters/adapter-lease.test.ts
@@ -146,13 +146,21 @@ describe('AdapterLease', () => {
 
     it('tolerates a partial adapter double that defines no dispose', async () => {
       const adapter = new FakeDebugAdapter();
-      // The production guard is duck-typed because partial doubles (and any
-      // adapter predating the member) reach it; model exactly that shape.
+      // `dispose()` is required by IDebugAdapter, so this shape is a violation
+      // — and since #573 dropped the duck-typed guard, calling it raises a
+      // TypeError. That is reported as a failed disposal (the slot really was
+      // not returned) and must still not escape the caller's `finally`.
       delete (adapter as Partial<FakeDebugAdapter>).dispose;
-      const lease = await leaseFor(adapter);
+      const logger = createMockLogger();
+      const lease = await leaseFor(adapter, logger);
 
       await expect(lease.release()).resolves.toBeUndefined();
       expect(lease.getState()).toBe('released');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[SessionManager] Failed to dispose adapter after launch setup error for session sess-1'
+        )
+      );
     });
 
     it('tolerates a registry double that resolves no adapter at all', async () => {

--- a/tests/unit/proxy/proxy-manager.branch-coverage.test.ts
+++ b/tests/unit/proxy/proxy-manager.branch-coverage.test.ts
@@ -370,4 +370,30 @@ describe('ProxyManager branch coverage scenarios', () => {
     expect(logger.warn).toHaveBeenCalledWith('[ProxyManager] Error disposing adapter launch barrier', expect.any(Error));
     expect((manager as unknown as { activeLaunchBarrier: AdapterLaunchBarrier | null }).activeLaunchBarrier).toBeNull();
   });
+
+  it('cleanup swallows an adapter dispose that throws synchronously and warns (issue #573)', async () => {
+    const adapter = new FakeDebugAdapter();
+    // The interface declares `dispose(): Promise<void>`, so a synchronous throw
+    // takes a cast — and that violation IS the case under test. No promise ever
+    // exists, so the `dispose().catch(...)` this replaced never ran and the
+    // throw escaped cleanup() in the middle of teardown.
+    adapter.dispose = vi.fn(() => {
+      throw new Error('adapter handle was already torn down');
+    }) as unknown as FakeDebugAdapter['dispose'];
+    const owningManager = new ProxyManager(adapter, launcher, fileSystem, logger);
+
+    expect(() =>
+      (owningManager as unknown as { cleanup: () => void }).cleanup()
+    ).not.toThrow();
+    // The disposal is fire-and-forget; let its microtask run before asserting.
+    await Promise.resolve();
+
+    expect(adapter.dispose).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[ProxyManager] Error disposing adapter during cleanup: adapter handle was already torn down'
+    );
+    // The slot is not coming back, but the handle is dropped either way — a
+    // retained adapter would be disposed twice by the next teardown.
+    expect((owningManager as unknown as { adapter: unknown }).adapter).toBeNull();
+  });
 });

--- a/tests/unit/proxy/proxy-manager.branch-coverage.test.ts
+++ b/tests/unit/proxy/proxy-manager.branch-coverage.test.ts
@@ -371,7 +371,7 @@ describe('ProxyManager branch coverage scenarios', () => {
     expect((manager as unknown as { activeLaunchBarrier: AdapterLaunchBarrier | null }).activeLaunchBarrier).toBeNull();
   });
 
-  it('cleanup swallows an adapter dispose that throws synchronously and warns (issue #573)', async () => {
+  it('cleanup swallows an adapter dispose that throws synchronously and warns (issue #573)', () => {
     const adapter = new FakeDebugAdapter();
     // The interface declares `dispose(): Promise<void>`, so a synchronous throw
     // takes a cast — and that violation IS the case under test. No promise ever
@@ -382,11 +382,11 @@ describe('ProxyManager branch coverage scenarios', () => {
     }) as unknown as FakeDebugAdapter['dispose'];
     const owningManager = new ProxyManager(adapter, launcher, fileSystem, logger);
 
+    // No tick needed: the throw happens while evaluating the operand of the
+    // helper's `await`, so catch and warn both run before cleanup() returns.
     expect(() =>
       (owningManager as unknown as { cleanup: () => void }).cleanup()
     ).not.toThrow();
-    // The disposal is fire-and-forget; let its microtask run before asserting.
-    await Promise.resolve();
 
     expect(adapter.dispose).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
@@ -394,6 +394,30 @@ describe('ProxyManager branch coverage scenarios', () => {
     );
     // The slot is not coming back, but the handle is dropped either way — a
     // retained adapter would be disposed twice by the next teardown.
+    expect((owningManager as unknown as { adapter: unknown }).adapter).toBeNull();
+  });
+
+  it('cleanup swallows an adapter dispose that rejects and warns (issue #573)', async () => {
+    const adapter = new FakeDebugAdapter({
+      // The other half of #573, and the half the replaced `dispose().catch(...)`
+      // did handle: an honest async failure. It is pinned separately because it
+      // settles on a later tick, so a helper that stopped awaiting would still
+      // pass the synchronous test above.
+      dispose: async () => {
+        throw new Error('dispose transport closed');
+      }
+    });
+    const owningManager = new ProxyManager(adapter, launcher, fileSystem, logger);
+
+    (owningManager as unknown as { cleanup: () => void }).cleanup();
+    expect(adapter.dispose).toHaveBeenCalledTimes(1);
+    // The disposal is fire-and-forget; let its microtasks run before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[ProxyManager] Error disposing adapter during cleanup: dispose transport closed'
+    );
     expect((owningManager as unknown as { adapter: unknown }).adapter).toBeNull();
   });
 });

--- a/tests/unit/server-coverage.test.ts
+++ b/tests/unit/server-coverage.test.ts
@@ -4,22 +4,30 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { DebugMcpServer } from '../../src/server';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { SessionLifecycleState } from '@debugmcp/shared';
 import { createProductionDependencies } from '../../src/container/dependencies.js';
-import { createMockDependencies } from '../core/unit/server/server-test-helpers.js';
+import { SessionManager } from '../../src/session/session-manager.js';
+import {
+  createMockDependencies,
+  createMockServer,
+  getResourceHandlers
+} from '../core/unit/server/server-test-helpers.js';
 
 // The same preamble the sibling suites under tests/core/unit/server/ use.
 // DebugMcpServer builds its dependencies in the constructor, so every
 // construction here used to open winston's shared file transport and a session
 // log directory that nothing ever closed: ~10 MaxListenersExceededWarning lines
 // per run and a /tmp/test.log that grew with it (issue #578).
+vi.mock('@modelcontextprotocol/sdk/server/index.js');
 vi.mock('../../src/container/dependencies.js');
 vi.mock('../../src/session/session-manager.js');
 
 describe('Server Coverage - Error Paths and Edge Cases', () => {
   let server: DebugMcpServer;
+  let mockServer: any;
   let mockSessionManager: any;
   let mockLogger: any;
 
@@ -31,13 +39,6 @@ describe('Server Coverage - Error Paths and Edge Cases', () => {
       warn: vi.fn(),
       debug: vi.fn()
     };
-
-    // Create server instance. No logFile: with the container mocked the option
-    // is inert, and naming a path here is what made this suite write one.
-    vi.mocked(createProductionDependencies).mockReturnValue(
-      createMockDependencies() as unknown as ReturnType<typeof createProductionDependencies>
-    );
-    server = new DebugMcpServer({ logLevel: 'info' });
 
     // Mock the session manager
     mockSessionManager = {
@@ -72,8 +73,26 @@ describe('Server Coverage - Error Paths and Edge Cases', () => {
       }
     };
 
-    // Replace the session manager with our mock
-    (server as any).sessionManager = mockSessionManager;
+    // Everything the server needs is wired BEFORE construction. The session
+    // manager especially: the constructor hands it to registerResourceHandlers
+    // by reference (see the trap documented in src/server.ts), so a suite that
+    // built the server first and swapped `(server as any).sessionManager`
+    // afterwards left the resource handlers bound to the automocked instance —
+    // whose getAllSessions() returns undefined, and resources/list throws.
+    // Tool handlers read the context live and did not notice; resources do.
+    vi.mocked(createProductionDependencies).mockReturnValue(
+      createMockDependencies() as unknown as ReturnType<typeof createProductionDependencies>
+    );
+    mockServer = createMockServer();
+    vi.mocked(Server).mockImplementation(function () { return mockServer as any; });
+    // `function`, not an arrow: the implementation is invoked with `new`.
+    vi.mocked(SessionManager).mockImplementation(function () {
+      return mockSessionManager as unknown as SessionManager;
+    });
+
+    // No logFile: with the container mocked the option is inert, and naming a
+    // path here is what made this suite write one.
+    server = new DebugMcpServer({ logLevel: 'info' });
     (server as any).logger = mockLogger;
   });
 
@@ -553,6 +572,24 @@ describe('Server Coverage - Error Paths and Edge Cases', () => {
       mockSessionManager.closeAllSessions.mockRejectedValue(new Error('Cleanup failed'));
       
       await expect(server.stop()).rejects.toThrow('Cleanup failed');
+    });
+  });
+
+  describe('Resource Handler Wiring', () => {
+    it('binds resources/list to the session manager the tests drive', async () => {
+      mockSessionManager.getAllSessions.mockReturnValue([
+        { id: 'sess-1', name: 'alpha', language: 'python' }
+      ]);
+
+      const { listResourcesHandler } = getResourceHandlers(mockServer);
+      const result = await listResourcesHandler({ method: 'resources/list', params: {} });
+
+      expect(mockSessionManager.getAllSessions).toHaveBeenCalled();
+      expect(result.resources).toHaveLength(1);
+      expect(result.resources[0]).toMatchObject({
+        uri: 'debug://sessions/sess-1/output',
+        mimeType: 'text/plain'
+      });
     });
   });
 

--- a/tests/unit/server-coverage.test.ts
+++ b/tests/unit/server-coverage.test.ts
@@ -7,6 +7,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DebugMcpServer } from '../../src/server';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { SessionLifecycleState } from '@debugmcp/shared';
+import { createProductionDependencies } from '../../src/container/dependencies.js';
+import { createMockDependencies } from '../core/unit/server/server-test-helpers.js';
+
+// The same preamble the sibling suites under tests/core/unit/server/ use.
+// DebugMcpServer builds its dependencies in the constructor, so every
+// construction here used to open winston's shared file transport and a session
+// log directory that nothing ever closed: ~10 MaxListenersExceededWarning lines
+// per run and a /tmp/test.log that grew with it (issue #578).
+vi.mock('../../src/container/dependencies.js');
+vi.mock('../../src/session/session-manager.js');
 
 describe('Server Coverage - Error Paths and Edge Cases', () => {
   let server: DebugMcpServer;
@@ -22,11 +32,12 @@ describe('Server Coverage - Error Paths and Edge Cases', () => {
       debug: vi.fn()
     };
 
-    // Create server instance
-    server = new DebugMcpServer({
-      logLevel: 'info',
-      logFile: '/tmp/test.log'
-    });
+    // Create server instance. No logFile: with the container mocked the option
+    // is inert, and naming a path here is what made this suite write one.
+    vi.mocked(createProductionDependencies).mockReturnValue(
+      createMockDependencies() as unknown as ReturnType<typeof createProductionDependencies>
+    );
+    server = new DebugMcpServer({ logLevel: 'info' });
 
     // Mock the session manager
     mockSessionManager = {

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import { SessionManagerOperations } from '../../src/session/session-manager-operations';
-import { SessionLifecycleState, SessionState } from '@debugmcp/shared';
+import { DebugLanguage, SessionLifecycleState, SessionState } from '@debugmcp/shared';
 
 /** Concrete subclass for testing the abstract SessionManagerOperations */
 class TestableSessionManagerOperations extends SessionManagerOperations {
@@ -22,6 +22,7 @@ import {
   DebugSessionCreationError
 } from '../../src/errors/debug-errors';
 import { createEnvironmentMock } from '../test-utils/mocks/environment';
+import { FakeDebugAdapter } from '../test-utils/fakes/fake-debug-adapter';
 import type { ExecutionController } from '../../src/session/execution/execution-controller';
 import type { DebugLauncher } from '../../src/session/launch/debug-launcher';
 import type { ManagedSession } from '../../src/session/session-store';
@@ -149,20 +150,16 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         findFreePort: vi.fn().mockResolvedValue(9000)
       },
       adapterRegistry: {
-        create: vi.fn().mockResolvedValue({
-          transformLaunchConfig: vi.fn(async (config: unknown) => config),
-          buildAdapterCommand: vi.fn().mockReturnValue('python -m debugpy'),
-          resolveExecutablePath: vi.fn().mockResolvedValue('python'),
-          dispose: vi.fn().mockResolvedValue(undefined)
-        }),
+        create: vi.fn().mockResolvedValue(
+          new FakeDebugAdapter({
+            language: DebugLanguage.PYTHON,
+            resolveExecutablePath: async () => 'python'
+          })
+        ),
         // Implementation (not mockResolvedValue) so it survives mock resets;
         // undefined metadata lets the attach-'none' gate fall through while
         // still being exercised (issue #435 part 4 review).
-        getFactoryMetadata: vi.fn(async () => undefined),
-        getAdapterPolicy: vi.fn().mockReturnValue({
-          name: 'python',
-          getInitializationBehavior: () => ({})
-        })
+        getFactoryMetadata: vi.fn(async () => undefined)
       }
     };
 
@@ -187,12 +184,12 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     });
 
     it('raises PythonNotFoundError when adapter cannot resolve interpreter', async () => {
-      const adapterStub = {
-        transformLaunchConfig: vi.fn(async (config: unknown) => config),
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('python not found')),
-        buildAdapterCommand: vi.fn(),
-        dispose: vi.fn().mockResolvedValue(undefined)
-      };
+      const adapterStub = new FakeDebugAdapter({
+        language: DebugLanguage.PYTHON,
+        resolveExecutablePath: async () => {
+          throw new Error('python not found');
+        }
+      });
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       await expect(
@@ -205,12 +202,12 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
     it('disposes the adapter when the launch transform rejects', async () => {
       mockSession.language = 'cpp';
-      const adapterStub = {
-        transformLaunchConfig: vi.fn().mockRejectedValue(new Error('C/C++ compile failed: boom')),
-        resolveExecutablePath: vi.fn(),
-        buildAdapterCommand: vi.fn(),
-        dispose: vi.fn().mockResolvedValue(undefined)
-      };
+      const adapterStub = new FakeDebugAdapter({
+        language: DebugLanguage.CPP,
+        transformLaunchConfig: async () => {
+          throw new Error('C/C++ compile failed: boom');
+        }
+      });
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       await expect(
@@ -228,13 +225,15 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         toolchain: 'msvc',
         message: 'MSVC binaries are not supported by CodeLLDB'
       };
-      const adapterStub = {
-        transformLaunchConfig: vi.fn().mockRejectedValue(new Error(validation.message)),
-        consumeLastToolchainValidation: vi.fn().mockReturnValue(validation),
-        resolveExecutablePath: vi.fn(),
-        buildAdapterCommand: vi.fn(),
-        dispose: vi.fn().mockResolvedValue(undefined)
-      };
+      const adapterStub = new FakeDebugAdapter({
+        language: DebugLanguage.CPP,
+        transformLaunchConfig: async () => {
+          throw new Error(validation.message);
+        }
+        // The toolchain verdict is duck-typed by the launcher, not an
+        // IDebugAdapter member, so it is attached as an extra rather than
+        // smuggled in through a cast.
+      }).withExtras({ consumeLastToolchainValidation: vi.fn(() => validation) });
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       let capturedError: unknown;
@@ -261,13 +260,12 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         toolchain: 'msvc',
         message: 'stale verdict from a previous launch'
       } as any;
-      const adapterStub = {
-        transformLaunchConfig: vi.fn().mockRejectedValue(new Error('C/C++ compile failed: syntax error')),
-        consumeLastToolchainValidation: vi.fn().mockReturnValue(undefined),
-        resolveExecutablePath: vi.fn(),
-        buildAdapterCommand: vi.fn(),
-        dispose: vi.fn().mockResolvedValue(undefined)
-      };
+      const adapterStub = new FakeDebugAdapter({
+        language: DebugLanguage.CPP,
+        transformLaunchConfig: async () => {
+          throw new Error('C/C++ compile failed: syntax error');
+        }
+      }).withExtras({ consumeLastToolchainValidation: vi.fn(() => undefined) });
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       await expect(
@@ -281,12 +279,12 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
     it('wraps unresolved executable errors for non-python languages', async () => {
       mockSession.language = 'javascript';
-      const adapterStub = {
-        transformLaunchConfig: vi.fn(async (config: unknown) => config),
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('node missing')),
-        buildAdapterCommand: vi.fn(),
-        dispose: vi.fn().mockResolvedValue(undefined)
-      };
+      const adapterStub = new FakeDebugAdapter({
+        language: DebugLanguage.JAVASCRIPT,
+        resolveExecutablePath: async () => {
+          throw new Error('node missing');
+        }
+      });
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       await expect(
@@ -365,12 +363,10 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         message: 'MSVC binaries have limited support'
       };
 
-      const adapterStub = {
-        transformLaunchConfig: vi.fn().mockResolvedValue({ program: 'debug.exe' }),
-        consumeLastToolchainValidation: vi.fn().mockReturnValue(validation),
-        resolveExecutablePath: vi.fn(),
-        buildAdapterCommand: vi.fn()
-      };
+      const adapterStub = new FakeDebugAdapter({
+        language: DebugLanguage.RUST,
+        transformLaunchConfig: async () => ({ program: 'debug.exe' })
+      }).withExtras({ consumeLastToolchainValidation: vi.fn(() => validation) });
       mockDependencies.adapterRegistry.create.mockResolvedValue(adapterStub);
 
       let capturedError: unknown;
@@ -1756,12 +1752,13 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     let mockAdapter: any;
 
     beforeEach(() => {
-      mockAdapter = {
-        supportsAttach: vi.fn().mockReturnValue(true),
-        transformAttachConfig: vi.fn().mockReturnValue({ type: 'java', request: 'attach', host: 'localhost', port: 5005 }),
-        buildAdapterCommand: vi.fn().mockReturnValue({ command: 'java', args: ['-jar', 'debug.jar'] }),
-        resolveExecutablePath: vi.fn().mockResolvedValue('java')
-      };
+      mockAdapter = new FakeDebugAdapter({
+        language: DebugLanguage.JAVA,
+        buildAdapterCommand: () => ({ command: 'java', args: ['-jar', 'debug.jar'] }),
+        resolveExecutablePath: async () => 'java'
+      }).withAttachSupport({
+        transform: () => ({ type: 'java', request: 'attach', host: 'localhost', port: 5005 })
+      });
       mockDependencies.adapterRegistry.create.mockResolvedValue(mockAdapter);
       mockSession.language = 'java';
       mockSession.state = SessionState.CREATED;
@@ -2476,13 +2473,14 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     // Note: startDebugging returns { success: false, ... } on error, not throw
 
     it('should detect attach mode from request field', async () => {
-      const mockAdapter = {
-        supportsAttach: vi.fn().mockReturnValue(true),
-        transformAttachConfig: vi.fn().mockReturnValue({ type: 'java', request: 'attach' }),
-        transformLaunchConfig: vi.fn().mockResolvedValue({}),
+      const mockAdapter = new FakeDebugAdapter({
+        language: DebugLanguage.JAVA,
+        transformLaunchConfig: async () => ({}),
         // Throw after config transform to exit fast
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('early_exit'))
-      };
+        resolveExecutablePath: async () => {
+          throw new Error('early_exit');
+        }
+      }).withAttachSupport({ transform: () => ({ type: 'java', request: 'attach' }) });
 
       mockDependencies.adapterRegistry.create.mockResolvedValue(mockAdapter);
       mockSession.language = 'java';
@@ -2502,12 +2500,13 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     });
 
     it('should detect attach mode from __attachMode flag', async () => {
-      const mockAdapter = {
-        supportsAttach: vi.fn().mockReturnValue(true),
-        transformAttachConfig: vi.fn().mockReturnValue({ type: 'java', request: 'attach' }),
-        transformLaunchConfig: vi.fn().mockResolvedValue({}),
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('early_exit'))
-      };
+      const mockAdapter = new FakeDebugAdapter({
+        language: DebugLanguage.JAVA,
+        transformLaunchConfig: async () => ({}),
+        resolveExecutablePath: async () => {
+          throw new Error('early_exit');
+        }
+      }).withAttachSupport({ transform: () => ({ type: 'java', request: 'attach' }) });
 
       mockDependencies.adapterRegistry.create.mockResolvedValue(mockAdapter);
       mockSession.language = 'java';
@@ -2527,15 +2526,18 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
     it('should not set program/cwd/args in attach mode', async () => {
       let capturedConfig: Record<string, unknown> | null = null;
-      const mockAdapter = {
-        supportsAttach: vi.fn().mockReturnValue(true),
-        transformAttachConfig: vi.fn().mockImplementation((config) => {
+      const mockAdapter = new FakeDebugAdapter({
+        language: DebugLanguage.JAVA,
+        transformLaunchConfig: async () => ({}),
+        resolveExecutablePath: async () => {
+          throw new Error('early_exit');
+        }
+      }).withAttachSupport({
+        transform: (config) => {
           capturedConfig = config;
           return { type: 'java', request: 'attach' };
-        }),
-        transformLaunchConfig: vi.fn().mockResolvedValue({}),
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('early_exit'))
-      };
+        }
+      });
 
       mockDependencies.adapterRegistry.create.mockResolvedValue(mockAdapter);
       mockSession.language = 'java';
@@ -2556,11 +2558,14 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     });
 
     it('should fall back to transformLaunchConfig when adapter does not support attach', async () => {
-      const mockAdapter = {
-        supportsAttach: vi.fn().mockReturnValue(false), // Does not support attach
-        transformLaunchConfig: vi.fn().mockResolvedValue({ type: 'python' }),
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('early_exit'))
-      };
+      const mockAdapter = new FakeDebugAdapter({
+        language: DebugLanguage.PYTHON,
+        supportsAttach: () => false, // Does not support attach
+        transformLaunchConfig: async () => ({ type: 'python' }),
+        resolveExecutablePath: async () => {
+          throw new Error('early_exit');
+        }
+      });
 
       mockDependencies.adapterRegistry.create.mockResolvedValue(mockAdapter);
       mockSession.language = 'python';
@@ -2579,14 +2584,17 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     });
 
     it('should propagate transformAttachConfig errors without starting an untransformed attach', async () => {
-      const mockAdapter = {
-        supportsAttach: vi.fn().mockReturnValue(true),
-        transformAttachConfig: vi.fn().mockImplementation(() => {
+      const mockAdapter = new FakeDebugAdapter({
+        language: DebugLanguage.JAVA,
+        transformLaunchConfig: async () => ({}),
+        resolveExecutablePath: async () => {
+          throw new Error('early_exit');
+        }
+      }).withAttachSupport({
+        transform: () => {
           throw new Error('Attach config transformation failed');
-        }),
-        transformLaunchConfig: vi.fn().mockResolvedValue({}),
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('early_exit'))
-      };
+        }
+      });
 
       mockDependencies.adapterRegistry.create.mockResolvedValue(mockAdapter);
       mockSession.language = 'java';
@@ -2609,11 +2617,15 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
     });
 
     it('should propagate transformLaunchConfig errors without starting an untransformed launch', async () => {
-      const mockAdapter = {
-        transformLaunchConfig: vi.fn().mockRejectedValue(new Error('C/C++ compile failed: denied')),
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('must not run')),
-        dispose: vi.fn().mockResolvedValue(undefined)
-      };
+      const mockAdapter = new FakeDebugAdapter({
+        language: DebugLanguage.CPP,
+        transformLaunchConfig: async () => {
+          throw new Error('C/C++ compile failed: denied');
+        },
+        resolveExecutablePath: async () => {
+          throw new Error('must not run');
+        }
+      });
 
       mockDependencies.adapterRegistry.create.mockResolvedValue(mockAdapter);
       mockSession.language = 'cpp';
@@ -2639,12 +2651,15 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         toolchain: 'msvc',
         message: 'MSVC binaries are not supported by CodeLLDB'
       };
-      const mockAdapter = {
-        transformLaunchConfig: vi.fn().mockRejectedValue(new Error(validation.message)),
-        consumeLastToolchainValidation: vi.fn().mockReturnValue(validation),
-        resolveExecutablePath: vi.fn().mockRejectedValue(new Error('must not run')),
-        dispose: vi.fn().mockResolvedValue(undefined)
-      };
+      const mockAdapter = new FakeDebugAdapter({
+        language: DebugLanguage.CPP,
+        transformLaunchConfig: async () => {
+          throw new Error(validation.message);
+        },
+        resolveExecutablePath: async () => {
+          throw new Error('must not run');
+        }
+      }).withExtras({ consumeLastToolchainValidation: vi.fn(() => validation) });
 
       mockDependencies.adapterRegistry.create.mockResolvedValue(mockAdapter);
       mockSession.language = 'cpp';
@@ -3150,7 +3165,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(mockProxyManager.sendDapRequest).toHaveBeenCalledWith('disconnect', {
         terminateDebuggee: false
       });
-      expect(result.data.message).toContain('process still running');
+      expect(result.data?.message).toContain('process still running');
     });
 
     it('detachFromProcess should survive proxyManager being nulled during disconnect (race condition)', async () => {
@@ -3203,7 +3218,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       const result = await operations.detachFromProcess('test-session', true);
 
       expect(result.success).toBe(true);
-      expect(result.data.message).toContain('terminated process');
+      expect(result.data?.message).toContain('terminated process');
       // Should NOT have sent disconnect with terminateDebuggee=false
       expect(mockProxyManager.sendDapRequest).not.toHaveBeenCalledWith('disconnect', {
         terminateDebuggee: false

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -501,9 +501,9 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       // marker and the session completes the step asynchronously.
       expect(result.success).toBe(true);
       expect(result.state).toBe(SessionState.RUNNING);
-      const data = result.data as { message?: string; pending?: boolean };
-      expect(data.pending).toBe(true);
-      expect(data.message).toContain('still executing');
+      const data = result.data;
+      expect(data?.pending).toBe(true);
+      expect(data?.message).toContain('still executing');
 
       vi.useRealTimers();
     });
@@ -1650,7 +1650,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       const result = await promise;
 
       expect(result.success).toBe(true);
-      expect((result.data as { message?: string }).message).toBe('Step completed.');
+      expect(result.data?.message).toBe('Step completed.');
       expect(proxyStub.off).toHaveBeenCalledWith('stopped', expect.any(Function));
       expect(proxyStub.sendDapRequest).toHaveBeenCalledWith('next', { threadId: 1 });
       expect(mockSessionStore.updateState).toHaveBeenCalledWith(session.id, SessionState.RUNNING);
@@ -3470,9 +3470,9 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       emitStopped();
       const result = await promise;
 
-      const data = result.data as { stopReason?: string; rawStopReason?: string };
-      expect(data.stopReason).toBe('pause');
-      expect(data.rawStopReason).toBe('exception');
+      const data = result.data;
+      expect(data?.stopReason).toBe('pause');
+      expect(data?.rawStopReason).toBe('exception');
     });
 
     it('does not echo a stale stop recorded before the pause was requested', async () => {
@@ -3488,8 +3488,8 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       emitStopped();
       const result = await promise;
 
-      const data = result.data as { stopReason?: string };
-      expect(data.stopReason).toBeUndefined();
+      const data = result.data;
+      expect(data?.stopReason).toBeUndefined();
     });
 
     it('flags the in-flight pause for stop-reason normalization (pausePending)', async () => {
@@ -3544,9 +3544,9 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
       const result = await operations.pause('test-session');
 
-      const data = result.data as { message?: string; stopReason?: string };
-      expect(data.message).toBe('Already paused');
-      expect(data.stopReason).toBe('breakpoint');
+      const data = result.data;
+      expect(data?.message).toBe('Already paused');
+      expect(data?.stopReason).toBe('breakpoint');
     });
 
     it('reports state PAUSED when stopped arrives before the pause response resolves (netcoredbg ordering)', async () => {
@@ -3598,9 +3598,9 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         // PAUSED asynchronously when the stop lands.
         expect(result.success).toBe(true);
         expect(result.state).toBe(SessionState.RUNNING);
-        const data = result.data as { message?: string; pending?: boolean };
-        expect(data.pending).toBe(true);
-        expect(data.message).toContain("no 'stopped' event");
+        const data = result.data;
+        expect(data?.pending).toBe(true);
+        expect(data?.message).toContain("no 'stopped' event");
       } finally {
         vi.useRealTimers();
       }


### PR DESCRIPTION
## Summary

Closes #573. Closes #578. Tenth PR of the structural-refactor series (after #563–#568, #582, #583, #586).

**`DebugResult<TData>`.** `DebugResult.data` was `unknown`, so every reader — nine server handler sites, two in the launcher, and every test that looked at a result — went through a hand-written `as { warning?: string }` / `as Record<string, unknown>` cast, and the launch/attach/step result shapes existed only as structural literals copied into `ToolContext` and `server.ts`. `DebugResult` is now generic over a typed data bag: `DebugResultData` (`ProxyFailureDiagnostics & { message?; warning?; [key: string]: unknown }`), `StepResultData`, `PauseResultData`, `AttachResultData` — an open bag with the fields every reader actually touches named, rather than a discriminated union (`startDebugging` alone returns three shapes and `restartDebugging` spreads launch data; a union would force narrowing at every read for no gain). Step methods return `Promise<DebugResult<StepResultData>>` and `pause` `Promise<DebugResult<PauseResultData>>` at every layer; `attachData` becomes `AttachResultData`. Ten casts and two hand-copied structural types are deleted from `src/` (`git grep "\.data as" -- src/` is empty), and the last `data as {…}` casts in the two big session tests go with them. `ProxyFailureDiagnostics` stays where #582 put it (`launch/proxy-failure-diagnostics.ts`), converted `interface` → `type` because only a type alias carries the implicit index signature that lets a diagnostics value be assigned into `data`; core takes a type-only import, so there is no runtime cycle.

**Last two files onto `FakeDebugAdapter`.** `session-manager-attach-modes.test.ts` (9 hand-rolled `as unknown as IDebugAdapter` literals) and `session-manager-operations-coverage.test.ts` (15) now build every adapter double on the compile-checked fake from #564; the dead `getAdapterPolicy` registry stubs are deleted. Assertions are unchanged (65 → 65 and 445 → 445 `expect`s, verified by diff), and the migration surfaced exactly the drift the fake exists to catch: one stub had `buildAdapterCommand` returning the *string* `'python -m debugpy'` where the interface returns an `AdapterCommand` (nothing asserted on it), and three literals lacked the required `dispose`. `withAttachSupport()` now returns `this & DefinedAttachMembers` so the attach mocks are readable without a cast — narrowing only.

**#573.** `AdapterLease.release()` and `ProxyManager.cleanup()` each carried their own dispose-with-warn block with different swallow semantics — the proxy's fire-and-forget `.catch` missed a *synchronous* throw from `dispose()`. One `disposeAdapterQuietly(adapter, logger, context)` (`src/adapters/adapter-disposal.ts`, await inside try, never throws, warn text unchanged at the lease) serves both, and the duck-typed `typeof adapter.dispose === 'function'` guards are gone now that every fake has `dispose`. A new proxy test pins the synchronous-throw case. Follow-up for the three fire-and-forget sites in `adapter-registry.ts`: #587.

**#578.** `tests/unit/server-coverage.test.ts` built a real `DebugMcpServer` per test without mocking the container, opening winston's shared file transport every time (~10 `MaxListenersExceededWarning` lines, a growing `/tmp/test.log`). It now uses the same `vi.mock` + `createMockDependencies()` preamble as the 24 sibling files; 79 → 79 assertions, zero warnings.

**Review round.** A 15-finding `/code-review` pass is adjudicated: eight fixed here (the type-vs-interface comment that blamed the wrong side; a ProxyManager test for the *async* dispose-rejection path — the sync-only test let a dropped `await` through; `server-coverage` now installs its mock through `vi.mocked(SessionManager).mockImplementation` so the resource handlers are bound to the same double the tests swap in; `AttachResultData` actually threaded through `attachToProcess`; `withAttachSupport()` built with `Object.assign` so a missing member is a TS2741 error instead of an unchecked cast; `docs/patterns/error-handling.md`; one `StopLocation` alias for the five restated location literals; the restart handler on the shared `successWarning` helper). Four pre-existing grace-timer/race edges in `execution-controller.ts` and the terminated-step message go to the next PR with #574; #589 (raw `attachConfig` echo) and #590 (close the `[key: string]: unknown` bag) are filed.

No changelog fragment (`no-changelog`): no user-visible behaviour changes.

## Test plan

- [x] `pnpm run typecheck` 0; `pnpm run typecheck:all` exit 0 (baseline 738 → 734, ops-coverage 30 → 26); `npm run lint`; `pnpm changelog:check`
- [x] `npx vitest run tests/core/unit/session tests/unit/session-manager-operations-coverage.test.ts tests/core/unit/server tests/unit/server-coverage.test.ts tests/unit/adapters tests/unit/proxy` green; `--project unit` 4,724 green after `npm run build`; 12-snapshot tool-list fence unchanged
- [x] `npm run build` (declaration emit) green
- [x] `npx vitest run tests/unit/server-coverage.test.ts 2>&1 | grep -c MaxListeners` → 0
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eq9fRrPuacc6ScMEkEGX9T
