### PR TITLE
fix: stop echoing raw attach configuration (#589)

### DIFF
--- a/changelog.d/589.fixed.md
+++ b/changelog.d/589.fixed.md
@@ -1,0 +1,1 @@
+**`attach_to_process` no longer echoes its raw configuration** — adapter-specific credentials are no longer disclosed back to MCP clients in `data.attachConfig` (#589)

--- a/src/session/attach/attach-controller.ts
+++ b/src/session/attach/attach-controller.ts
@@ -265,8 +265,7 @@ export class AttachController {
       const attachData: AttachResultData = {
         message: attachConfig.processId
           ? `Attached to process PID ${attachConfig.processId}`
-          : `Attached to process at ${attachConfig.host || 'localhost'}:${attachConfig.port}`,
-        attachConfig
+          : `Attached to process at ${attachConfig.host || 'localhost'}:${attachConfig.port}`
       };
       // Surface adapterConfig keys the adapter's attach transform dropped
       // (issue #450) and keys forwarded to the adapter unrecognized (issue

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -91,9 +91,7 @@ export type PauseResultData = DebugResultData & {
 };
 
 /** What a successful attach returns on top of the common fields. */
-export type AttachResultData = DebugResultData & {
-  attachConfig?: unknown;
-};
+export type AttachResultData = DebugResultData;
 
 export interface DebugResult<TData extends DebugResultData = DebugResultData> {
   success: boolean;

--- a/tests/core/unit/session/session-manager-attach-modes.test.ts
+++ b/tests/core/unit/session/session-manager-attach-modes.test.ts
@@ -228,11 +228,14 @@ describe('SessionManagerOperations attach modes', () => {
         stopOnEntry: false, // skip the post-attach thread-verify poll
         adapterConfig: {
           program: '/proc/1/root/pricer',
-          initCommands: ['settings set target.exec-search-paths /proc/1/root']
+          initCommands: ['settings set target.exec-search-paths /proc/1/root'],
+          token: 'attach-secret-must-not-be-echoed'
         }
       });
 
       expect(result.success).toBe(true);
+      expect(JSON.stringify(result)).not.toContain('attach-secret-must-not-be-echoed');
+      expect(result.data).not.toHaveProperty('attachConfig');
       const cfg = adapterStub.transformAttachConfig.mock.calls[0][0];
       expect(cfg.program).toBe('/proc/1/root/pricer');
       expect(cfg.initCommands).toEqual(['settings set target.exec-search-paths /proc/1/root']);


### PR DESCRIPTION
Closes #589. Removes the secret-bearing attachConfig response field and adds a negative serialization ratchet. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.