### PR TITLE
refactor: classify session failures by type (#575)

### DIFF
--- a/changelog.d/560.fixed.md
+++ b/changelog.d/560.fixed.md
@@ -1,0 +1,1 @@
+**C/C++ source compilation publishes only complete executables** — compiler output now stays under an unselectable temporary name until an atomic rename succeeds, and recent managed artifacts survive concurrent-build cleanup (#560)

--- a/changelog.d/575.fixed.md
+++ b/changelog.d/575.fixed.md
@@ -1,0 +1,1 @@
+**Session failures are now classified by typed errors instead of message text** — user-controlled paths, expressions, and breakpoint text containing words such as `closed`, `terminated`, or `not found` can no longer change an MCP error into a `{success:false}` result (#575)

--- a/changelog.d/576.fixed.md
+++ b/changelog.d/576.fixed.md
@@ -1,0 +1,1 @@
+**Missing required tool arguments now fail consistently at the MCP boundary** — every advertised `inputSchema.required` field produces `InvalidParams: Missing required parameter: <name>` before handler dispatch (#576)

--- a/changelog.d/589.fixed.md
+++ b/changelog.d/589.fixed.md
@@ -1,0 +1,1 @@
+**`attach_to_process` no longer echoes its raw configuration** — adapter-specific credentials are no longer disclosed back to MCP clients in `data.attachConfig` (#589)

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1160,7 +1160,7 @@ Tools can return errors in two formats:
 - `-32603`: Internal error (feature not implemented, unexpected failures)
 - `-32602`: Invalid parameters (e.g., missing `sessionId`)
 
-Session-lifecycle failures (unknown/terminated session, proxy not running) are application-level failures: they return `{ "success": false, "error": "..." }` rather than an MCP transport error.
+Session-lifecycle failures (unknown/terminated session, proxy not running) are application-level failures: they return `{ "success": false, "error": "..." }` rather than an MCP transport error. Classification is based on typed lifecycle errors, never on words in an error message; an invalid path, expression, or breakpoint containing text such as `closed` or `not found` remains its original MCP error.
 
 ### MCP Error Response Format
 ```json

--- a/packages/adapter-cpp/src/utils/compile-utils.ts
+++ b/packages/adapter-cpp/src/utils/compile-utils.ts
@@ -54,6 +54,7 @@ const artifactFileSystem: ArtifactFileSystem = {
 };
 
 let managedArtifactSequence = 0;
+const MANAGED_OUTPUT_CLEANUP_GRACE_MS = 60_000;
 
 export function isCppSourceFile(filePath: string): boolean {
   const ext = path.extname(filePath).toLowerCase();
@@ -174,7 +175,11 @@ export function getManagedOutputPath(outputPath: string, token?: string): string
 
 function isManagedOutputName(fileName: string, outputPath: string): boolean {
   const parsed = path.parse(outputPath);
-  return fileName.startsWith(`${parsed.name}.debug-mcp-`) && fileName.endsWith(parsed.ext);
+  const prefix = `${parsed.name}.debug-mcp-`;
+  if (!fileName.startsWith(prefix) || !fileName.endsWith(parsed.ext)) {
+    return false;
+  }
+  return fileName.slice(prefix.length, fileName.length - parsed.ext.length).length > 0;
 }
 
 async function findNewestCompiledOutput(
@@ -226,6 +231,13 @@ async function removeOlderManagedOutputs(
       continue;
     }
     try {
+      const ageMs = Date.now() - (await fileSystem.stat(candidate)).mtimeMs;
+      if (ageMs < MANAGED_OUTPUT_CLEANUP_GRACE_MS) {
+        logger?.debug?.(
+          `[compile-utils] Keeping recent managed artifact ${candidate} during the concurrent-build grace window`
+        );
+        continue;
+      }
       await fileSystem.unlink(candidate);
     } catch (error) {
       logger?.debug?.(
@@ -239,11 +251,12 @@ async function removeOlderManagedOutputs(
 
 async function promoteStagedOutput(
   stagedPath: string,
+  managedPath: string,
   outputPath: string,
   platform: NodeJS.Platform,
   fileSystem: ArtifactFileSystem,
   logger?: CompileLogger
-): Promise<string> {
+): Promise<{ binaryPath?: string; error?: string }> {
   // Rename straight over the canonical path: on POSIX that is an atomic
   // replace, and on Windows fs.rename maps to MoveFileEx(REPLACE_EXISTING),
   // which replaces an unlocked target and fails on one a running debuggee
@@ -252,17 +265,26 @@ async function promoteStagedOutput(
   // this staging scheme exists to prevent.
   try {
     await fileSystem.rename(stagedPath, outputPath);
-    return outputPath;
+    return { binaryPath: outputPath };
   } catch (error) {
     const code = (error as NodeJS.ErrnoException)?.code;
     const reason = error instanceof Error ? error.message : String(error);
     const lockHint = platform === 'win32' ? ' (still locked by a running debuggee?)' : '';
     logger?.warn?.(
-      `[compile-utils] Could not replace ${outputPath}${lockHint}; launching managed rebuild ${stagedPath}: ${
+      `[compile-utils] Could not replace ${outputPath}${lockHint}; retaining managed rebuild ${managedPath}: ${
         code ? `${code}: ` : ''
       }${reason}`
     );
-    return stagedPath;
+    try {
+      await fileSystem.rename(stagedPath, managedPath);
+      return { binaryPath: managedPath };
+    } catch (managedError) {
+      return {
+        error: `Could not finalize compiled artifact ${managedPath}: ${
+          managedError instanceof Error ? managedError.message : String(managedError)
+        }`
+      };
+    }
   }
 }
 
@@ -321,7 +343,11 @@ export async function prepareSourceBinary(
     return { success: true, binaryPath: currentOutput, compiled: false };
   }
 
-  const stagedPath = getManagedOutputPath(outputPath);
+  // The compiler writes a suffix the selector cannot recognize. Only a
+  // successful rename below publishes a reusable managed artifact, so a
+  // server/compiler crash can leave at worst an ignored *.tmp file (#560).
+  const managedPath = getManagedOutputPath(outputPath);
+  const stagedPath = `${managedPath}.tmp`;
   const result = await compile({ sourcePath, outputPath: stagedPath, logger });
   if (!result.success) {
     try {
@@ -333,13 +359,23 @@ export async function prepareSourceBinary(
   }
 
   const compiledPath = result.binaryPath ?? stagedPath;
-  const launchPath = await promoteStagedOutput(
+  const promoted = await promoteStagedOutput(
     compiledPath,
+    managedPath,
     outputPath,
     platform,
     fileSystem,
     logger
   );
+  if (!promoted.binaryPath) {
+    try {
+      await fileSystem.unlink(compiledPath);
+    } catch {
+      // Best effort: the unselectable temporary file is safe to leave behind.
+    }
+    return { success: false, error: promoted.error ?? 'Could not finalize compiled artifact' };
+  }
+  const launchPath = promoted.binaryPath;
   await removeOlderManagedOutputs(outputPath, launchPath, fileSystem, logger);
   return { success: true, binaryPath: launchPath, compiled: true };
 }

--- a/packages/adapter-cpp/tests/compile-utils.test.ts
+++ b/packages/adapter-cpp/tests/compile-utils.test.ts
@@ -390,7 +390,7 @@ describe('compile-utils', () => {
       await fs.writeFile(outputPath, 'old binary');
       const compile = vi.fn(async ({ outputPath: stagedPath }: { outputPath: string }) => {
         expect(stagedPath).not.toBe(outputPath);
-        expect(path.extname(stagedPath)).toBe('.exe');
+        expect(stagedPath).toMatch(/\.exe\.tmp$/);
         await fs.writeFile(stagedPath, 'new binary');
         return { success: true, binaryPath: stagedPath };
       });
@@ -404,6 +404,7 @@ describe('compile-utils', () => {
       });
 
       expect(result).toMatchObject({ success: true, binaryPath: outputPath, compiled: true });
+      expect(result.binaryPath).not.toMatch(/\.tmp$/);
       await expect(fs.readFile(outputPath, 'utf8')).resolves.toBe('new binary');
     });
 
@@ -509,6 +510,8 @@ describe('compile-utils', () => {
     it('removes older managed artifacts after a successful deterministic rebuild', async () => {
       const olderManagedPath = getManagedOutputPath(outputPath, 'older');
       await fs.writeFile(olderManagedPath, 'obsolete');
+      const old = new Date(Date.now() - 120_000);
+      await fs.utimes(olderManagedPath, old, old);
       const result = await prepareSourceBinary({
         sourcePath,
         outputPath,
@@ -528,6 +531,8 @@ describe('compile-utils', () => {
       await fs.writeFile(outputPath, 'running binary');
       const olderManagedPath = getManagedOutputPath(outputPath, 'older');
       await fs.writeFile(olderManagedPath, 'obsolete but locked');
+      const old = new Date(Date.now() - 120_000);
+      await fs.utimes(olderManagedPath, old, old);
       const cleanupFailures = new Set([outputPath, olderManagedPath]);
       const logger = { debug: vi.fn() };
       const lockedFileSystem = {
@@ -586,7 +591,7 @@ describe('compile-utils', () => {
       expect(unavailableFileSystem.readdir).toHaveBeenCalledTimes(2);
     });
 
-    it('launches the staged artifact when promotion fails', async () => {
+    it('never launches the temporary artifact when both final renames fail', async () => {
       const logger = { warn: vi.fn() };
       const renameFailureFileSystem = {
         mkdir: fs.mkdir.bind(fs),
@@ -609,10 +614,54 @@ describe('compile-utils', () => {
         fileSystem: renameFailureFileSystem
       });
 
-      expect(result.success).toBe(true);
-      expect(result.binaryPath).toMatch(/hello\.debug-mcp-.+\.exe$/);
+      expect(result.success).toBe(false);
+      expect(result.binaryPath).toBeUndefined();
+      expect(result.error).toContain('Could not finalize compiled artifact');
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('rename denied'));
-      await expect(fs.stat(result.binaryPath!)).resolves.toBeDefined();
+      const names = await fs.readdir(path.dirname(outputPath));
+      expect(names.some((name) => name.endsWith('.tmp'))).toBe(false);
+    });
+
+    it('ignores a newer partial temporary artifact left by a crashed compiler', async () => {
+      const partialPath = `${getManagedOutputPath(outputPath, 'crashed')}.tmp`;
+      await fs.writeFile(partialPath, 'partial executable');
+      const old = new Date(Date.now() - 120_000);
+      await fs.utimes(sourcePath, old, old);
+      const compile = vi.fn(async ({ outputPath: stagedPath }: { outputPath: string }) => {
+        await fs.writeFile(stagedPath, 'complete executable');
+        return { success: true, binaryPath: stagedPath };
+      });
+
+      const result = await prepareSourceBinary({
+        sourcePath,
+        outputPath,
+        forceRebuild: false,
+        platform: 'win32',
+        compile
+      });
+
+      expect(compile).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({ success: true, binaryPath: outputPath, compiled: true });
+      await expect(fs.readFile(outputPath, 'utf8')).resolves.toBe('complete executable');
+    });
+
+    it('does not delete a recent managed artifact from a concurrent rebuild', async () => {
+      const concurrentPath = getManagedOutputPath(outputPath, 'concurrent');
+      await fs.writeFile(concurrentPath, 'other completed rebuild');
+
+      const result = await prepareSourceBinary({
+        sourcePath,
+        outputPath,
+        forceRebuild: true,
+        platform: 'win32',
+        compile: vi.fn(async ({ outputPath: stagedPath }: { outputPath: string }) => {
+          await fs.writeFile(stagedPath, 'this rebuild');
+          return { success: true, binaryPath: stagedPath };
+        })
+      });
+
+      expect(result.success).toBe(true);
+      await expect(fs.readFile(concurrentPath, 'utf8')).resolves.toBe('other completed rebuild');
     });
 
     it('uses the default selection options when the canonical artifact is fresh', async () => {

--- a/src/server/handlers/breakpoint-tools.ts
+++ b/src/server/handlers/breakpoint-tools.ts
@@ -121,7 +121,7 @@ async function setFunctionBreakpointBranch(ctx: ToolContext, args: WithSessionId
       warning: warnings.length > 0 ? warnings.join('; ') : undefined
     });
   } catch (error) {
-    return sessionErrorResultOrThrow(error, 'session-state');
+    return sessionErrorResultOrThrow(error);
   }
 }
 
@@ -213,10 +213,7 @@ async function setLineBreakpointBranch(ctx: ToolContext, args: WithSessionId): P
     });
     return result;
   } catch (error) {
-    // Message-sniffed session state -> {success: false}, everything else
-    // re-thrown; the sniff is wider than its name suggests (see the note in
-    // debuggee-tools.ts, start_debugging).
-    return sessionErrorResultOrThrow(error, 'session-state');
+    return sessionErrorResultOrThrow(error);
   }
 }
 
@@ -238,7 +235,7 @@ export const listBreakpointsTool: ToolHandler = async (ctx, args) => {
         : {})
     });
   } catch (error) {
-    return sessionErrorResultOrThrow(error, 'session-state');
+    return sessionErrorResultOrThrow(error);
   }
 };
 
@@ -300,7 +297,7 @@ export const removeBreakpointTool: ToolHandler = async (ctx, args) => {
       warning
     });
   } catch (error) {
-    return sessionErrorResultOrThrow(error, 'session-state');
+    return sessionErrorResultOrThrow(error);
   }
 };
 
@@ -337,6 +334,6 @@ export const clearBreakpointsTool: ToolHandler = async (ctx, args) => {
       warning: res.warning
     });
   } catch (error) {
-    return sessionErrorResultOrThrow(error, 'session-state');
+    return sessionErrorResultOrThrow(error);
   }
 };

--- a/src/server/handlers/breakpoint-tools.ts
+++ b/src/server/handlers/breakpoint-tools.ts
@@ -18,7 +18,7 @@ import { failureResult, jsonResult, sessionErrorResultOrThrow, type ToolResult }
 
 export const setBreakpointTool: ToolHandler = async (ctx, args) => {
   const isFunctionBp = args.function !== undefined;
-  if (!args.sessionId || (!isFunctionBp && (!args.file || (args.line === undefined && args.statement === undefined)))) {
+  if (!isFunctionBp && (!args.file || (args.line === undefined && args.statement === undefined))) {
     throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
   }
 

--- a/src/server/handlers/debuggee-tools.ts
+++ b/src/server/handlers/debuggee-tools.ts
@@ -2,7 +2,6 @@
  * Debuggee lifecycle tools: start_debugging, restart_debugging,
  * attach_to_process, detach_from_process, redefine_classes.
  */
-import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolHandler } from '../tool-context.js';
 import { successWarning } from './shared.js';
 import {
@@ -14,17 +13,16 @@ import {
 import { jsonResult, prettyJsonResult, sessionErrorResultOrThrow } from '../tool-result.js';
 
 export const startDebuggingTool: ToolHandler = async (ctx, args) => {
-  if (!args.sessionId || !args.scriptPath) {
-    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
-  }
+  const sessionId = args.sessionId!;
+  const scriptPath = args.scriptPath!;
 
   try {
     assertPlainObjectArg(args.adapterLaunchConfig, 'adapterLaunchConfig');
 
     const intake = normalizeStartDebuggingArgs(args.dapLaunchArgs, args.breakOnExceptions);
     const debugResult = await ctx.startDebugging(
-      args.sessionId,
-      args.scriptPath,
+      sessionId,
+      scriptPath,
       args.args,
       intake.dapLaunchArgs,
       args.dryRunSpawn,
@@ -34,7 +32,7 @@ export const startDebuggingTool: ToolHandler = async (ctx, args) => {
     const responsePayload: Record<string, unknown> = {
       success: debugResult.success,
       state: debugResult.state,
-      message: debugResult.error ? debugResult.error : debugResult.data?.message || `Operation status for ${args.scriptPath}`,
+      message: debugResult.error ? debugResult.error : debugResult.data?.message || `Operation status for ${scriptPath}`,
     };
     if (debugResult.data) {
       responsePayload.data = debugResult.data;

--- a/src/server/handlers/debuggee-tools.ts
+++ b/src/server/handlers/debuggee-tools.ts
@@ -47,14 +47,7 @@ export const startDebuggingTool: ToolHandler = async (ctx, args) => {
     }
     return jsonResult(responsePayload);
   } catch (error) {
-    // The 'session-state' sniff reads the McpError MESSAGE: terminated,
-    // closed, or ('not found' AND 'Session') becomes {success: false};
-    // everything else is re-thrown. Being a message sniff it also catches
-    // errors that merely echo user text -- a script path containing
-    // "Sessions" makes "Script file not found: ..." match -- so it is wider
-    // than "session-lifecycle failures only". Preserved verbatim from before
-    // the extraction; classifying by error code instead is a follow-up.
-    return sessionErrorResultOrThrow(error, 'session-state', { state: 'stopped' });
+    return sessionErrorResultOrThrow(error, { state: 'stopped' });
   }
 };
 
@@ -84,7 +77,7 @@ export const restartDebuggingTool: ToolHandler = async (ctx, args) => {
     }
     return jsonResult(responsePayload);
   } catch (error) {
-    return sessionErrorResultOrThrow(error, 'session-state');
+    return sessionErrorResultOrThrow(error);
   }
 };
 
@@ -135,8 +128,7 @@ export const attachToProcessTool: ToolHandler = async (ctx, args) => {
 
     return jsonResult(responsePayload);
   } catch (error) {
-    // Handle session state errors specifically
-    return sessionErrorResultOrThrow(error, 'session-state', { state: 'stopped' });
+    return sessionErrorResultOrThrow(error, { state: 'stopped' });
   }
 };
 
@@ -168,8 +160,7 @@ export const detachFromProcessTool: ToolHandler = async (ctx, args) => {
 
     return jsonResult(responsePayload);
   } catch (error) {
-    // Handle session state errors specifically
-    return sessionErrorResultOrThrow(error, 'session-state', { state: 'stopped' });
+    return sessionErrorResultOrThrow(error, { state: 'stopped' });
   }
 };
 

--- a/src/server/handlers/execution-tools.ts
+++ b/src/server/handlers/execution-tools.ts
@@ -79,7 +79,7 @@ export const stepTool: ToolHandler = async (ctx, args, toolName) => {
   } catch (error) {
     // Typed session errors and other expected Errors (like "Failed to step
     // over") both report as {success: false}; only non-Error throws escape.
-    const sessionResult = sessionErrorToResult(error, 'typed');
+    const sessionResult = sessionErrorToResult(error);
     if (sessionResult) {
       return sessionResult;
     }
@@ -99,7 +99,7 @@ export const continueExecutionTool: ToolHandler = async (ctx, args) => {
   } catch (error) {
     // Same contract as the step tools: typed session errors and other
     // expected Errors report as {success: false}; non-Errors escape.
-    const sessionResult = sessionErrorToResult(error, 'typed');
+    const sessionResult = sessionErrorToResult(error);
     if (sessionResult) {
       return sessionResult;
     }
@@ -117,7 +117,7 @@ export async function handlePause(ctx: ToolContext, args: { sessionId: string; t
     return jsonResult(result);
   } catch (error) {
     ctx.logger.error('Failed to pause execution', { error });
-    return sessionErrorToResult(error, 'typed') ??
+    return sessionErrorToResult(error) ??
       rethrowAsMcpError(error, 'Failed to pause execution');
   }
 }
@@ -133,7 +133,7 @@ export async function handleListThreads(ctx: ToolContext, args: { sessionId: str
     return jsonResult({ success: true, threads });
   } catch (error) {
     ctx.logger.error('Failed to list threads', { error });
-    return sessionErrorToResult(error, 'typed') ??
+    return sessionErrorToResult(error) ??
       rethrowAsMcpError(error, 'Failed to list threads');
   }
 }

--- a/src/server/handlers/inspection-tools.ts
+++ b/src/server/handlers/inspection-tools.ts
@@ -4,6 +4,7 @@
  */
 import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { SessionState } from '@debugmcp/shared';
+import { SessionTerminatedError } from '../../errors/debug-errors.js';
 import type { ToolContext, ToolHandler } from '../tool-context.js';
 import { enforceExplicitNames, requireSessionId } from '../tool-validation.js';
 import { variablePayloadExtras } from './shared.js';
@@ -43,7 +44,7 @@ export const getVariablesTool: ToolHandler = async (ctx, args) => {
     return jsonResult({ success: true, variables, count: variables.length, variablesReference: scope, ...variablePayloadExtras(variables, args.names, truncation) });
   } catch (error) {
     // Typed session errors report as {success: false}; anything else escapes.
-    return sessionErrorResultOrThrow(error, 'typed');
+    return sessionErrorResultOrThrow(error);
   }
 };
 
@@ -82,7 +83,7 @@ export const getStackTraceTool: ToolHandler = async (ctx, args) => {
     }
     return jsonResult(payload);
   } catch (error) {
-    const sessionResult = sessionErrorToResult(error, 'typed');
+    const sessionResult = sessionErrorToResult(error);
     if (sessionResult) {
       return sessionResult;
     }
@@ -106,7 +107,7 @@ export const getScopesTool: ToolHandler = async (ctx, args) => {
     return jsonResult({ success: true, scopes });
   } catch (error) {
     // Typed session errors report as {success: false}; anything else escapes.
-    return sessionErrorResultOrThrow(error, 'typed');
+    return sessionErrorResultOrThrow(error);
   }
 };
 
@@ -153,8 +154,7 @@ export async function handleEvaluateExpression(ctx: ToolContext, args: { session
       timestamp: Date.now()
     });
 
-    // Handle session state errors specifically
-    return sessionErrorToResult(error, 'session-state-or-not-paused') ??
+    return sessionErrorToResult(error) ??
       rethrowAsMcpError(error, 'Failed to evaluate expression');
   }
 }
@@ -212,7 +212,7 @@ export async function handleGetSourceContext(ctx: ToolContext, args: { sessionId
     });
   } catch (error) {
     ctx.logger.error('Failed to get source context', { error });
-    return sessionErrorToResult(error, 'typed') ??
+    return sessionErrorToResult(error) ??
       rethrowAsMcpError(error, 'Failed to get source context');
   }
 }
