### PR TITLE
fix: scope launch toolchain verdicts to one attempt (#584)

### DIFF
--- a/changelog.d/584.fixed.md
+++ b/changelog.d/584.fixed.md
@@ -1,0 +1,1 @@
+**Launch failures no longer inherit stale MSVC toolchain verdicts** — validation state is reset for each proxy-launch attempt, and only a verdict attached to the current thrown error can produce `MSVC_TOOLCHAIN_DETECTED` (#584)

--- a/src/session/launch/debug-launcher.ts
+++ b/src/session/launch/debug-launcher.ts
@@ -461,8 +461,7 @@ export class DebugLauncher {
       }
 
       const toolchainValidation =
-        (error as { toolchainValidation?: ToolchainValidationState })?.toolchainValidation ??
-        session.toolchainValidation;
+        (error as { toolchainValidation?: ToolchainValidationState })?.toolchainValidation;
       const incompatibleToolchain =
         Boolean(toolchainValidation) && toolchainValidation?.compatible === false;
 

--- a/src/session/launch/proxy-launcher.ts
+++ b/src/session/launch/proxy-launcher.ts
@@ -80,6 +80,11 @@ export class ProxyLauncher {
     session: ManagedSession,
     request: ProxyLaunchRequest
   ): Promise<LanguageSpecificLaunchConfig> {
+    // A verdict belongs to exactly one proxy-launch attempt. Clear the stored
+    // projection before any fallible setup so an adapter-acquire, filesystem,
+    // or transform failure cannot inherit an earlier MSVC classification.
+    this.ctx.updateSession(session.id, { toolchainValidation: undefined });
+
     // Log entrance for Windows CI debugging
     this.ctx.logger.info(
       `[SessionManager] Entering ProxyLauncher.start for session ${session.id}, dryRunSpawn: ${request.dryRunSpawn}, scriptPath: ${request.scriptPath}`
@@ -553,7 +558,9 @@ export class ProxyLauncher {
    * CPP/RUST_MSVC_BEHAVIOR=error the adapter records the verdict and then
    * rejects from inside transformLaunchConfig, and that verdict must still
    * reach the caller. Clearing on the no-verdict path keeps a previous
-   * launch's verdict from mislabeling an unrelated failure.
+   * launch's verdict from mislabeling an unrelated failure. The launch-level
+   * catch classifies only the verdict attached to the thrown sentinel; this
+   * stored copy is a projection for diagnostics, not an error discriminator.
    */
   private applyToolchainValidation(sessionId: string, adapter: IDebugAdapter): void {
     const adapterWithToolchain = adapter as {

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -397,6 +397,35 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         startProxySpy.mockRestore();
       }
     });
+
+    it('does not classify an unrelated launch failure from a stale session verdict', async () => {
+      mockSession.proxyManager = undefined as any;
+      mockSession.language = 'cpp';
+      mockSession.toolchainValidation = {
+        compatible: false,
+        behavior: 'warn',
+        toolchain: 'msvc',
+        message: 'stale verdict from an earlier launch'
+      } as any;
+
+      const startProxySpy = vi
+        .spyOn(internals(operations).proxyLauncher, 'start')
+        .mockRejectedValue(new Error('C/C++ compile failed: syntax error'));
+
+      try {
+        const result = await operations.startDebugging('test-session', 'main.cpp');
+
+        expect(result).toEqual(expect.objectContaining({
+          success: false,
+          error: 'C/C++ compile failed: syntax error',
+          state: SessionState.ERROR
+        }));
+        expect(result.error).not.toBe('MSVC_TOOLCHAIN_DETECTED');
+        expect(result.canContinue).toBeUndefined();
+      } finally {
+        startProxySpy.mockRestore();
+      }
+    });
   });
 
   describe('Operation Failures with Error Details', () => {


### PR DESCRIPTION
Closes #584. Resets launch-attempt validation state and classifies toolchain failures only from verdicts attached to the thrown error. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.