### PR TITLE
fix: require acknowledged dry-run completion (#596)

### DIFF
--- a/changelog.d/596.fixed.md
+++ b/changelog.d/596.fixed.md
@@ -1,0 +1,1 @@
+**Dry-run success now requires an explicit `dry_run_complete` status** — a code-0 proxy exit before that acknowledgement remains a loud initialization failure; acknowledged dry-run exits are logged quietly at debug level (#596)

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -437,26 +437,21 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
       const handleExit = (code: number | null, signal?: string) => {
         cleanup();
-        if (this.isDryRun && code === 0) {
-          // Normal exit for dry run
-          resolve();
-        } else {
-          let errorMessage = `Proxy exited during initialization. Code: ${code}, Signal: ${signal}`;
-          if (this.stderrBuffer.length > 0) {
-            // Cap what gets embedded in the user-facing error — the full
-            // buffer is already in the logs (issue #146).
-            const lines = this.stderrBuffer.slice(-10);
-            let text = lines.join('\n');
-            if (text.length > 2000) {
-              text = '…' + text.slice(-2000);
-            }
-            const label = this.stderrBuffer.length > lines.length
-              ? ` (last ${lines.length} of ${this.stderrBuffer.length} lines)`
-              : '';
-            errorMessage += `\nStderr output${label}:\n${text}`;
+        let errorMessage = `Proxy exited during initialization. Code: ${code}, Signal: ${signal}`;
+        if (this.stderrBuffer.length > 0) {
+          // Cap what gets embedded in the user-facing error — the full
+          // buffer is already in the logs (issue #146).
+          const lines = this.stderrBuffer.slice(-10);
+          let text = lines.join('\n');
+          if (text.length > 2000) {
+            text = '…' + text.slice(-2000);
           }
-          reject(new Error(errorMessage));
+          const label = this.stderrBuffer.length > lines.length
+            ? ` (last ${lines.length} of ${this.stderrBuffer.length} lines)`
+            : '';
+          errorMessage += `\nStderr output${label}:\n${text}`;
         }
+        reject(new Error(errorMessage));
       };
 
       this.once('initialized', handleInitialized);
@@ -1033,7 +1028,14 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
     // Handle exit
     track(proc, 'exit', (code: number | null, signal: string | null) => {
-      this.logger.info(`[ProxyManager] Proxy exited. Code: ${code}, Signal: ${signal}`);
+      const expectedDryRunExit =
+        this.isDryRun && code === 0 && this.dryRunCompleteReceived;
+      const exitMessage = `[ProxyManager] Proxy exited. Code: ${code}, Signal: ${signal}`;
+      if (expectedDryRunExit) {
+        this.logger.debug(exitMessage);
+      } else {
+        this.logger.info(exitMessage);
+      }
 
       this.lastExitDetails = {
         code,
@@ -1045,7 +1047,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       // everInitialized, not isInitialized: stop() runs cleanup() (which
       // resets isInitialized) before this event fires, so the reset flag
       // would report every orderly shutdown as a pre-init death (issue #530)
-      if (!this.everInitialized) {
+      if (!this.everInitialized && !expectedDryRunExit) {
         this.logger.error(
           `[ProxyManager] Proxy exited before initialization. code=${code} signal=${signal} stderrLines=${this.stderrBuffer.length}`,
           this.stderrBuffer
@@ -1435,18 +1437,6 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private handleProxyExit(code: number | null, signal: string | null): void {
     this.activeLaunchBarrier?.onProxyExit(code, signal);
     this.clearActiveLaunchBarrier();
-
-    if (this.isDryRun && code === 0 && !this.dryRunCompleteReceived) {
-      const fallbackCommand = this.dryRunCommandSnapshot ?? '(command unavailable)';
-      const fallbackScript = this.dryRunScriptPath ?? '';
-      this.logger.warn(
-        `[ProxyManager] Dry run proxy exited without reporting completion; synthesizing dry-run-complete event.`
-      );
-      this.dryRunCompleteReceived = true;
-      this.dryRunCommandSnapshot = fallbackCommand;
-      this.dryRunScriptPath = fallbackScript;
-      this.emit('dry-run-complete', fallbackCommand, fallbackScript);
-    }
 
     // Clean up pending requests
     this.pendingDapRequests.forEach(pending => {

--- a/tests/core/unit/session/session-manager-workflow.test.ts
+++ b/tests/core/unit/session/session-manager-workflow.test.ts
@@ -246,7 +246,9 @@ describe('SessionManager - Debug Session Workflow', () => {
 
       await vi.runAllTimersAsync();
       const result = await startPromise;
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.state).toBe(SessionState.ERROR);
+      expect(result.error).toContain('code=1');
       expect(dependencies.mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('proxy exited during startup')
       );

--- a/tests/unit/proxy/proxy-manager.start.test.ts
+++ b/tests/unit/proxy/proxy-manager.start.test.ts
@@ -647,7 +647,7 @@ describe('ProxyManager.start', () => {
     }
   });
 
-  it('resolves when dry-run proxy exits cleanly before reporting completion', async () => {
+  it('rejects when a dry-run proxy exits cleanly without reporting completion', async () => {
     fakeProcess.sendCommand.mockImplementation((cmd: any) => {
       if (cmd.cmd === 'init') {
         setTimeout(() => {
@@ -663,7 +663,13 @@ describe('ProxyManager.start', () => {
       }
     });
 
-    await expect(proxyManager.start({ ...baseConfig, dryRunSpawn: true })).resolves.toBeUndefined();
+    await expect(proxyManager.start({ ...baseConfig, dryRunSpawn: true })).rejects.toThrow(
+      /Proxy exited during initialization\. Code: 0/
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('exited before initialization'),
+      expect.any(Array)
+    );
   });
 
   it('rejects when proxy exits during initialization with captured stderr', async () => {
@@ -1192,6 +1198,22 @@ describe('ProxyManager.start', () => {
       expect(preInitErrors.length).toBe(1);
     });
 
+    it('logs an acknowledged clean dry-run exit at debug without a pre-init error', async () => {
+      await proxyManager.start(baseConfig);
+      (logger.debug as ReturnType<typeof vi.fn>).mockClear();
+      (logger.error as ReturnType<typeof vi.fn>).mockClear();
+
+      fakeProcess.emit('exit', 0, null);
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        '[ProxyManager] Proxy exited. Code: 0, Signal: null'
+      );
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('exited before initialization'),
+        expect.anything()
+      );
+    });
+
     it('cleanup rejects all pending requests and clears launch barrier', () => {
       const pendingReject = vi.fn();
       (proxyManager as unknown as { pendingDapRequests: Map<string, any> }).pendingDapRequests.set('req-1', {
@@ -1323,7 +1345,7 @@ describe('ProxyManager.start', () => {
   });
 
   describe('handleProxyExit', () => {
-    it('emits synthesized dry-run completion when exit occurs without prior notification', () => {
+    it('does not synthesize dry-run completion from a clean exit', () => {
       const dryRunListener = vi.fn();
       proxyManager.on('dry-run-complete', dryRunListener);
 
@@ -1334,8 +1356,8 @@ describe('ProxyManager.start', () => {
 
       (proxyManager as unknown as { handleProxyExit: (code: number | null, signal: string | null) => void }).handleProxyExit(0, null);
 
-      expect(proxyManager.hasDryRunCompleted()).toBe(true);
-      expect(dryRunListener).toHaveBeenCalledWith('cmd', 'script');
+      expect(proxyManager.hasDryRunCompleted()).toBe(false);
+      expect(dryRunListener).not.toHaveBeenCalled();
     });
 
     it('rejects pending requests and emits exit event for non-dry-run exits', () => {


### PR DESCRIPTION
Closes #596. Treats code-zero dry-run exit as expected only after dry_run_complete and keeps pre-initialization failures loud. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.