@@ -326,10 +326,10 @@ export async function handleGetLocalVariables(ctx: ToolContext, args: { sessionI
     // Handle session state errors specifically. A terminated session is a
     // normal end state (e.g. a step_out ran the program to completion) —
     // explain that instead of implying misuse.
-    const stateMessage = errorMessage.includes('terminated')
+    const stateMessage = error instanceof SessionTerminatedError
       ? 'The program has terminated, so no frames or variables exist. Use restart_debugging to run it again.'
       : 'Cannot get local variables. The session must be paused at a breakpoint.';
-    return sessionErrorToResult(error, 'session-state-or-not-paused', { message: stateMessage }) ??
+    return sessionErrorToResult(error, { message: stateMessage }) ??
       rethrowAsMcpError(error, 'Failed to get local variables');
   }
 }

--- a/src/server/handlers/inspection-tools.ts
+++ b/src/server/handlers/inspection-tools.ts
@@ -17,13 +17,12 @@ import {
 } from '../tool-result.js';
 
 export const getVariablesTool: ToolHandler = async (ctx, args) => {
-  if (!args.sessionId || args.scope === undefined) {
-    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
-  }
+  const sessionId = args.sessionId!;
+  const scope = args.scope!;
   enforceExplicitNames(ctx.environment, 'get_variables', args.names);
 
   try {
-    const { variables, truncation } = await ctx.getVariablesDetailed(args.sessionId, args.scope, args.names);
+    const { variables, truncation } = await ctx.getVariablesDetailed(sessionId, scope, args.names);
 
     // Log variable inspection (truncate large values)
     const truncatedVars = variables.map(v => ({
@@ -33,15 +32,15 @@ export const getVariablesTool: ToolHandler = async (ctx, args) => {
     }));
 
     ctx.logger.info('debug:variables', {
-      sessionId: args.sessionId,
-      sessionName: ctx.getSessionName(args.sessionId),
-      variablesReference: args.scope,
+      sessionId,
+      sessionName: ctx.getSessionName(sessionId),
+      variablesReference: scope,
       variableCount: variables.length,
       variables: truncatedVars.slice(0, 10), // Log first 10 variables
       timestamp: Date.now()
     });
 
-    return jsonResult({ success: true, variables, count: variables.length, variablesReference: args.scope, ...variablePayloadExtras(variables, args.names, truncation) });
+    return jsonResult({ success: true, variables, count: variables.length, variablesReference: scope, ...variablePayloadExtras(variables, args.names, truncation) });
   } catch (error) {
     // Typed session errors report as {success: false}; anything else escapes.
     return sessionErrorResultOrThrow(error, 'typed');
@@ -99,12 +98,11 @@ export const getStackTraceTool: ToolHandler = async (ctx, args) => {
 };
 
 export const getScopesTool: ToolHandler = async (ctx, args) => {
-  if (!args.sessionId || args.frameId === undefined) {
-    throw new McpError(McpErrorCode.InvalidParams, 'Missing required parameters');
-  }
+  const sessionId = args.sessionId!;
+  const frameId = args.frameId!;
 
   try {
-    const scopes = await ctx.getScopes(args.sessionId, args.frameId);
+    const scopes = await ctx.getScopes(sessionId, frameId);
     return jsonResult({ success: true, scopes });
   } catch (error) {
     // Typed session errors report as {success: false}; anything else escapes.

--- a/src/server/handlers/mirror-tools.ts
+++ b/src/server/handlers/mirror-tools.ts
@@ -41,7 +41,7 @@ export async function handleExposeSession(ctx: ToolContext, sessionId: string): 
     });
   } catch (error) {
     ctx.logger.error('Failed to expose session', { error });
-    return sessionErrorToResult(error, 'typed') ??
+    return sessionErrorToResult(error) ??
       rethrowAsMcpError(error, 'Failed to expose session');
   }
 }
@@ -69,7 +69,7 @@ export async function handleUnexposeSession(ctx: ToolContext, sessionId: string)
     });
   } catch (error) {
     ctx.logger.error('Failed to unexpose session', { error });
-    return sessionErrorToResult(error, 'typed') ??
+    return sessionErrorToResult(error) ??
       rethrowAsMcpError(error, 'Failed to unexpose session');
   }
 }

