### PR TITLE
fix: report launch outcomes truthfully (#585)

### DIFF
--- a/changelog.d/585.fixed.md
+++ b/changelog.d/585.fixed.md
@@ -1,0 +1,1 @@
+**`start_debugging` no longer reports success after the proxy enters `ERROR`** — unexpected proxy exits during readiness return `success:false` with available proxy-log diagnostics, while clean program completion remains a successful `stopped` result (#585)

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1187,6 +1187,8 @@ Session-lifecycle failures (unknown/terminated session, proxy not running) are a
 3. **File not found**: When setting breakpoints in non-existent files
 4. **Invalid scope**: When passing wrong variablesReference to get_variables
 
+`start_debugging` reports `success: false` when the proxy or adapter enters an `error` state during readiness and includes available proxy-log diagnostics. A program that exits cleanly before the debugger pauses is still a successful result with `state: "stopped"`.
+
 ---
 
 ## Best Practices

--- a/src/session/launch/debug-launcher.ts
+++ b/src/session/launch/debug-launcher.ts
@@ -164,6 +164,11 @@ export class DebugLauncher {
       sessionLifecycle: SessionLifecycleState.ACTIVE,
       attachMode: false,
     });
+    // Per-attempt terminal evidence. A prior program/proxy exit must not
+    // influence whether this launch is reported as successful.
+    session.exitCode = undefined;
+    session.lastProxyExit = undefined;
+    session.lastProxyError = undefined;
     this.ctx.logger.info(`[SessionManager] Session ${sessionId} lifecycle state set to ACTIVE`);
 
     // Record the launch spec for restart_debugging BEFORE attempting the
@@ -367,6 +372,33 @@ export class DebugLauncher {
       // Re-fetch session to get the most up-to-date state
       const finalSession = this.ctx.getSession(sessionId);
       const finalState = finalSession.state;
+
+      // Readiness resolves on terminal events as well as a usable debugger.
+      // Do not turn an adapter/proxy crash into a successful start merely
+      // because the wait completed. STOPPED remains a truthful success for a
+      // program that ran to completion; infrastructure failures map to ERROR.
+      if (finalState === SessionState.ERROR) {
+        const proxyExit = finalSession.lastProxyExit;
+        const exitDescription = proxyExit
+          ? `code=${proxyExit.code ?? 'null'}${proxyExit.signal ? `, signal=${proxyExit.signal}` : ''}`
+          : undefined;
+        const errorMessage = finalSession.lastProxyError ??
+          (exitDescription
+            ? `Debug proxy exited unexpectedly during launch (${exitDescription})`
+            : 'Debug proxy entered an error state during launch');
+        const diagnosticData = await failProxySetup(
+          this.ctx,
+          finalSession,
+          new Error(errorMessage),
+          'startDebugging'
+        );
+        return {
+          success: false,
+          state: SessionState.ERROR,
+          error: errorMessage,
+          ...(Object.keys(diagnosticData).length > 0 ? { data: diagnosticData } : {})
+        };
+      }
 
       // Belt-and-braces re-sync (issues #236/#439, function breakpoints
       // #271 phase 3): the store is normally already stamped by the worker's

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -1031,6 +1031,7 @@ export abstract class SessionManagerCore extends EventEmitter {
     const handleError = (error: Error) => {
       this.logger.debug(`[SessionManager] 'error' event handler called for session ${sessionId}`);
       this.logger.error(`[ProxyManager ${sessionId}] Error:`, error);
+      session.lastProxyError = error.message;
       this._updateSessionState(session, SessionState.ERROR);
 
       // Clean up listeners since proxy is in error state
@@ -1053,6 +1054,7 @@ export abstract class SessionManagerCore extends EventEmitter {
     const handleExit = (code: number | null, signal?: string, expected?: boolean) => {
       this.logger.debug(`[SessionManager] handleExit: session=${sessionId} currentState=${session.state} code=${code} signal=${signal} expected=${expected}`);
       this.logger.info(`[ProxyManager ${sessionId}] Exit: code=${code}, signal=${signal}, expected=${expected}`);
+      session.lastProxyExit = { code, signal, expected };
       if (session.state !== SessionState.STOPPED && session.state !== SessionState.ERROR) {
         if (expected === true) {
           // Orderly debuggee termination (issue #258): the worker saw a

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -42,6 +42,13 @@ export interface ToolchainValidationState {
   binaryInfo?: Record<string, unknown>;
 }
 
+/** Terminal status reported by the proxy worker for the current launch. */
+export interface ProxyExitState {
+  code: number | null;
+  signal?: string;
+  expected?: boolean;
+}
+
 /**
  * The most recent real (non-dry-run) launch, captured as SessionManager
  * received it — scriptPath is the server-layer-resolved effective path, so a
@@ -94,6 +101,10 @@ export interface ManagedSession extends DebugSessionInfo {
   executionState?: ExecutionState;
   logDir?: string;
   toolchainValidation?: ToolchainValidationState;
+  /** Reset per launch; distinguishes a proxy crash from debuggee completion. */
+  lastProxyExit?: ProxyExitState;
+  /** Last proxy error-event message for the current launch. */
+  lastProxyError?: string;
   // True once the first 'stopped' event after launch has been observed.
   // Used by the auto-continue trigger to identify the initial entry stop
   // even when the adapter reports a non-'entry' reason (e.g., js-debug

--- a/tests/core/unit/session/session-manager-exit-mapping.test.ts
+++ b/tests/core/unit/session/session-manager-exit-mapping.test.ts
@@ -90,7 +90,9 @@ describe('SessionManager - proxy exit mapping (issue #258)', () => {
 
     dependencies.mockProxyManager.simulateEvent('exit', 134, undefined, false);
 
-    expect(sessionManager.getSession(sessionId)?.state).toBe(SessionState.ERROR);
+    const session = sessionManager.getSession(sessionId);
+    expect(session?.state).toBe(SessionState.ERROR);
+    expect(session?.lastProxyExit).toEqual({ code: 134, signal: undefined, expected: false });
   });
 
   it('keeps the legacy mapping when expected is absent: clean proxy exit → STOPPED', async () => {

--- a/tests/core/unit/session/session-manager-workflow.test.ts
+++ b/tests/core/unit/session/session-manager-workflow.test.ts
@@ -246,7 +246,9 @@ describe('SessionManager - Debug Session Workflow', () => {
 
       await vi.runAllTimersAsync();
       const result = await startPromise;
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.state).toBe(SessionState.ERROR);
+      expect(result.error).toContain('signal=SIGKILL');
       expect(dependencies.mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('proxy exited during startup')
       );

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -1226,6 +1226,86 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
   });
 
   describe('Start Debugging Success Scenarios', () => {
+    it('returns failure with diagnostics when the proxy exits non-zero during readiness', async () => {
+      mockSession.proxyManager = undefined;
+      mockSession.state = SessionState.CREATED;
+      mockSession.logDir = '/tmp/session-logs';
+      mockDependencies.fileSystem.readFile.mockResolvedValue('adapter crash details');
+
+      const proxyStub: any = {
+        ...mockProxyManager,
+        once: vi.fn(),
+        removeListener: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        isRunning: vi.fn().mockReturnValue(true),
+        stop: vi.fn().mockResolvedValue(undefined)
+      };
+      proxyStub.on.mockReturnValue(proxyStub);
+      proxyStub.off.mockReturnValue(proxyStub);
+      proxyStub.once.mockImplementation((event: string, handler: () => void) => {
+        if (event === 'exit') {
+          mockSession.state = SessionState.ERROR;
+          mockSession.lastProxyExit = { code: 134, signal: 'SIGABRT', expected: false };
+          handler();
+        }
+        return proxyStub;
+      });
+
+      const startProxySpy = vi.spyOn(internals(operations).proxyLauncher, 'start').mockImplementation(async () => {
+        mockSession.proxyManager = proxyStub;
+      });
+      try {
+        const result = await operations.startDebugging('test-session', 'main.py');
+
+        expect(result).toEqual(expect.objectContaining({
+          success: false,
+          state: SessionState.ERROR,
+          error: expect.stringContaining('code=134')
+        }));
+        expect(result.data).toEqual({
+          proxyLogPath: path.join('/tmp/session-logs', 'proxy-test-session.log')
+        });
+      } finally {
+        startProxySpy.mockRestore();
+      }
+    });
+
+    it('keeps a clean code-0 program completion as a successful stopped launch', async () => {
+      mockSession.proxyManager = undefined;
+      mockSession.state = SessionState.CREATED;
+
+      const proxyStub: any = {
+        ...mockProxyManager,
+        once: vi.fn(),
+        removeListener: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        isRunning: vi.fn().mockReturnValue(true)
+      };
+      proxyStub.on.mockReturnValue(proxyStub);
+      proxyStub.off.mockReturnValue(proxyStub);
+      proxyStub.once.mockImplementation((event: string, handler: () => void) => {
+        if (event === 'exited') {
+          mockSession.state = SessionState.STOPPED;
+          mockSession.exitCode = 0;
+          handler();
+        }
+        return proxyStub;
+      });
+
+      const startProxySpy = vi.spyOn(internals(operations).proxyLauncher, 'start').mockImplementation(async () => {
+        mockSession.proxyManager = proxyStub;
+      });
+      try {
+        const result = await operations.startDebugging('test-session', 'main.py');
+        expect(result.success).toBe(true);
+        expect(result.state).toBe(SessionState.STOPPED);
+      } finally {
+        startProxySpy.mockRestore();
+      }
+    });
+
     it('completes handshake and waits for stop event', async () => {
       vi.stubEnv('CI', 'true');
       vi.stubEnv('GITHUB_ACTIONS', undefined);


### PR DESCRIPTION
Closes #585. Classifies post-readiness proxy exits and ERROR state as failed starts while preserving clean code-zero stops. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.