### PR TITLE
refactor: scope pause intent to proxy generations (#591)

### DIFF
--- a/changelog.d/591.fixed.md
+++ b/changelog.d/591.fixed.md
@@ -1,0 +1,1 @@
+**Pending pauses are now scoped to the active proxy generation** — stops, terminal events, teardown, and relaunch clear pause intent so an old request cannot relabel a later launch's stop reason (#591)

--- a/src/session/execution/execution-controller.ts
+++ b/src/session/execution/execution-controller.ts
@@ -49,6 +49,7 @@ import type {
   StopLocation
 } from '../session-manager-core.js';
 import type { ExecutionContext } from '../operations-context.js';
+import { armPauseIntent, clearPauseIntent } from './pause-intent.js';
 
 /** What distinguishes the three step flavours: everything else is shared. */
 interface StepKind {
@@ -487,7 +488,11 @@ export class ExecutionController {
     // what the post-response race branch below wants; a session that
     // auto-continued back to RUNNING arms it. handleStopped clears it on
     // every stop; the settle paths below clear it where no stop is coming.
-    session.pausePending = session.state === SessionState.RUNNING;
+    if (session.state === SessionState.RUNNING) {
+      armPauseIntent(session, 'user');
+    } else {
+      clearPauseIntent(session);
+    }
 
     // The pause response only acknowledges the request; the state transition
     // to PAUSED happens when the asynchronous 'stopped' event is handled by
@@ -608,7 +613,7 @@ export class ExecutionController {
           );
           return;
         }
-        session.pausePending = false;
+        clearPauseIntent(session);
         settle({
           success: true,
           state: session.state,
@@ -632,7 +637,7 @@ export class ExecutionController {
         this.ctx.logger.info(
           `[SessionManager pause] No stopped event within ${this.ctx.tunables.pauseGraceMs}ms grace window in session ${sessionId}; completing asynchronously`
         );
-        // session.pausePending stays armed on purpose: the pause was
+        // The generation-scoped pause intent stays armed on purpose: the pause was
         // delivered and the stop may land whenever the debuggee next runs
         // (e.g. an idle server, issue #513) — that late stop must still be
         // normalized to 'pause'. handleStopped clears the flag on any stop.
@@ -689,7 +694,7 @@ export class ExecutionController {
             void settleFromStop();
             return;
           }
-          session.pausePending = false;
+          clearPauseIntent(session);
           this.ctx.logger.error(
             `[SessionManager pause] Error sending 'pause' for session ${sessionId}: ${errorMessage}`
           );

--- a/src/session/execution/pause-intent.ts
+++ b/src/session/execution/pause-intent.ts
@@ -1,0 +1,49 @@
+/** A pause request scoped to the proxy generation that received it. */
+export interface PauseIntent {
+  generation: number;
+  source: 'user' | 'attach';
+  armedAt: number;
+}
+
+interface PauseIntentSession {
+  proxyGeneration?: number;
+  pauseIntent?: PauseIntent;
+}
+
+/** Start a new proxy generation and invalidate every earlier pause request. */
+export function beginProxyGeneration(session: PauseIntentSession): number {
+  const generation = (session.proxyGeneration ?? 0) + 1;
+  session.proxyGeneration = generation;
+  session.pauseIntent = undefined;
+  return generation;
+}
+
+/** Arm a pause against the currently installed proxy only. */
+export function armPauseIntent(
+  session: PauseIntentSession,
+  source: PauseIntent['source']
+): PauseIntent {
+  const intent: PauseIntent = {
+    generation: session.proxyGeneration ?? 0,
+    source,
+    armedAt: Date.now()
+  };
+  session.pauseIntent = intent;
+  return intent;
+}
+
+/** Whether this session's intent belongs to its current proxy generation. */
+export function hasCurrentPauseIntent(session: PauseIntentSession): boolean {
+  return session.pauseIntent !== undefined &&
+    session.pauseIntent.generation === (session.proxyGeneration ?? 0);
+}
+
+/** Clear one current intent, optionally only if it is the expected object. */
+export function clearPauseIntent(
+  session: PauseIntentSession,
+  expected?: PauseIntent
+): void {
+  if (!expected || session.pauseIntent === expected) {
+    session.pauseIntent = undefined;
+  }
+}

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -13,6 +13,11 @@ import { ValidationResultCache } from '../utils/language-availability.js';
 import { SessionStore, ManagedSession } from './session-store.js';
 import type { ToolchainValidationState } from './session-store.js';
 import { OutputRingBuffer } from './output-buffer.js';
+import {
+  beginProxyGeneration,
+  clearPauseIntent,
+  hasCurrentPauseIntent
+} from './execution/pause-intent.js';
 import { DebugProtocol } from '@vscode/debugprotocol'; 
 import path from 'path';
 import os from 'os';
@@ -262,6 +267,7 @@ export abstract class SessionManagerCore extends EventEmitter {
       return false;
     }
     this.logger.info(`Closing debug session: ${sessionId}. Active proxy: ${session.proxyManager ? 'yes' : 'no'}`);
+    clearPauseIntent(session);
     
     if (session.proxyManager) {
       session.lastProxyPid = session.proxyManager.getProxyPid?.() ?? session.lastProxyPid;
@@ -341,6 +347,7 @@ export abstract class SessionManagerCore extends EventEmitter {
    * always released (issue #238).
    */
   protected async stopProxyPreservingSession(session: ManagedSession): Promise<void> {
+    clearPauseIntent(session);
     const proxyManager = session.proxyManager;
     if (proxyManager) {
       session.lastProxyPid = proxyManager.getProxyPid?.() ?? session.lastProxyPid;
@@ -386,6 +393,7 @@ export abstract class SessionManagerCore extends EventEmitter {
     effectiveLaunchArgs: Partial<CustomLaunchRequestArguments>
   ): void {
     const sessionId = session.id;
+    beginProxyGeneration(session);
     const handlers = new Map<string, (...args: any[]) => void>(); // eslint-disable-line @typescript-eslint/no-explicit-any -- Event handlers require flexible argument signatures to support various event types
 
     // Reset first-stop tracking for this launch — a session may be re-launched.
@@ -472,7 +480,7 @@ export abstract class SessionManagerCore extends EventEmitter {
         const userBreakpointIds: ReadonlySet<number> | undefined =
           lineComplete && fnComplete ? new Set([...lineIds, ...fnIds]) : undefined;
         const normalized = policy.normalizeStopReason?.(rawReason, body, {
-          pausePending: session.pausePending === true,
+          pausePending: hasCurrentPauseIntent(session),
           userBreakpointIds,
           functionBreakpointIds: fnComplete ? fnIds : undefined,
           lineBreakpointCount: session.breakpoints.size,
@@ -489,7 +497,7 @@ export abstract class SessionManagerCore extends EventEmitter {
           `[SessionManager ${sessionId}] Stop-reason normalization failed; keeping raw reason '${rawReason}': ${err instanceof Error ? err.message : String(err)}`
         );
       }
-      session.pausePending = false;
+      clearPauseIntent(session);
       this.logger.debug(`[SessionManager] handleStopped: session=${sessionId} currentState=${session.state} reason=${reason} threadId=${threadId}`);
       this.logger.info(`[ProxyManager ${sessionId}] Stopped event: thread=${threadId}, reason=${reason}`);
 
@@ -770,6 +778,7 @@ export abstract class SessionManagerCore extends EventEmitter {
 
     // Named function for terminated event
     const handleTerminated = () => {
+      clearPauseIntent(session);
       this.logger.debug(`[SessionManager] handleTerminated: session=${sessionId} currentState=${session.state}`);
       this.logger.info(`[ProxyManager ${sessionId}] Terminated event`);
 
@@ -806,6 +815,7 @@ export abstract class SessionManagerCore extends EventEmitter {
 
     // Named function for exited event
     const handleExited = (exitCode?: number) => {
+      clearPauseIntent(session);
       this.logger.debug(`[SessionManager] handleExited: session=${sessionId} currentState=${session.state} exitCode=${exitCode}`);
       this.logger.info(`[ProxyManager ${sessionId}] Exited event (exitCode=${exitCode})`);
       // Record the debuggee exit code so a crash (non-zero) is
@@ -1015,6 +1025,7 @@ export abstract class SessionManagerCore extends EventEmitter {
 
     // Named function for dry run complete event
     const handleDryRunComplete = (command: string, script: string) => {
+      clearPauseIntent(session);
       this.logger.debug(`[SessionManager] 'dry-run-complete' event handler called for session ${sessionId}`);
       this.logger.info(`[ProxyManager ${sessionId}] Dry run complete: ${command} ${script}`);
       this._updateSessionState(session, SessionState.STOPPED);
@@ -1029,6 +1040,7 @@ export abstract class SessionManagerCore extends EventEmitter {
 
     // Named function for error event
     const handleError = (error: Error) => {
+      clearPauseIntent(session);
       this.logger.debug(`[SessionManager] 'error' event handler called for session ${sessionId}`);
       this.logger.error(`[ProxyManager ${sessionId}] Error:`, error);
       session.lastProxyError = error.message;
@@ -1052,6 +1064,7 @@ export abstract class SessionManagerCore extends EventEmitter {
 
     // Named function for exit event
     const handleExit = (code: number | null, signal?: string, expected?: boolean) => {
+      clearPauseIntent(session);
       this.logger.debug(`[SessionManager] handleExit: session=${sessionId} currentState=${session.state} code=${code} signal=${signal} expected=${expected}`);
       this.logger.info(`[ProxyManager ${sessionId}] Exit: code=${code}, signal=${signal}, expected=${expected}`);
       session.lastProxyExit = { code, signal, expected };
@@ -1227,6 +1240,7 @@ export abstract class SessionManagerCore extends EventEmitter {
   }
 
   protected cleanupProxyEventHandlers(session: ManagedSession, proxyManager: IProxyManager): void {
+    clearPauseIntent(session);
     // Safety check to prevent double cleanup
     if (!this.sessionEventHandlers.has(session)) {
       this.logger.debug(`[SessionManager] Cleanup already performed for session ${session.id}`);

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -32,6 +32,7 @@ export interface CreateSessionParams {
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import { IProxyManager } from '../proxy/proxy-manager.js';
 import { OutputRingBuffer } from './output-buffer.js';
+import type { PauseIntent } from './execution/pause-intent.js';
 
 export interface ToolchainValidationState {
   compatible: boolean;
@@ -110,10 +111,11 @@ export interface ManagedSession extends DebugSessionInfo {
   // even when the adapter reports a non-'entry' reason (e.g., js-debug
   // emits 'pause' from its post-attach forced pause).
   firstStopHandled?: boolean;
-  // True while a user-initiated DAP pause request is awaiting its stopped
-  // event. Read by policy stop-reason normalization (adapters like CodeLLDB
-  // report pauses with a misleading raw reason); cleared on every stop.
-  pausePending?: boolean;
+  // Monotonic identity for each proxy installed on this session. A late event
+  // from an older worker cannot satisfy intent armed against a newer one.
+  proxyGeneration?: number;
+  // Pause request awaiting its stopped event, scoped to proxyGeneration.
+  pauseIntent?: PauseIntent;
   // True for sessions established via attach_to_process. Attach targets may
   // run on a remote filesystem (container, pod, other machine), so host-side
   // file existence checks do not apply to their source paths.

--- a/tests/core/unit/session/pause-intent.test.ts
+++ b/tests/core/unit/session/pause-intent.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  armPauseIntent,
+  beginProxyGeneration,
+  clearPauseIntent,
+  hasCurrentPauseIntent
+} from '../../../../src/session/execution/pause-intent.js';
+
+describe('generation-scoped pause intent', () => {
+  it('invalidates a pending pause when a new proxy generation begins', () => {
+    const session: {
+      proxyGeneration?: number;
+      pauseIntent?: ReturnType<typeof armPauseIntent>;
+    } = {};
+    beginProxyGeneration(session);
+    const first = armPauseIntent(session, 'user');
+    expect(hasCurrentPauseIntent(session)).toBe(true);
+
+    beginProxyGeneration(session);
+
+    expect(session.proxyGeneration).toBe(first.generation + 1);
+    expect(session.pauseIntent).toBeUndefined();
+    expect(hasCurrentPauseIntent({
+      proxyGeneration: session.proxyGeneration,
+      pauseIntent: first
+    })).toBe(false);
+  });
+
+  it('does not clear a newer intent while an older request settles', () => {
+    vi.spyOn(Date, 'now').mockReturnValueOnce(1).mockReturnValueOnce(2);
+    const session: {
+      proxyGeneration?: number;
+      pauseIntent?: ReturnType<typeof armPauseIntent>;
+    } = { proxyGeneration: 4 };
+    const older = armPauseIntent(session, 'user');
+    const newer = armPauseIntent(session, 'attach');
+
+    clearPauseIntent(session, older);
+    expect(session.pauseIntent).toBe(newer);
+    clearPauseIntent(session, newer);
+    expect(session.pauseIntent).toBeUndefined();
+  });
+});

--- a/tests/core/unit/session/session-manager-dap.test.ts
+++ b/tests/core/unit/session/session-manager-dap.test.ts
@@ -2579,13 +2579,17 @@ describe('SessionManager - DAP Operations', () => {
       expect(managedSession?.lastStop?.reason).toBe('pause');
       expect(managedSession?.lastStop?.rawReason).toBe('exception');
       expect(managedSession?.state).toBe(SessionState.PAUSED);
-      expect(managedSession?.pausePending).toBe(false);
+      expect(managedSession?.pauseIntent).toBeUndefined();
     });
 
     it('normalizes the Windows break-in pause (0x80000003) while a pause is pending (issue #275)', async () => {
       const session = await createPausedRustSession();
       const managed = sessionManager.getSession(session.id)!;
-      managed.pausePending = true;
+      managed.pauseIntent = {
+        generation: managed.proxyGeneration ?? 0,
+        source: 'user',
+        armedAt: Date.now()
+      };
 
       dependencies.mockProxyManager.simulateStopped(1, 'exception', {
         reason: 'exception',
@@ -2595,7 +2599,7 @@ describe('SessionManager - DAP Operations', () => {
 
       expect(managed.lastStop?.reason).toBe('pause');
       expect(managed.lastStop?.rawReason).toBe('exception');
-      expect(managed.pausePending).toBe(false);
+      expect(managed.pauseIntent).toBeUndefined();
     });
 
     it('leaves a real rust exception stop unnormalized (no rawReason)', async () => {

--- a/tests/unit/session-manager-operations-coverage.test.ts
+++ b/tests/unit/session-manager-operations-coverage.test.ts
@@ -3700,19 +3700,19 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(data?.stopReason).toBeUndefined();
     });
 
-    it('flags the in-flight pause for stop-reason normalization (pausePending)', async () => {
+    it('flags the in-flight pause for stop-reason normalization', async () => {
       mockSession.state = SessionState.RUNNING;
       mockProxyManager.sendDapRequest.mockResolvedValue({});
 
       const promise = operations.pause('test-session', 1);
       await vi.waitFor(() => {
-        expect(mockSession.pausePending).toBe(true);
+        expect(mockSession.pauseIntent).toEqual(expect.objectContaining({ source: 'user' }));
       });
       emitStopped();
       await promise;
     });
 
-    it('clears pausePending when the pause request fails', async () => {
+    it('clears pause intent when the pause request fails', async () => {
       mockSession.state = SessionState.RUNNING;
       mockProxyManager.sendDapRequest.mockImplementation((command: string) => {
         if (command === 'pause') {
@@ -3722,7 +3722,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       });
 
       await expect(operations.pause('test-session', 1)).rejects.toThrow('pause not supported');
-      expect(mockSession.pausePending).toBe(false);
+      expect(mockSession.pauseIntent).toBeUndefined();
     });
 
     it('returns a structured failure (not a rejection) when the pause has no debug target (issue #513)', async () => {
@@ -3743,7 +3743,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/no debug target/);
       expect(result.state).toBe(SessionState.RUNNING);
-      expect(mockSession.pausePending).toBe(false);
+      expect(mockSession.pauseIntent).toBeUndefined();
     });
 
     it('includes the last stop reason when already paused', async () => {
@@ -3791,7 +3791,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       expect(result.state).toBe(SessionState.PAUSED);
     });
 
-    it('leaves pausePending false when the stop happened during thread discovery (issue #574)', async () => {
+    it('leaves pause intent clear when the stop happened during thread discovery (issue #574)', async () => {
       mockSession.state = SessionState.RUNNING;
       mockProxyManager.sendDapRequest.mockImplementation((command: string) => {
         if (command === 'threads') {
@@ -3808,10 +3808,10 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
       await operations.pause('test-session');
 
-      expect(mockSession.pausePending).toBe(false);
+      expect(mockSession.pauseIntent).toBeUndefined();
     });
 
-    it('arms pausePending for a stop that auto-continued during thread discovery (issue #574)', async () => {
+    it('arms pause intent for a stop that auto-continued during thread discovery (issue #574)', async () => {
       // The other half of the rule. A js-debug entry stop with pre-launch
       // function breakpoints is auto-continued, so the session is RUNNING
       // again by the time discovery resolves — and handleStopped cleared the
@@ -3822,12 +3822,12 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
       mockProxyManager.sendDapRequest.mockImplementation((command: string) => {
         if (command === 'threads') {
           mockSession.state = SessionState.PAUSED;   // the entry stop lands
-          mockSession.pausePending = false;          // handleStopped clears it
+          mockSession.pauseIntent = undefined;       // handleStopped clears it
           mockSession.state = SessionState.RUNNING;  // auto-continued
           return Promise.resolve({ body: { threads: [{ id: 3, name: 'Main' }] } });
         }
         if (command === 'pause') {
-          armedWhenPauseSent = mockSession.pausePending;
+          armedWhenPauseSent = mockSession.pauseIntent !== undefined;
         }
         return Promise.resolve({});
       });
@@ -4048,7 +4048,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
         .rejects.toBeInstanceOf(SessionTerminatedError);
       // Never armed: the flag is set after these checks, and normalization
       // reads it as `=== true`.
-      expect(mockSession.pausePending).not.toBe(true);
+      expect(mockSession.pauseIntent).toBeUndefined();
     });
 
     it('fails with ProxyNotRunningError when only the proxy handle is cleared during discovery (issue #574)', async () => {
@@ -4066,7 +4066,7 @@ describe('Session Manager Operations Coverage - Error Paths and Edge Cases', () 
 
       await expect(operations.pause('test-session'))
         .rejects.toBeInstanceOf(ProxyNotRunningError);
-      expect(mockSession.pausePending).not.toBe(true);
+      expect(mockSession.pauseIntent).toBeUndefined();
     });
 
     it('reports a pending pause when no stopped event arrives within the grace window', async () => {


### PR DESCRIPTION
Closes #591. Replaces the unscoped pausePending flag with generation-bound intent cleared across terminal lifecycle paths. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.