--- a/src/server/tool-dispatch.ts
+++ b/src/server/tool-dispatch.ts
@@ -15,10 +15,19 @@ import {
 import { coerceToolArguments, ToolArguments } from './tool-arguments.js';
 import { extractPayloadSuccess, sanitizeRequest } from './tool-result.js';
 import { buildToolDefinitions, isToolName } from './tool-schemas.js';
+import { assertRequiredToolArguments } from './tool-validation.js';
 import type { ToolContext } from './tool-context.js';
 import { TOOL_HANDLERS } from './handlers/index.js';
 
 export function registerToolHandlers(server: Server, ctx: ToolContext): void {
+  // Required fields do not depend on language discovery. Build this immutable
+  // dispatch index once; tools/list can still rebuild descriptions with the
+  // dynamically discovered language enum for each request.
+  const dispatchDefinitions = new Map(
+    buildToolDefinitions({ supportedLanguages: [], environment: ctx.environment })
+      .map((definition) => [definition.name, definition] as const)
+  );
+
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     ctx.logger.debug('Handling ListToolsRequest');
     
@@ -47,6 +56,11 @@ export function registerToolHandlers(server: Server, ctx: ToolContext): void {
         if (!isToolName(toolName)) {
           throw new McpError(McpErrorCode.MethodNotFound, `Unknown tool: ${toolName}`);
         }
+        const definition = dispatchDefinitions.get(toolName);
+        if (!definition) {
+          throw new McpError(McpErrorCode.MethodNotFound, `Unknown tool: ${toolName}`);
+        }
+        assertRequiredToolArguments(definition, args as unknown as Record<string, unknown>);
         const result = await TOOL_HANDLERS[toolName](ctx, args, toolName);
         
         // Log tool response; success mirrors the payload's own success flag (issue #397)

--- a/src/server/tool-result.ts
+++ b/src/server/tool-result.ts
@@ -37,29 +37,8 @@ export function failureResult(message: string, extra?: Record<string, unknown>):
 }
 
 /**
- * How a catch block recognizes "the session is gone / not usable".
- *
- * - 'typed'  matches the typed error classes, so ProxyNotRunningError counts
- *            (its message, `Cannot X: no active proxy...`, matches no sniff).
- * - 'session-state' string-sniffs an McpError the way the breakpoint and
- *            launch tools do: terminated / closed / (not found AND Session).
- * - 'session-state-or-not-paused' is the looser sniff used by
- *            evaluate_expression and get_local_variables: bare `not found`
- *            counts, and so does `not paused`.
- *
- * These reproduce the pre-existing per-site sniffs byte for byte, including
- * their over-matches (a message that merely echoes user text) and their dead
- * branches (nothing in the server throws a 'closed' or a 'not paused'
- * McpError today). They differ where it counts -- ProxyNotRunningError is
- * invisible to both string dialects -- so they stay parameterised rather than
- * merged; unify them only together with a move to error-code classification
- * (follow-up).
- */
-export type SessionErrorSniff = 'typed' | 'session-state' | 'session-state-or-not-paused';
-
-/**
  * The typed session-lifecycle errors thrown by the session layer.
- * @internal exported for the dialect tests; handlers go through
+ * @internal exported for the classification tests; handlers go through
  * sessionErrorToResult / sessionErrorResultOrThrow.
  */
 export function isTypedSessionError(
@@ -71,38 +50,14 @@ export function isTypedSessionError(
 }
 
 /**
- * The string-sniffing dialects, applied to McpError messages only.
- * @internal exported for the dialect tests; see isTypedSessionError.
- */
-export function isSessionStateError(
-  error: unknown,
-  sniff: Exclude<SessionErrorSniff, 'typed'>
-): error is McpError {
-  if (!(error instanceof McpError)) {
-    return false;
-  }
-  if (error.message.includes('terminated') || error.message.includes('closed')) {
-    return true;
-  }
-  if (sniff === 'session-state-or-not-paused') {
-    return error.message.includes('not found') || error.message.includes('not paused');
-  }
-  return error.message.includes('not found') && error.message.includes('Session');
-}
-
-/**
  * A {success: false} result for a session-lifecycle failure, or undefined when
- * the error is not one under this dialect (the caller applies its own fallback).
+ * the error is not a typed session failure (the caller applies its own fallback).
  */
 export function sessionErrorToResult(
   error: unknown,
-  sniff: SessionErrorSniff,
   extra?: Record<string, unknown>
 ): ToolResult | undefined {
-  const matched = sniff === 'typed'
-    ? isTypedSessionError(error)
-    : isSessionStateError(error, sniff);
-  return matched ? failureResult((error as Error).message, extra) : undefined;
+  return isTypedSessionError(error) ? failureResult(error.message, extra) : undefined;
 }
 
 /**
@@ -111,10 +66,9 @@ export function sessionErrorToResult(
  */
 export function sessionErrorResultOrThrow(
   error: unknown,
-  sniff: SessionErrorSniff,
   extra?: Record<string, unknown>
 ): ToolResult {
-  const result = sessionErrorToResult(error, sniff, extra);
+  const result = sessionErrorToResult(error, extra);
   if (result) {
     return result;
   }

--- a/src/server/tool-validation.ts
+++ b/src/server/tool-validation.ts
@@ -11,7 +11,7 @@ import { getVariableAccessMode, requiresExplicitNames } from '../utils/variable-
 import type { ToolArguments } from './tool-arguments.js';
 import type { ToolDefinition } from './tool-schemas.js';
 
-/** Arguments whose sessionId has been established by requireSessionId. */
+/** Arguments whose sessionId has been established at dispatch or by requireSessionId. */
 export type WithSessionId = ToolArguments & { sessionId: string };
 
 /**
@@ -40,17 +40,9 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * The up-front sessionId guard: 13 guards covering the 15 tools that have one.
- * The message came in two variants ('Missing required sessionId' and
- * 'Missing required parameter: sessionId') depending on which tool you hit;
- * they are unified here. Multi-parameter guards keep their own
- * 'Missing required parameters' message.
- *
- * Not every tool has this guard: pause_execution, evaluate_expression,
- * get_source_context, get_local_variables, get_output and redefine_classes
- * cast their arguments instead, so a missing sessionId surfaces further down
- * (as 'Session not found: undefined'). Pre-existing; guarding them changes
- * their error shape and is a follow-up.
+ * Defensive narrowing for handlers that are also invoked directly by unit
+ * tests. Production dispatch has already enforced the schema's required
+ * fields through assertRequiredToolArguments.
  */
 export function requireSessionId(args: ToolArguments): asserts args is WithSessionId {
   if (!args.sessionId) {

--- a/src/server/tool-validation.ts
+++ b/src/server/tool-validation.ts
@@ -9,9 +9,30 @@ import { ExceptionBreakMode, IEnvironment } from '@debugmcp/shared';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { getVariableAccessMode, requiresExplicitNames } from '../utils/variable-access.js';
 import type { ToolArguments } from './tool-arguments.js';
+import type { ToolDefinition } from './tool-schemas.js';
 
 /** Arguments whose sessionId has been established by requireSessionId. */
 export type WithSessionId = ToolArguments & { sessionId: string };
+
+/**
+ * Enforce the required properties advertised for one tool before dispatch.
+ * The schema order is intentional: when several values are absent, clients
+ * receive a deterministic error naming the first missing parameter.
+ */
+export function assertRequiredToolArguments(
+  definition: Pick<ToolDefinition, 'inputSchema'>,
+  args: Record<string, unknown>
+): void {
+  for (const parameterName of definition.inputSchema.required ?? []) {
+    const value = args[parameterName];
+    if (value === undefined || value === null || value === '') {
+      throw new McpError(
+        McpErrorCode.InvalidParams,
+        `Missing required parameter: ${parameterName}`
+      );
+    }
+  }
+}
 
 /** A non-null, non-array object — what the pass-through config bags must be. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/src/session/attach/attach-controller.ts
+++ b/src/session/attach/attach-controller.ts
@@ -265,8 +265,7 @@ export class AttachController {
       const attachData: AttachResultData = {
         message: attachConfig.processId
           ? `Attached to process PID ${attachConfig.processId}`
-          : `Attached to process at ${attachConfig.host || 'localhost'}:${attachConfig.port}`,
-        attachConfig
+          : `Attached to process at ${attachConfig.host || 'localhost'}:${attachConfig.port}`
       };
       // Surface adapterConfig keys the adapter's attach transform dropped
       // (issue #450) and keys forwarded to the adapter unrecognized (issue

--- a/src/session/launch/proxy-failure-diagnostics.ts
+++ b/src/session/launch/proxy-failure-diagnostics.ts
@@ -33,17 +33,11 @@ const PROXY_LOG_TAIL_LINES = 80;
  */
 const PROXY_LOG_TAIL_CHARS = 64 * 1024;
 
-/**
- * The pointers a failed launch/attach returns to the caller (issue #493 / #551).
- *
- * A `type` rather than an `interface` because these pointers are returned *as*
- * a `DebugResult.data` bag: only a type alias gets the implicit index signature
- * that makes it assignable to `DebugResultData`.
- */
-export type ProxyFailureDiagnostics = {
-  initProgress?: ProxyInitProgress;
-  proxyLogPath?: string;
-};
+  /** The pointers a failed launch/attach returns to the caller (issue #493 / #551). */
+  export interface ProxyFailureDiagnostics {
+    initProgress?: ProxyInitProgress;
+    proxyLogPath?: string;
+  }
 
 /**
  * What `logProxyFailure` needs. Declared here, as the narrowest possible slice,

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -11,6 +11,7 @@ import type { StackFrame } from '@debugmcp/shared';
 import { isRedactionEnabled } from '../utils/redaction-mode.js';
 import { ValidationResultCache } from '../utils/language-availability.js';
 import { SessionStore, ManagedSession } from './session-store.js';
+import type { ToolchainValidationState } from './session-store.js';
 import { OutputRingBuffer } from './output-buffer.js';
 import { DebugProtocol } from '@vscode/debugprotocol'; 
 import path from 'path';
@@ -30,6 +31,7 @@ import { consumeChildOrigin } from '../utils/child-origin-events.js';
 import { isPidAlive } from '../utils/jvm-orphan-reaper.js';
 import { IAdapterRegistry } from '@debugmcp/shared';
 import type { ProxyFailureDiagnostics } from './launch/proxy-failure-diagnostics.js';
+import type { AnchorResolution } from './breakpoints/anchor-resolution.js';
 
 // Custom launch arguments interface extending DebugProtocol.LaunchRequestArguments
 export interface CustomLaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
@@ -40,15 +42,13 @@ export interface CustomLaunchRequestArguments extends DebugProtocol.LaunchReques
 /**
  * The `data` bag a debug operation returns alongside its state.
  *
- * An open bag with typed common fields rather than a discriminated union:
+ * A closed set of typed common fields rather than a discriminated union:
  * `startDebugging` alone returns three shapes (dry run, launch, toolchain
  * refusal) and `restartDebugging` spreads whatever the launch produced, so a
- * union would force narrowing at every server read for no gain. Naming the
- * fields every reader actually touches — `message`, `warning`, and the proxy
- * failure pointers — is what lets the server handlers read them directly
- * instead of casting.
+ * union would force narrowing at every server read for no gain. Keeping the
+ * optional field set closed makes misspelled reads and writes fail typecheck.
  */
-export type DebugResultData = ProxyFailureDiagnostics & {
+export interface DebugResultData extends ProxyFailureDiagnostics {
   /** Human-readable status for the tool result. */
   message?: string;
   /** Advisory notes joined by the operation (unbound breakpoints, dropped keys, ...). */
@@ -59,8 +59,19 @@ export type DebugResultData = ProxyFailureDiagnostics & {
    * window elapses before a `stopped` event arrives.
    */
   pending?: boolean;
-  [key: string]: unknown;
-};
+  /** Dry-run response fields. */
+  dryRun?: boolean;
+  command?: string;
+  script?: string;
+  /** Launch result fields. */
+  reason?: string;
+  stopOnEntrySuccessful?: boolean;
+  toolchainValidation?: ToolchainValidationState;
+  /** Restart result fields. */
+  breakpointsReapplied?: number;
+  outputReset?: boolean;
+  anchorResolution?: AnchorResolution;
+}
 
 /**
  * Where the debuggee is stopped, as a result payload reports it.

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -91,9 +91,7 @@ export type PauseResultData = DebugResultData & {
 };
 
 /** What a successful attach returns on top of the common fields. */
-export type AttachResultData = DebugResultData & {
-  attachConfig?: unknown;
-};
+export type AttachResultData = DebugResultData;
 
 export interface DebugResult<TData extends DebugResultData = DebugResultData> {
   success: boolean;

--- a/tests/core/unit/server/handlers/inspection-tools.test.ts
+++ b/tests/core/unit/server/handlers/inspection-tools.test.ts
@@ -12,6 +12,7 @@ import {
   handleGetSourceContext,
   handleGetLocalVariables
 } from '../../../../../src/server/handlers/inspection-tools.js';
+import { SessionTerminatedError } from '../../../../../src/errors/debug-errors.js';
 import { createMockToolContext } from '../server-test-helpers.js';
 
 // DebugMcpServer builds its dependencies in the constructor; mock the container
@@ -282,24 +283,19 @@ describe('inspection tool handlers', () => {
       expect(payload.warning).toBeUndefined();
     });
 
-    it('returns graceful JSON for McpError with "not paused"', async () => {
+    it('does not classify an untyped McpError from its message text', async () => {
       ctx.validateSession = vi.fn().mockImplementation(() => {
         throw new McpError(McpErrorCode.InvalidRequest, 'Session is not paused');
       });
 
-      const result = await handleGetLocalVariables(ctx, {
+      await expect(handleGetLocalVariables(ctx, {
         sessionId: 'test-session'
-      });
-      const payload = JSON.parse(result.content[0].text);
-
-      expect(payload.success).toBe(false);
-      expect(payload.error).toContain('not paused');
-      expect(payload.message).toContain('Cannot get local variables');
+      })).rejects.toThrow('Session is not paused');
     });
 
     it('explains a terminated session as a normal end state (program finished)', async () => {
       ctx.validateSession = vi.fn().mockImplementation(() => {
-        throw new McpError(McpErrorCode.InvalidRequest, 'Session is terminated: test-session');
+        throw new SessionTerminatedError('test-session');
       });
 
       const result = await handleGetLocalVariables(ctx, {
@@ -328,7 +324,7 @@ describe('inspection tool handlers', () => {
       });
 
       ctx.sessionManager.getLocalVariables = vi.fn().mockRejectedValue(
-        new McpError(McpErrorCode.InvalidRequest, 'Session is terminated: test-session')
+        new SessionTerminatedError('test-session')
       );
 
       const result = await handleGetLocalVariables(ctx, {

--- a/tests/core/unit/server/server-control-tools.test.ts
+++ b/tests/core/unit/server/server-control-tools.test.ts
@@ -312,6 +312,27 @@ describe('Server Control Tools Tests', () => {
       expect(mockSessionManager.startDebugging).not.toHaveBeenCalled();
     });
 
+    it('does not turn user text containing "closed" into a session failure payload', async () => {
+      mockSessionManager.getSession.mockReturnValue({
+        id: 'test-session',
+        sessionLifecycle: 'ACTIVE'
+      });
+
+      await expect(callToolHandler({
+        method: 'tools/call',
+        params: {
+          name: 'start_debugging',
+          arguments: {
+            sessionId: 'test-session',
+            scriptPath: '/path/to/test.py',
+            breakOnExceptions: 'closed'
+          }
+        }
+      })).rejects.toThrow(/breakOnExceptions must be one of/);
+
+      expect(mockSessionManager.startDebugging).not.toHaveBeenCalled();
+    });
+
     it('honors breakOnExceptions nested inside dapLaunchArgs with a warning (#305)', async () => {
       mockSessionManager.getSession.mockReturnValue({
         id: 'test-session',

--- a/tests/core/unit/server/server-redefine-and-attach.test.ts
+++ b/tests/core/unit/server/server-redefine-and-attach.test.ts
@@ -9,6 +9,7 @@ import { DebugMcpServer } from '../../../../src/server.js';
 import { SessionManager } from '../../../../src/session/session-manager.js';
 import { DebugSessionInfo, DebugLanguage, SessionState } from '@debugmcp/shared';
 import { createProductionDependencies } from '../../../../src/container/dependencies.js';
+import { SessionNotFoundError } from '../../../../src/errors/debug-errors.js';
 import {
   createMockDependencies,
   createMockServer,
@@ -716,9 +717,9 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
       expect(payload.message).toBe('No attach session to detach from');
     });
 
-    it('maps session-state McpErrors to a stopped failure payload', async () => {
+    it('maps typed session errors to a stopped failure payload', async () => {
       mockSessionManager.detachFromProcess.mockRejectedValue(
-        new McpError(McpErrorCode.InvalidParams, 'Session sess-1 not found')
+        new SessionNotFoundError('sess-1')
       );
 
       const result = await callDetach({ sessionId: 'sess-1' });
@@ -726,7 +727,7 @@ describe('redefine_classes and attach stopOnEntry tests', () => {
 
       expect(payload).toEqual({
         success: false,
-        error: expect.stringContaining('Session sess-1 not found'),
+        error: expect.stringContaining('Session not found: sess-1'),
         state: 'stopped'
       });
     });

--- a/tests/core/unit/server/server-required-arguments.test.ts
+++ b/tests/core/unit/server/server-required-arguments.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Schema-driven required-argument enforcement at the MCP dispatch boundary.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ErrorCode as McpErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { DebugMcpServer } from '../../../../src/server.js';
+import { SessionManager } from '../../../../src/session/session-manager.js';
+import { createProductionDependencies } from '../../../../src/container/dependencies.js';
+import { buildToolDefinitions, TOOL_NAMES } from '../../../../src/server/tool-schemas.js';
+import {
+  createMockDependencies,
+  createMockServer,
+  createMockSessionManager,
+  createMockStdioTransport,
+  getToolHandlers
+} from './server-test-helpers.js';
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js');
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js');
+vi.mock('../../../../src/session/session-manager.js');
+vi.mock('../../../../src/container/dependencies.js');
+
+const PRESENT_VALUES: Record<string, unknown> = {
+  sessionId: 'session-1',
+  language: 'python',
+  file: '/workspace/main.py',
+  line: 1,
+  scriptPath: '/workspace/main.py',
+  scope: 1,
+  frameId: 1,
+  expression: 'value',
+  classesDir: '/workspace/classes',
+  names: ['value']
+};
+
+describe('schema-driven required arguments', () => {
+  let callToolHandler: (request: unknown) => Promise<unknown>;
+  let mockDependencies: ReturnType<typeof createMockDependencies>;
+
+  beforeEach(() => {
+    mockDependencies = createMockDependencies();
+    mockDependencies.environment.get.mockReturnValue(undefined);
+    vi.mocked(createProductionDependencies).mockReturnValue(mockDependencies as never);
+
+    const mockServer = createMockServer();
+    vi.mocked(Server).mockImplementation(function() { return mockServer as never; });
+    vi.mocked(StdioServerTransport).mockImplementation(function() {
+      return createMockStdioTransport() as never;
+    });
+    const manager = createMockSessionManager(mockDependencies.adapterRegistry);
+    vi.mocked(SessionManager).mockImplementation(function() { return manager as never; });
+
+    new DebugMcpServer();
+    callToolHandler = getToolHandlers(mockServer).callToolHandler;
+  });
+
+  it('checks every advertised required field before dispatch, in schema order', async () => {
+    const definitions = buildToolDefinitions({
+      supportedLanguages: ['python'],
+      environment: mockDependencies.environment
+    });
+    expect(definitions.map(({ name }) => name)).toEqual([...TOOL_NAMES]);
+    expect(definitions).toHaveLength(28);
+
+    for (const definition of definitions) {
+      const required = definition.inputSchema.required ?? [];
+      for (const missing of required) {
+        const args = Object.fromEntries(
+          required
+            .filter((parameterName) => parameterName !== missing)
+            .map((parameterName) => [parameterName, PRESENT_VALUES[parameterName]])
+        );
+
+        let caught: unknown;
+        try {
+          await callToolHandler({
+            method: 'tools/call',
+            params: { name: definition.name, arguments: args }
+          });
+        } catch (error) {
+          caught = error;
+        }
+
+        expect(caught, `${definition.name}.${missing}`).toBeInstanceOf(McpError);
+        expect((caught as McpError).code, `${definition.name}.${missing}`).toBe(McpErrorCode.InvalidParams);
+        expect((caught as Error).message, `${definition.name}.${missing}`)
+          .toContain(`Missing required parameter: ${missing}`);
+      }
+    }
+  });
+});

--- a/tests/core/unit/server/server-variable-access-gating.test.ts
+++ b/tests/core/unit/server/server-variable-access-gating.test.ts
@@ -144,8 +144,7 @@ describe('Variable access gating (issue #237)', () => {
       })).rejects.toSatisfy((error: unknown) => {
         expect(error).toBeInstanceOf(McpError);
         expect((error as McpError).code).toBe(McpErrorCode.InvalidParams);
-        expect((error as McpError).message).toContain('DEBUG_MCP_VARIABLE_ACCESS=explicit');
-        expect((error as McpError).message).toContain('names');
+        expect((error as McpError).message).toContain('Missing required parameter: names');
         return true;
       });
     });
@@ -167,7 +166,8 @@ describe('Variable access gating (issue #237)', () => {
         params: { name: 'get_local_variables', arguments: { sessionId: 'test-session' } }
       })).rejects.toSatisfy((error: unknown) => {
         expect(error).toBeInstanceOf(McpError);
-        expect((error as McpError).message).toContain('DEBUG_MCP_VARIABLE_ACCESS=explicit');
+        expect((error as McpError).code).toBe(McpErrorCode.InvalidParams);
+        expect((error as McpError).message).toContain('Missing required parameter: names');
         return true;
       });
     });

--- a/tests/core/unit/server/tool-result.test.ts
+++ b/tests/core/unit/server/tool-result.test.ts
@@ -1,16 +1,8 @@
-/**
- * The session-error catch helpers, one case per dialect row of the site table.
- *
- * The point of these tests is that the three dialects are NOT interchangeable:
- * ProxyNotRunningError converts under 'typed' but under neither string sniff,
- * a bare 'not found' converts only under the loose sniff, and each row keeps
- * its own fallback.
- */
+/** The session-error catch helpers classify only typed lifecycle failures. */
 import { describe, it, expect } from 'vitest';
 import { McpError, ErrorCode as McpErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import {
   failureResult,
-  isSessionStateError,
   isTypedSessionError,
   jsonResult,
   prettyJsonResult,
@@ -44,31 +36,31 @@ describe('tool-result envelopes', () => {
   });
 });
 
-describe('sniff: typed', () => {
+describe('typed session errors', () => {
   it('recognizes the three typed session errors', () => {
     expect(isTypedSessionError(new SessionTerminatedError('s1'))).toBe(true);
     expect(isTypedSessionError(new SessionNotFoundError('s1'))).toBe(true);
     expect(isTypedSessionError(new ProxyNotRunningError('s1', 'pause'))).toBe(true);
   });
 
-  it('converts ProxyNotRunningError, whose message matches no string sniff', () => {
+  it('converts ProxyNotRunningError', () => {
     const error = new ProxyNotRunningError('s1', 'pause');
     // McpError prefixes its own message with the JSON-RPC code; the payload
     // carries that verbatim, exactly as it always has.
-    expect(payload(sessionErrorToResult(error, 'typed')!)).toEqual({
+    expect(payload(sessionErrorToResult(error)!)).toEqual({
       success: false,
       error: error.message
     });
     expect(error.message).toContain('Cannot pause: no active proxy for session s1');
   });
 
-  it('converts SessionTerminatedError and SessionNotFoundError under typed', () => {
+  it('converts all typed lifecycle errors', () => {
     for (const error of [new SessionTerminatedError('s1'), new SessionNotFoundError('s1')]) {
-      expect(payload(sessionErrorToResult(error, 'typed')!)).toEqual({
+      expect(payload(sessionErrorToResult(error)!)).toEqual({
         success: false,
         error: error.message
       });
-      expect(payload(sessionErrorResultOrThrow(error, 'typed'))).toEqual({
+      expect(payload(sessionErrorResultOrThrow(error))).toEqual({
         success: false,
         error: error.message
       });
@@ -77,80 +69,43 @@ describe('sniff: typed', () => {
   it('does NOT convert a look-alike McpError that is not one of the typed classes', () => {
     const error = new McpError(McpErrorCode.InvalidRequest, 'Session is terminated: s1');
     expect(isTypedSessionError(error)).toBe(false);
-    expect(sessionErrorToResult(error, 'typed')).toBeUndefined();
+    expect(sessionErrorToResult(error)).toBeUndefined();
   });
 
   it('does not convert a plain Error', () => {
-    expect(sessionErrorToResult(new Error('unexpected'), 'typed')).toBeUndefined();
-  });
-});
-
-describe('sniff: session-state', () => {
-  const cases: Array<[string, boolean]> = [
-    ['Session is terminated: s1', true],
-    ['Session closed', true],
-    ['Session not found: s1', true],
-    ['Breakpoint not found', false],   // "not found" without "Session"
-    ['Session is not paused', false]   // "not paused" is the loose dialect only
-  ];
-
-  it.each(cases)('%s -> converts: %s', (message, converts) => {
-    const error = new McpError(McpErrorCode.InvalidRequest, message);
-    expect(isSessionStateError(error, 'session-state')).toBe(converts);
-    expect(sessionErrorToResult(error, 'session-state') !== undefined).toBe(converts);
+    expect(sessionErrorToResult(new Error('unexpected'))).toBeUndefined();
   });
 
-  it('does NOT convert ProxyNotRunningError even though it is an McpError', () => {
-    const error = new ProxyNotRunningError('s1', 'get stack trace');
-    expect(isSessionStateError(error, 'session-state')).toBe(false);
-    expect(sessionErrorToResult(error, 'session-state')).toBeUndefined();
-  });
-
-  it('carries the launch/attach extra after success and error', () => {
-    const error = new McpError(McpErrorCode.InvalidRequest, 'Session is terminated: s1');
-    const result = sessionErrorToResult(error, 'session-state', { state: 'stopped' })!;
-    expect(Object.keys(payload(result))).toEqual(['success', 'error', 'state']);
-    expect(payload(result).state).toBe('stopped');
-  });
-});
-
-describe('sniff: session-state-or-not-paused', () => {
-  const cases: Array<[string, boolean]> = [
-    ['Session is terminated: s1', true],
-    ['Session closed', true],
-    ['Breakpoint not found', true],    // bare "not found" counts here
-    ['Session is not paused', true],
-    ['Expression too long (max 10KB)', false]
-  ];
-
-  it.each(cases)('%s -> converts: %s', (message, converts) => {
-    const error = new McpError(McpErrorCode.InvalidRequest, message);
-    expect(isSessionStateError(error, 'session-state-or-not-paused')).toBe(converts);
-  });
-
-  it('does NOT convert ProxyNotRunningError', () => {
-    const error = new ProxyNotRunningError('s1', 'evaluate expression');
-    expect(isSessionStateError(error, 'session-state-or-not-paused')).toBe(false);
-  });
-
-  it('carries the get_local_variables explanatory message after the error', () => {
-    const error = new McpError(McpErrorCode.InvalidRequest, 'Session is terminated: s1');
-    const result = sessionErrorToResult(error, 'session-state-or-not-paused', {
+  it('carries tool-specific fields after the typed error', () => {
+    const error = new SessionTerminatedError('s1');
+    const result = sessionErrorToResult(error, {
       message: 'The program has terminated, so no frames or variables exist. Use restart_debugging to run it again.'
     })!;
     expect(Object.keys(payload(result))).toEqual(['success', 'error', 'message']);
   });
+
+  it.each([
+    'Session is terminated: s1',
+    'Session closed',
+    'Session not found: s1',
+    'Breakpoint not found',
+    'Session is not paused',
+    'user expression: conn.closed'
+  ])('does not classify user-controlled look-alike text: %s', (message) => {
+    const error = new McpError(McpErrorCode.InvalidParams, message);
+    expect(sessionErrorToResult(error)).toBeUndefined();
+  });
 });
 
 describe('sessionErrorResultOrThrow', () => {
-  it('returns the failure result when the dialect recognizes the error', () => {
-    const error = new McpError(McpErrorCode.InvalidRequest, 'Session is terminated: s1');
-    expect(payload(sessionErrorResultOrThrow(error, 'session-state')).success).toBe(false);
+  it('returns the failure result for a typed session error', () => {
+    const error = new SessionTerminatedError('s1');
+    expect(payload(sessionErrorResultOrThrow(error)).success).toBe(false);
   });
 
   it('re-throws the original error untouched otherwise', () => {
     const error = new McpError(McpErrorCode.InvalidParams, 'Breakpoint file not found');
-    expect(() => sessionErrorResultOrThrow(error, 'session-state')).toThrow(error);
+    expect(() => sessionErrorResultOrThrow(error)).toThrow(error);
   });
 });
 

--- a/tests/core/unit/server/tool-validation.test.ts
+++ b/tests/core/unit/server/tool-validation.test.ts
@@ -7,12 +7,14 @@ import { IEnvironment } from '@debugmcp/shared';
 import type { ToolArguments } from '../../../../src/server/tool-arguments.js';
 import {
   assertPlainObjectArg,
+  assertRequiredToolArguments,
   enforceExplicitNames,
   NEVER_VALID_DAP_LAUNCH_KEYS,
   normalizeStartDebuggingArgs,
   requireSessionId,
   validateBreakOnExceptions
 } from '../../../../src/server/tool-validation.js';
+import type { ToolDefinition } from '../../../../src/server/tool-schemas.js';
 
 function environmentWith(values: Record<string, string>): IEnvironment {
   return {
@@ -32,6 +34,36 @@ describe('requireSessionId', () => {
     const args = raw as ToolArguments;
     expect(() => requireSessionId(args)).toThrow(McpError);
     expect(() => requireSessionId(args)).toThrow('Missing required parameter: sessionId');
+  });
+});
+
+describe('assertRequiredToolArguments', () => {
+  const definition = {
+    name: 'start_debugging',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: ['sessionId', 'scriptPath']
+    }
+  } as ToolDefinition;
+
+  it('reports the first missing field in schema order', () => {
+    expect(() => assertRequiredToolArguments(definition, {}))
+      .toThrow('Missing required parameter: sessionId');
+  });
+
+  it.each([undefined, null, ''])('treats %j as missing', (value) => {
+    expect(() => assertRequiredToolArguments(definition, { sessionId: value, scriptPath: '/app.py' }))
+      .toThrow('Missing required parameter: sessionId');
+  });
+
+  it('accepts zero and false as present values', () => {
+    const numericDefinition = {
+      ...definition,
+      inputSchema: { ...definition.inputSchema, required: ['line', 'stopOnEntry'] }
+    } as ToolDefinition;
+    expect(() => assertRequiredToolArguments(numericDefinition, { line: 0, stopOnEntry: false }))
+      .not.toThrow();
   });
 });
 

--- a/tests/core/unit/session/debug-result-data.test.ts
+++ b/tests/core/unit/session/debug-result-data.test.ts
@@ -1,0 +1,23 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { DebugResultData } from '../../../../src/session/session-manager-core.js';
+
+describe('DebugResultData type contract (issue #590)', () => {
+  it('stays closed over the result keys written by the session layer', () => {
+    expectTypeOf<keyof DebugResultData>().toEqualTypeOf<
+      | 'initProgress'
+      | 'proxyLogPath'
+      | 'message'
+      | 'warning'
+      | 'pending'
+      | 'dryRun'
+      | 'command'
+      | 'script'
+      | 'reason'
+      | 'stopOnEntrySuccessful'
+      | 'toolchainValidation'
+      | 'breakpointsReapplied'
+      | 'outputReset'
+      | 'anchorResolution'
+    >();
+  });
+});

--- a/tests/core/unit/session/session-manager-attach-modes.test.ts
+++ b/tests/core/unit/session/session-manager-attach-modes.test.ts
@@ -228,11 +228,14 @@ describe('SessionManagerOperations attach modes', () => {
         stopOnEntry: false, // skip the post-attach thread-verify poll
         adapterConfig: {
           program: '/proc/1/root/pricer',
-          initCommands: ['settings set target.exec-search-paths /proc/1/root']
+          initCommands: ['settings set target.exec-search-paths /proc/1/root'],
+          token: 'attach-secret-must-not-be-echoed'
         }
       });
 
       expect(result.success).toBe(true);
+      expect(JSON.stringify(result)).not.toContain('attach-secret-must-not-be-echoed');
+      expect(result.data).not.toHaveProperty('attachConfig');
       const cfg = adapterStub.transformAttachConfig.mock.calls[0][0];
       expect(cfg.program).toBe('/proc/1/root/pricer');
       expect(cfg.initCommands).toEqual(['settings set target.exec-search-paths /proc/1/root']);


### PR DESCRIPTION
Closes #575. Replaces message sniffing with typed session and proxy errors so user text cannot alter MCP error classification. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.