### PR TITLE
fix: publish compiled C++ artifacts atomically (#560)

### DIFF
--- a/changelog.d/560.fixed.md
+++ b/changelog.d/560.fixed.md
@@ -1,0 +1,1 @@
+**C/C++ source compilation publishes only complete executables** — compiler output now stays under an unselectable temporary name until an atomic rename succeeds, and recent managed artifacts survive concurrent-build cleanup (#560)

--- a/changelog.d/589.fixed.md
+++ b/changelog.d/589.fixed.md
@@ -1,0 +1,1 @@
+**`attach_to_process` no longer echoes its raw configuration** — adapter-specific credentials are no longer disclosed back to MCP clients in `data.attachConfig` (#589)

--- a/packages/adapter-cpp/src/utils/compile-utils.ts
+++ b/packages/adapter-cpp/src/utils/compile-utils.ts
@@ -54,6 +54,7 @@ const artifactFileSystem: ArtifactFileSystem = {
 };
 
 let managedArtifactSequence = 0;
+const MANAGED_OUTPUT_CLEANUP_GRACE_MS = 60_000;
 
 export function isCppSourceFile(filePath: string): boolean {
   const ext = path.extname(filePath).toLowerCase();
@@ -174,7 +175,11 @@ export function getManagedOutputPath(outputPath: string, token?: string): string
 
 function isManagedOutputName(fileName: string, outputPath: string): boolean {
   const parsed = path.parse(outputPath);
-  return fileName.startsWith(`${parsed.name}.debug-mcp-`) && fileName.endsWith(parsed.ext);
+  const prefix = `${parsed.name}.debug-mcp-`;
+  if (!fileName.startsWith(prefix) || !fileName.endsWith(parsed.ext)) {
+    return false;
+  }
+  return fileName.slice(prefix.length, fileName.length - parsed.ext.length).length > 0;
 }
 
 async function findNewestCompiledOutput(
@@ -226,6 +231,13 @@ async function removeOlderManagedOutputs(
       continue;
     }
     try {
+      const ageMs = Date.now() - (await fileSystem.stat(candidate)).mtimeMs;
+      if (ageMs < MANAGED_OUTPUT_CLEANUP_GRACE_MS) {
+        logger?.debug?.(
+          `[compile-utils] Keeping recent managed artifact ${candidate} during the concurrent-build grace window`
+        );
+        continue;
+      }
       await fileSystem.unlink(candidate);
     } catch (error) {
       logger?.debug?.(
@@ -239,11 +251,12 @@ async function removeOlderManagedOutputs(
 
 async function promoteStagedOutput(
   stagedPath: string,
+  managedPath: string,
   outputPath: string,
   platform: NodeJS.Platform,
   fileSystem: ArtifactFileSystem,
   logger?: CompileLogger
-): Promise<string> {
+): Promise<{ binaryPath?: string; error?: string }> {
   // Rename straight over the canonical path: on POSIX that is an atomic
   // replace, and on Windows fs.rename maps to MoveFileEx(REPLACE_EXISTING),
   // which replaces an unlocked target and fails on one a running debuggee
@@ -252,17 +265,26 @@ async function promoteStagedOutput(
   // this staging scheme exists to prevent.
   try {
     await fileSystem.rename(stagedPath, outputPath);
-    return outputPath;
+    return { binaryPath: outputPath };
   } catch (error) {
     const code = (error as NodeJS.ErrnoException)?.code;
     const reason = error instanceof Error ? error.message : String(error);
     const lockHint = platform === 'win32' ? ' (still locked by a running debuggee?)' : '';
     logger?.warn?.(
-      `[compile-utils] Could not replace ${outputPath}${lockHint}; launching managed rebuild ${stagedPath}: ${
+      `[compile-utils] Could not replace ${outputPath}${lockHint}; retaining managed rebuild ${managedPath}: ${
         code ? `${code}: ` : ''
       }${reason}`
     );
-    return stagedPath;
+    try {
+      await fileSystem.rename(stagedPath, managedPath);
+      return { binaryPath: managedPath };
+    } catch (managedError) {
+      return {
+        error: `Could not finalize compiled artifact ${managedPath}: ${
+          managedError instanceof Error ? managedError.message : String(managedError)
+        }`
+      };
+    }
   }
 }
 
@@ -321,7 +343,11 @@ export async function prepareSourceBinary(
     return { success: true, binaryPath: currentOutput, compiled: false };
   }
 
-  const stagedPath = getManagedOutputPath(outputPath);
+  // The compiler writes a suffix the selector cannot recognize. Only a
+  // successful rename below publishes a reusable managed artifact, so a
+  // server/compiler crash can leave at worst an ignored *.tmp file (#560).
+  const managedPath = getManagedOutputPath(outputPath);
+  const stagedPath = `${managedPath}.tmp`;
   const result = await compile({ sourcePath, outputPath: stagedPath, logger });
   if (!result.success) {
     try {
@@ -333,13 +359,23 @@ export async function prepareSourceBinary(
   }
 
   const compiledPath = result.binaryPath ?? stagedPath;
-  const launchPath = await promoteStagedOutput(
+  const promoted = await promoteStagedOutput(
     compiledPath,
+    managedPath,
     outputPath,
     platform,
     fileSystem,
     logger
   );
+  if (!promoted.binaryPath) {
+    try {
+      await fileSystem.unlink(compiledPath);
+    } catch {
+      // Best effort: the unselectable temporary file is safe to leave behind.
+    }
+    return { success: false, error: promoted.error ?? 'Could not finalize compiled artifact' };
+  }
+  const launchPath = promoted.binaryPath;
   await removeOlderManagedOutputs(outputPath, launchPath, fileSystem, logger);
   return { success: true, binaryPath: launchPath, compiled: true };
 }

--- a/packages/adapter-cpp/tests/compile-utils.test.ts
+++ b/packages/adapter-cpp/tests/compile-utils.test.ts
@@ -390,7 +390,7 @@ describe('compile-utils', () => {
       await fs.writeFile(outputPath, 'old binary');
       const compile = vi.fn(async ({ outputPath: stagedPath }: { outputPath: string }) => {
         expect(stagedPath).not.toBe(outputPath);
-        expect(path.extname(stagedPath)).toBe('.exe');
+        expect(stagedPath).toMatch(/\.exe\.tmp$/);
         await fs.writeFile(stagedPath, 'new binary');
         return { success: true, binaryPath: stagedPath };
       });
@@ -404,6 +404,7 @@ describe('compile-utils', () => {
       });
 
       expect(result).toMatchObject({ success: true, binaryPath: outputPath, compiled: true });
+      expect(result.binaryPath).not.toMatch(/\.tmp$/);
       await expect(fs.readFile(outputPath, 'utf8')).resolves.toBe('new binary');
     });
 
@@ -509,6 +510,8 @@ describe('compile-utils', () => {
     it('removes older managed artifacts after a successful deterministic rebuild', async () => {
       const olderManagedPath = getManagedOutputPath(outputPath, 'older');
       await fs.writeFile(olderManagedPath, 'obsolete');
+      const old = new Date(Date.now() - 120_000);
+      await fs.utimes(olderManagedPath, old, old);
       const result = await prepareSourceBinary({
         sourcePath,
         outputPath,
@@ -528,6 +531,8 @@ describe('compile-utils', () => {
       await fs.writeFile(outputPath, 'running binary');
       const olderManagedPath = getManagedOutputPath(outputPath, 'older');
       await fs.writeFile(olderManagedPath, 'obsolete but locked');
+      const old = new Date(Date.now() - 120_000);
+      await fs.utimes(olderManagedPath, old, old);
       const cleanupFailures = new Set([outputPath, olderManagedPath]);
       const logger = { debug: vi.fn() };
       const lockedFileSystem = {
@@ -586,7 +591,7 @@ describe('compile-utils', () => {
       expect(unavailableFileSystem.readdir).toHaveBeenCalledTimes(2);
     });
 
-    it('launches the staged artifact when promotion fails', async () => {
+    it('never launches the temporary artifact when both final renames fail', async () => {
       const logger = { warn: vi.fn() };
       const renameFailureFileSystem = {
         mkdir: fs.mkdir.bind(fs),
@@ -609,10 +614,54 @@ describe('compile-utils', () => {
         fileSystem: renameFailureFileSystem
       });
 
-      expect(result.success).toBe(true);
-      expect(result.binaryPath).toMatch(/hello\.debug-mcp-.+\.exe$/);
+      expect(result.success).toBe(false);
+      expect(result.binaryPath).toBeUndefined();
+      expect(result.error).toContain('Could not finalize compiled artifact');
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('rename denied'));
-      await expect(fs.stat(result.binaryPath!)).resolves.toBeDefined();
+      const names = await fs.readdir(path.dirname(outputPath));
+      expect(names.some((name) => name.endsWith('.tmp'))).toBe(false);
+    });
+
+    it('ignores a newer partial temporary artifact left by a crashed compiler', async () => {
+      const partialPath = `${getManagedOutputPath(outputPath, 'crashed')}.tmp`;
+      await fs.writeFile(partialPath, 'partial executable');
+      const old = new Date(Date.now() - 120_000);
+      await fs.utimes(sourcePath, old, old);
+      const compile = vi.fn(async ({ outputPath: stagedPath }: { outputPath: string }) => {
+        await fs.writeFile(stagedPath, 'complete executable');
+        return { success: true, binaryPath: stagedPath };
+      });
+
+      const result = await prepareSourceBinary({
+        sourcePath,
+        outputPath,
+        forceRebuild: false,
+        platform: 'win32',
+        compile
+      });
+
+      expect(compile).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({ success: true, binaryPath: outputPath, compiled: true });
+      await expect(fs.readFile(outputPath, 'utf8')).resolves.toBe('complete executable');
+    });
+
+    it('does not delete a recent managed artifact from a concurrent rebuild', async () => {
+      const concurrentPath = getManagedOutputPath(outputPath, 'concurrent');
+      await fs.writeFile(concurrentPath, 'other completed rebuild');
+
+      const result = await prepareSourceBinary({
+        sourcePath,
+        outputPath,
+        forceRebuild: true,
+        platform: 'win32',
+        compile: vi.fn(async ({ outputPath: stagedPath }: { outputPath: string }) => {
+          await fs.writeFile(stagedPath, 'this rebuild');
+          return { success: true, binaryPath: stagedPath };
+        })
+      });
+
+      expect(result.success).toBe(true);
+      await expect(fs.readFile(concurrentPath, 'utf8')).resolves.toBe('other completed rebuild');
     });
 
     it('uses the default selection options when the canonical artifact is fresh', async () => {

--- a/src/session/attach/attach-controller.ts
+++ b/src/session/attach/attach-controller.ts
@@ -265,8 +265,7 @@ export class AttachController {
       const attachData: AttachResultData = {
         message: attachConfig.processId
           ? `Attached to process PID ${attachConfig.processId}`
-          : `Attached to process at ${attachConfig.host || 'localhost'}:${attachConfig.port}`,
-        attachConfig
+          : `Attached to process at ${attachConfig.host || 'localhost'}:${attachConfig.port}`
       };
       // Surface adapterConfig keys the adapter's attach transform dropped
       // (issue #450) and keys forwarded to the adapter unrecognized (issue

--- a/src/session/launch/proxy-failure-diagnostics.ts
+++ b/src/session/launch/proxy-failure-diagnostics.ts
@@ -33,17 +33,11 @@ const PROXY_LOG_TAIL_LINES = 80;
  */
 const PROXY_LOG_TAIL_CHARS = 64 * 1024;
 
-/**
- * The pointers a failed launch/attach returns to the caller (issue #493 / #551).
- *
- * A `type` rather than an `interface` because these pointers are returned *as*
- * a `DebugResult.data` bag: only a type alias gets the implicit index signature
- * that makes it assignable to `DebugResultData`.
- */
-export type ProxyFailureDiagnostics = {
-  initProgress?: ProxyInitProgress;
-  proxyLogPath?: string;
-};
+  /** The pointers a failed launch/attach returns to the caller (issue #493 / #551). */
+  export interface ProxyFailureDiagnostics {
+    initProgress?: ProxyInitProgress;
+    proxyLogPath?: string;
+  }
 
 /**
  * What `logProxyFailure` needs. Declared here, as the narrowest possible slice,

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -11,6 +11,7 @@ import type { StackFrame } from '@debugmcp/shared';
 import { isRedactionEnabled } from '../utils/redaction-mode.js';
 import { ValidationResultCache } from '../utils/language-availability.js';
 import { SessionStore, ManagedSession } from './session-store.js';
+import type { ToolchainValidationState } from './session-store.js';
 import { OutputRingBuffer } from './output-buffer.js';
 import { DebugProtocol } from '@vscode/debugprotocol'; 
 import path from 'path';
@@ -30,6 +31,7 @@ import { consumeChildOrigin } from '../utils/child-origin-events.js';
 import { isPidAlive } from '../utils/jvm-orphan-reaper.js';
 import { IAdapterRegistry } from '@debugmcp/shared';
 import type { ProxyFailureDiagnostics } from './launch/proxy-failure-diagnostics.js';
+import type { AnchorResolution } from './breakpoints/anchor-resolution.js';
 
 // Custom launch arguments interface extending DebugProtocol.LaunchRequestArguments
 export interface CustomLaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
@@ -40,15 +42,13 @@ export interface CustomLaunchRequestArguments extends DebugProtocol.LaunchReques
 /**
  * The `data` bag a debug operation returns alongside its state.
  *
- * An open bag with typed common fields rather than a discriminated union:
+ * A closed set of typed common fields rather than a discriminated union:
  * `startDebugging` alone returns three shapes (dry run, launch, toolchain
  * refusal) and `restartDebugging` spreads whatever the launch produced, so a
- * union would force narrowing at every server read for no gain. Naming the
- * fields every reader actually touches — `message`, `warning`, and the proxy
- * failure pointers — is what lets the server handlers read them directly
- * instead of casting.
+ * union would force narrowing at every server read for no gain. Keeping the
+ * optional field set closed makes misspelled reads and writes fail typecheck.
  */
-export type DebugResultData = ProxyFailureDiagnostics & {
+export interface DebugResultData extends ProxyFailureDiagnostics {
   /** Human-readable status for the tool result. */
   message?: string;
   /** Advisory notes joined by the operation (unbound breakpoints, dropped keys, ...). */
@@ -59,8 +59,19 @@ export type DebugResultData = ProxyFailureDiagnostics & {
    * window elapses before a `stopped` event arrives.
    */
   pending?: boolean;
-  [key: string]: unknown;
-};
+  /** Dry-run response fields. */
+  dryRun?: boolean;
+  command?: string;
+  script?: string;
+  /** Launch result fields. */
+  reason?: string;
+  stopOnEntrySuccessful?: boolean;
+  toolchainValidation?: ToolchainValidationState;
+  /** Restart result fields. */
+  breakpointsReapplied?: number;
+  outputReset?: boolean;
+  anchorResolution?: AnchorResolution;
+}
 
 /**
  * Where the debuggee is stopped, as a result payload reports it.

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -91,9 +91,7 @@ export type PauseResultData = DebugResultData & {
 };
 
 /** What a successful attach returns on top of the common fields. */
-export type AttachResultData = DebugResultData & {
-  attachConfig?: unknown;
-};
+export type AttachResultData = DebugResultData;
 
 export interface DebugResult<TData extends DebugResultData = DebugResultData> {
   success: boolean;

--- a/tests/core/unit/session/debug-result-data.test.ts
+++ b/tests/core/unit/session/debug-result-data.test.ts
@@ -1,0 +1,23 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { DebugResultData } from '../../../../src/session/session-manager-core.js';
+
+describe('DebugResultData type contract (issue #590)', () => {
+  it('stays closed over the result keys written by the session layer', () => {
+    expectTypeOf<keyof DebugResultData>().toEqualTypeOf<
+      | 'initProgress'
+      | 'proxyLogPath'
+      | 'message'
+      | 'warning'
+      | 'pending'
+      | 'dryRun'
+      | 'command'
+      | 'script'
+      | 'reason'
+      | 'stopOnEntrySuccessful'
+      | 'toolchainValidation'
+      | 'breakpointsReapplied'
+      | 'outputReset'
+      | 'anchorResolution'
+    >();
+  });
+});

--- a/tests/core/unit/session/session-manager-attach-modes.test.ts
+++ b/tests/core/unit/session/session-manager-attach-modes.test.ts
@@ -228,11 +228,14 @@ describe('SessionManagerOperations attach modes', () => {
         stopOnEntry: false, // skip the post-attach thread-verify poll
         adapterConfig: {
           program: '/proc/1/root/pricer',
-          initCommands: ['settings set target.exec-search-paths /proc/1/root']
+          initCommands: ['settings set target.exec-search-paths /proc/1/root'],
+          token: 'attach-secret-must-not-be-echoed'
         }
       });
 
       expect(result.success).toBe(true);
+      expect(JSON.stringify(result)).not.toContain('attach-secret-must-not-be-echoed');
+      expect(result.data).not.toHaveProperty('attachConfig');
       const cfg = adapterStub.transformAttachConfig.mock.calls[0][0];
       expect(cfg.program).toBe('/proc/1/root/pricer');
       expect(cfg.initCommands).toEqual(['settings set target.exec-search-paths /proc/1/root']);


### PR DESCRIPTION
Closes #560. Compiles into non-selectable temporary artifacts and publishes only successful managed binaries. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.