### PR TITLE
refactor: coordinate pause requests consistently (#593)

### DIFF
--- a/changelog.d/593.fixed.md
+++ b/changelog.d/593.fixed.md
@@ -1,0 +1,3 @@
+Share one generation-aware pause coordinator between `pause_execution` and
+post-attach suspension so both paths arm intent and listeners before sending
+the DAP request and classify the result as observed, pending, or rejected.

--- a/src/session/attach/attach-controller.ts
+++ b/src/session/attach/attach-controller.ts
@@ -22,13 +22,15 @@ import type { AttachContext } from '../operations-context.js';
 import type { BreakpointController } from '../breakpoints/breakpoint-controller.js';
 import { failProxySetup, sessionRemovedDuringTeardown } from '../launch/proxy-failure-diagnostics.js';
 import type { ProxyLauncher } from '../launch/proxy-launcher.js';
-import { pauseAfterAttach, verifyAttachThreads } from './attach-verification.js';
+import { verifyAttachThreads } from './attach-verification.js';
+import type { PauseCoordinator } from '../execution/pause-coordinator.js';
 
 export class AttachController {
   constructor(
     private readonly ctx: AttachContext,
     private readonly proxyLauncher: ProxyLauncher,
-    private readonly breakpoints: BreakpointController
+    private readonly breakpoints: BreakpointController,
+    private readonly pauseCoordinator: PauseCoordinator
   ) {}
 
   /**
@@ -233,7 +235,30 @@ export class AttachController {
         // (e.g. started suspended) — fine, no stop event will follow.
         const attachBehavior = this.ctx.selectPolicy(session.language).getAttachBehavior?.();
         if (attachBehavior?.pauseAfterAttach) {
-          await pauseAfterAttach(this.ctx, { proxyManager, attachBehavior, discoveredThreadId });
+          const pauseThreadId = attachBehavior.pauseAllThreads ? 0 : discoveredThreadId;
+          const pauseOutcome = await this.pauseCoordinator.requestPause({
+            session,
+            proxyManager,
+            threadId: pauseThreadId,
+            timeoutMs: this.ctx.tunables.attachPauseStopTimeoutMs,
+            source: 'attach'
+          });
+          if (pauseOutcome.status === 'observed') {
+            this.ctx.logger.info(
+              `[SessionManager] Observed post-attach pause (threadId=${pauseThreadId})`
+            );
+          } else if (pauseOutcome.status === 'pending') {
+            this.ctx.logger.warn(
+              `[SessionManager] No 'stopped' event within ${this.ctx.tunables.attachPauseStopTimeoutMs}ms after post-attach pause; reported state may lag the engine`
+            );
+          } else {
+            // A target started suspended may reject a redundant pause. The
+            // caller still applies the pre-existing attach state contract;
+            // issue #598 tightens that public mapping independently.
+            this.ctx.logger.info(
+              `[SessionManager] Post-attach pause not needed/accepted: ${pauseOutcome.error instanceof Error ? pauseOutcome.error.message : String(pauseOutcome.error)}`
+            );
+          }
         }
 
         this.ctx.updateState(session, SessionState.PAUSED);

--- a/src/session/attach/attach-verification.ts
+++ b/src/session/attach/attach-verification.ts
@@ -7,20 +7,15 @@
  * attach is not usable, and reporting success would be a lie (issue #124) —
  * and latches the first proxy error/exit so an adapter that dies mid-verify
  * fails fast with its own message rather than a generic "not initialized".
- * `pauseAfterAttach` then suspends targets whose debugger does not stop them
- * on attach (rdbg; js-debug with continueOnAttach), waiting for the stop to be
- * observed so the PAUSED state is real when it is reported.
+ * Post-attach suspension is coordinated separately by `PauseCoordinator` so
+ * attach and the public pause tool share one event-ordering contract.
  */
-import type { AdapterPolicy } from '@debugmcp/shared';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import type { ManagedSession } from '../session-store.js';
 import type { OperationsContext } from '../operations-context.js';
 
-/** The policy's attach behaviour, as `getAttachBehavior()` declares it. */
-export type AttachBehavior = NonNullable<ReturnType<NonNullable<AdapterPolicy['getAttachBehavior']>>>;
-
-/** Thread verification narrates its attempts; the post-attach pause reads its stop window. */
-export type AttachVerificationContext = Pick<OperationsContext, 'logger' | 'tunables'>;
+/** Thread verification narrates its attempts. */
+export type AttachVerificationContext = Pick<OperationsContext, 'logger'>;
 
 export interface AttachVerifyInput {
   proxyManager: NonNullable<ManagedSession['proxyManager']>;
@@ -142,68 +137,4 @@ export async function sendThreadsRequestBounded(
   timeoutMs: number
 ): Promise<DebugProtocol.ThreadsResponse | undefined> {
   return proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {}, { timeoutMs });
-}
-
-export interface PauseAfterAttachInput {
-  proxyManager: NonNullable<ManagedSession['proxyManager']>;
-  /** The policy's attach behaviour; only consulted when `pauseAfterAttach` is set. */
-  attachBehavior: AttachBehavior;
-  /** The thread verification settled on; the pause targets it unless the policy pauses all. */
-  discoveredThreadId: number;
-}
-
-/**
- * Issue the explicit post-attach pause and wait (bounded by the
- * `attachPauseStopTimeoutMs` tunable) for the resulting 'stopped' event. A
- * rejected pause means the target is already stopped — fine, no stop event
- * will follow.
- */
-export async function pauseAfterAttach(
-  ctx: AttachVerificationContext,
-  input: PauseAfterAttachInput
-): Promise<void> {
-  const { proxyManager, attachBehavior, discoveredThreadId } = input;
-    let stopSettled = false;
-    let stopTimer: ReturnType<typeof setTimeout> | undefined;
-    let onStopped: (() => void) | undefined;
-    const stoppedSeen = new Promise<boolean>((resolve) => {
-      onStopped = () => {
-        if (!stopSettled) {
-          stopSettled = true;
-          if (stopTimer) clearTimeout(stopTimer);
-          resolve(true);
-        }
-      };
-      stopTimer = setTimeout(() => {
-        if (!stopSettled) {
-          stopSettled = true;
-          resolve(false);
-        }
-      }, ctx.tunables.attachPauseStopTimeoutMs);
-      proxyManager.once('stopped', onStopped);
-    });
-    try {
-      // pauseAllThreads (issue #465): threadId 0 asks the adapter for a
-      // process-wide suspend — the JDI bridge then re-anchors its
-      // stopped event to a thread that can actually report frames,
-      // instead of single-thread-suspending whichever id we picked.
-      const pauseThreadId = attachBehavior.pauseAllThreads ? 0 : discoveredThreadId;
-      await proxyManager.sendDapRequest('pause', { threadId: pauseThreadId });
-      ctx.logger.info(`[SessionManager] Sent post-attach pause (threadId=${pauseThreadId})`);
-      const stopObserved = await stoppedSeen;
-      if (!stopObserved) {
-        ctx.logger.warn(
-          `[SessionManager] No 'stopped' event within ${ctx.tunables.attachPauseStopTimeoutMs}ms after post-attach pause; reported state may lag the engine`
-        );
-      }
-    } catch (err) {
-      // Already stopped (e.g. target was started suspended) — fine.
-      ctx.logger.info(
-        `[SessionManager] Post-attach pause not needed/accepted: ${err instanceof Error ? err.message : String(err)}`
-      );
-    } finally {
-      stopSettled = true;
-      if (stopTimer) clearTimeout(stopTimer);
-      if (onStopped) proxyManager.removeListener('stopped', onStopped);
-    }
 }

--- a/src/session/execution/execution-controller.ts
+++ b/src/session/execution/execution-controller.ts
@@ -49,7 +49,7 @@ import type {
   StopLocation
 } from '../session-manager-core.js';
 import type { ExecutionContext } from '../operations-context.js';
-import { armPauseIntent, clearPauseIntent } from './pause-intent.js';
+import type { PauseCoordinator } from './pause-coordinator.js';
 
 /** What distinguishes the three step flavours: everything else is shared. */
 interface StepKind {
@@ -114,7 +114,10 @@ export interface StepOperationOptions {
 }
 
 export class ExecutionController {
-  constructor(private readonly ctx: ExecutionContext) {}
+  constructor(
+    private readonly ctx: ExecutionContext,
+    private readonly pauseCoordinator: PauseCoordinator
+  ) {}
 
   async stepOver(sessionId: string): Promise<DebugResult<StepResultData>> {
     return this.step(sessionId, 'stepOver');
@@ -477,241 +480,93 @@ export class ExecutionController {
       throw new ProxyNotRunningError(sessionId, 'pause');
     }
 
-    // Flag the in-flight pause so policy stop-reason normalization can use it
-    // (e.g. CodeLLDB reports pauses as 'exception'/SIGSTOP). Armed AFTER
-    // discovery, and only while the session is still running: an unrelated
-    // stop landing during that await (a js-debug entry stop auto-continued by
-    // pre-launch function breakpoints) would otherwise clear the flag before
-    // the pause was even sent, and this pause's own stop would normalize
-    // without it — reported as 'step' rather than 'pause' (#574). A stop that
-    // landed during discovery and stayed leaves it unarmed, which is exactly
-    // what the post-response race branch below wants; a session that
-    // auto-continued back to RUNNING arms it. handleStopped clears it on
-    // every stop; the settle paths below clear it where no stop is coming.
-    if (session.state === SessionState.RUNNING) {
-      armPauseIntent(session, 'user');
-    } else {
-      clearPauseIntent(session);
+    const outcome = await this.pauseCoordinator.requestPause({
+      session,
+      proxyManager,
+      threadId: effectiveThreadId,
+      timeoutMs: this.ctx.tunables.pauseGraceMs,
+      source: 'user'
+    });
+    // The await above lets asynchronous proxy events mutate session.state;
+    // keeping this behind a function also prevents TypeScript from retaining
+    // the RUNNING-only narrowing established before dispatch.
+    const sessionEnded = () =>
+      session.state === SessionState.STOPPED || session.state === SessionState.ERROR;
+
+    /** The stop reason, but only when core recorded a NEW stop for this pause. */
+    const ownStopReason = (): Pick<PauseResultData, 'stopReason' | 'rawStopReason'> => {
+      if (!session.lastStop || session.lastStop === lastStopBefore) {
+        return {};
+      }
+      return {
+        stopReason: session.lastStop.reason,
+        ...(session.lastStop.rawReason ? { rawStopReason: session.lastStop.rawReason } : {})
+      };
+    };
+
+    if (outcome.status === 'observed') {
+      let location: StopLocation | undefined;
+      try {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        const [topFrame] = await this.ctx.getStackTrace(sessionId);
+        if (topFrame) {
+          location = { file: topFrame.file, line: topFrame.line, column: topFrame.column };
+        }
+      } catch (error) {
+        this.ctx.logger.debug(`[SessionManager pause ${sessionId}] Could not capture location:`, error);
+      }
+
+      if (sessionEnded()) {
+        return {
+          success: true,
+          state: session.state,
+          data: { message: PAUSED_THEN_ENDED_MESSAGE, ...ownStopReason() }
+        };
+      }
+      this.ctx.logger.info(
+        `[SessionManager pause] Paused session ${sessionId}. Current state: ${session.state}`
+      );
+      return {
+        success: true,
+        state: session.state,
+        data: {
+          message: 'Paused',
+          ...ownStopReason(),
+          ...(location ? { location } : {})
+        }
+      };
     }
 
-    // The pause response only acknowledges the request; the state transition
-    // to PAUSED happens when the asynchronous 'stopped' event is handled by
-    // the core handleStopped listener. Adapters differ on whether the event
-    // arrives before or after the response, so listen for it (registered
-    // BEFORE sending the request) and only settle once the stop is observed.
-    return new Promise<DebugResult<PauseResultData>>((resolve, reject) => {
-      let settled = false;
-      let stopEventSeen = false;
-
-      const cleanup = () => {
-        proxyManager.off('stopped', settleFromStop);
-        proxyManager.off('terminated', onEnded);
-        proxyManager.off('exited', onEnded);
-        proxyManager.off('exit', onEnded);
-        clearTimeout(timeout);
-      };
-
-      const settle = (result: DebugResult<PauseResultData>) => {
-        if (settled) {
-          return;
+    if (outcome.status === 'pending') {
+      this.ctx.logger.info(
+        `[SessionManager pause] No stopped event within ${this.ctx.tunables.pauseGraceMs}ms grace window in session ${sessionId}; completing asynchronously`
+      );
+      return {
+        success: true,
+        state: session.state,
+        data: {
+          message: ErrorMessages.pausePending(this.ctx.tunables.pauseGraceMs / 1000),
+          pending: true
         }
-        settled = true;
-        cleanup();
-        resolve(result);
       };
+    }
 
-      /**
-       * Where the debuggee came to rest. Both settle paths that mean "this
-       * pause took effect" need it — the event path and the post-response
-       * race branch — so it lives outside onStopped rather than inside it
-       * (#574): the race branch used to return a bare `{message:'Paused'}`
-       * where the event path returned a location.
-       */
-      const readStopLocation = async (): Promise<StopLocation | undefined> => {
-        try {
-          // Wait a brief moment for state to settle after stopped event
-          await new Promise(resolve => setTimeout(resolve, 10));
-
-          const stackFrames = await this.ctx.getStackTrace(sessionId);
-          if (stackFrames && stackFrames.length > 0) {
-            const topFrame = stackFrames[0];
-            return {
-              file: topFrame.file,
-              line: topFrame.line,
-              column: topFrame.column
-            };
-          }
-        } catch (error) {
-          this.ctx.logger.debug(`[SessionManager pause ${sessionId}] Could not capture location:`, error);
-        }
-        return undefined;
+    if (outcome.ended || sessionEnded()) {
+      return {
+        success: true,
+        state: session.state,
+        data: { message: 'Session ended before pause took effect' }
       };
+    }
 
-      /** Rule 2: has the session reached a terminal state by settle time? */
-      const sessionEnded = () =>
-        session.state === SessionState.STOPPED || session.state === SessionState.ERROR;
-
-      /** The stop reason, but only when handleStopped recorded a NEW one for THIS pause. */
-      const ownStopReason = (): Pick<PauseResultData, 'stopReason' | 'rawStopReason'> => {
-        if (!session.lastStop || session.lastStop === lastStopBefore) {
-          return {};
-        }
-        return {
-          stopReason: session.lastStop.reason,
-          ...(session.lastStop.rawReason ? { rawStopReason: session.lastStop.rawReason } : {})
-        };
-      };
-
-      /**
-       * The answer for "this pause took effect", under both rules. Every path
-       * that observed the stop routes through here, so the ended-at-settle
-       * check cannot be forgotten by one of them.
-       */
-      const stopResult = (location?: StopLocation): DebugResult<PauseResultData> => {
-        if (sessionEnded()) {
-          // Rule 2. The pause landed and the session ended before the stack
-          // could be read: say both, and offer no location, rather than
-          // pairing 'Paused' with a terminal state.
-          return {
-            success: true,
-            state: session.state,
-            data: { message: PAUSED_THEN_ENDED_MESSAGE, ...ownStopReason() }
-          };
-        }
-        return {
-          success: true,
-          state: session.state,
-          data: {
-            message: 'Paused',
-            ...ownStopReason(),
-            ...(location ? { location } : {})
-          }
-        };
-      };
-
-      /**
-       * The one stop path. Registered as the 'stopped' listener AND called by
-       * the post-response race branch, which used to re-implement it by hand
-       * and drifted from it twice (#574).
-       */
-      const settleFromStop = async () => {
-        stopEventSeen = true;
-        const location = await readStopLocation();
-        this.ctx.logger.info(
-          `[SessionManager pause] Paused session ${sessionId}. Current state: ${session.state}`
-        );
-        settle(stopResult(location));
-      };
-
-      const onEnded = () => {
-        // Rule 1: a stop was observed, so the pause DID take effect and this
-        // message would be false. The stop path settles, and rule 2 makes it
-        // report the ending.
-        if (stopEventSeen) {
-          this.ctx.logger.debug(
-            `[SessionManager pause] Session ended while the observed stop was being resolved; standing down for the stop path`
-          );
-          return;
-        }
-        clearPauseIntent(session);
-        settle({
-          success: true,
-          state: session.state,
-          data: { message: 'Session ended before pause took effect' }
-        });
-      };
-
-      const timeout = setTimeout(() => {
-        // Rule 1: the stop WAS observed, the stop path is still resolving
-        // where it landed. "No 'stopped' event within Ns" would be false, and
-        // would drop the stopReason and location it is about to report.
-        // Trade-off: past this point the answer is bounded by the stackTrace
-        // round trip (a 30s DAP request timeout plus the proxy's 5s parent
-        // margin) rather than by this window — hence the log line.
-        if (stopEventSeen) {
-          this.ctx.logger.debug(
-            `[SessionManager pause] Grace window elapsed but the stop is already being resolved; standing down`
-          );
-          return;
-        }
-        this.ctx.logger.info(
-          `[SessionManager pause] No stopped event within ${this.ctx.tunables.pauseGraceMs}ms grace window in session ${sessionId}; completing asynchronously`
-        );
-        // The generation-scoped pause intent stays armed on purpose: the pause was
-        // delivered and the stop may land whenever the debuggee next runs
-        // (e.g. an idle server, issue #513) — that late stop must still be
-        // normalized to 'pause'. handleStopped clears the flag on any stop.
-        settle({
-          success: true,
-          state: session.state,
-          data: {
-            message: ErrorMessages.pausePending(this.ctx.tunables.pauseGraceMs / 1000),
-            pending: true,
-          },
-        });
-      }, this.ctx.tunables.pauseGraceMs);
-
-      proxyManager.on('stopped', settleFromStop);
-      proxyManager.on('terminated', onEnded);
-      proxyManager.on('exited', onEnded);
-      proxyManager.on('exit', onEnded);
-
-      proxyManager
-        .sendDapRequest('pause', { threadId: effectiveThreadId })
-        .then(async () => {
-          this.ctx.logger.info(
-            `[SessionManager pause] DAP 'pause' sent for session ${sessionId}. Waiting for stopped event.`
-          );
-          // If the stopped event fired before the listeners above were
-          // registered (e.g. during the threads-discovery await), the state is
-          // already PAUSED and no further event will arrive — so this is the
-          // stop path, and runs it rather than a copy of it (#574).
-          if (session.state === SessionState.PAUSED && !stopEventSeen) {
-            await settleFromStop();
-          }
-        })
-        .catch((error: unknown) => {
-          const errorMessage = getErrorMessage(error);
-          // Rule 1. A proxy that dies just after the stop rejects the still
-          // pending pause, and an adapter asked to pause an already stopped
-          // target can answer failure outright. Neither unmakes the stop.
-          if (stopEventSeen) {
-            this.ctx.logger.debug(
-              `[SessionManager pause] Pause request rejected after the stop was observed; standing down: ${errorMessage}`
-            );
-            return;
-          }
-          if (session.state === SessionState.PAUSED) {
-            // Same situation, seen from the other side: the stop landed during
-            // discovery, so no 'stopped' listener will ever fire. Left alone
-            // the grace timer would eventually settle this — after a full
-            // pauseGraceMs, with `pending: true` and "no 'stopped' event
-            // within Ns", both false for a session that is demonstrably
-            // paused. Running the stop path answers now, and correctly.
-            this.ctx.logger.debug(
-              `[SessionManager pause] Pause request rejected but the session is already paused; reporting the stop: ${errorMessage}`
-            );
-            void settleFromStop();
-            return;
-          }
-          clearPauseIntent(session);
-          this.ctx.logger.error(
-            `[SessionManager pause] Error sending 'pause' for session ${sessionId}: ${errorMessage}`
-          );
-          if (!settled) {
-            settled = true;
-            cleanup();
-            // A pause with no debuggable target to run against (issue #513)
-            // is an actionable state, not a protocol failure — return the
-            // structured shape other unpausable states use
-            if (errorMessage.includes(NO_DEBUG_TARGET_MARKER)) {
-              resolve({ success: false, error: errorMessage, state: session.state });
-              return;
-            }
-            reject(error instanceof Error ? error : new Error(errorMessage));
-          }
-        });
-    });
+    const errorMessage = getErrorMessage(outcome.error);
+    this.ctx.logger.error(
+      `[SessionManager pause] Error sending 'pause' for session ${sessionId}: ${errorMessage}`
+    );
+    if (errorMessage.includes(NO_DEBUG_TARGET_MARKER)) {
+      return { success: false, error: errorMessage, state: session.state };
+    }
+    throw outcome.error instanceof Error ? outcome.error : new Error(errorMessage);
   }
 
   async listThreads(sessionId: string): Promise<Array<{ id: number; name: string }>> {

--- a/src/session/execution/pause-coordinator.ts
+++ b/src/session/execution/pause-coordinator.ts
@@ -1,0 +1,134 @@
+import { SessionState, type ILogger } from '@debugmcp/shared';
+import type { IProxyManager } from '../../proxy/proxy-manager.js';
+import type { ManagedSession } from '../session-store.js';
+import { armPauseIntent, clearPauseIntent } from './pause-intent.js';
+
+export type PauseOutcome =
+  | { status: 'observed' }
+  | { status: 'pending' }
+  | { status: 'rejected'; error: unknown; ended?: true };
+
+export interface CoordinatePauseInput {
+  session: ManagedSession;
+  proxyManager: IProxyManager;
+  threadId: number;
+  timeoutMs: number;
+  source: 'user' | 'attach';
+}
+
+export interface PauseCoordinatorContext {
+  logger: ILogger;
+}
+
+/**
+ * Own the low-level pause race shared by pause_execution and attach.
+ * Listeners and generation-scoped intent are installed before the request;
+ * callers decide how the three outcomes map onto their public result shape.
+ */
+export class PauseCoordinator {
+  constructor(private readonly ctx: PauseCoordinatorContext) {}
+
+  async requestPause(input: CoordinatePauseInput): Promise<PauseOutcome> {
+    const { session, proxyManager, threadId, timeoutMs, source } = input;
+
+    // A stop may have landed while the caller was discovering a thread.
+    if (session.state === SessionState.PAUSED) {
+      clearPauseIntent(session);
+      return { status: 'observed' };
+    }
+    const sessionPaused = () => session.state === SessionState.PAUSED;
+
+    let stoppedSeen = false;
+    let endedSeen = false;
+    let resolveEvent: ((value: 'stopped' | 'ended') => void) | undefined;
+    const event = new Promise<'stopped' | 'ended'>((resolve) => {
+      resolveEvent = resolve;
+    });
+    const onStopped = () => {
+      stoppedSeen = true;
+      resolveEvent?.('stopped');
+    };
+    const onEnded = () => {
+      endedSeen = true;
+      resolveEvent?.('ended');
+    };
+
+    // Listener registration precedes both intent and request dispatch.
+    proxyManager.on('stopped', onStopped);
+    proxyManager.on('terminated', onEnded);
+    proxyManager.on('exited', onEnded);
+    proxyManager.on('exit', onEnded);
+    const intent = armPauseIntent(session, source);
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      proxyManager.off('stopped', onStopped);
+      proxyManager.off('terminated', onEnded);
+      proxyManager.off('exited', onEnded);
+      proxyManager.off('exit', onEnded);
+    };
+    const observed = (): PauseOutcome => {
+      clearPauseIntent(session, intent);
+      return { status: 'observed' };
+    };
+    const rejected = (error: unknown, ended = false): PauseOutcome => {
+      clearPauseIntent(session, intent);
+      return { status: 'rejected', error, ...(ended ? { ended: true as const } : {}) };
+    };
+
+    try {
+      const request = proxyManager
+        .sendDapRequest('pause', { threadId })
+        .then(() => ({ kind: 'accepted' as const }))
+        .catch((error: unknown) => ({ kind: 'rejected' as const, error }));
+
+      const first = await Promise.race([
+        event.then((kind) => ({ kind } as const)),
+        request
+      ]);
+
+      if (first.kind === 'stopped') {
+        return observed();
+      }
+      if (first.kind === 'ended') {
+        return rejected(new Error('Session ended before pause took effect'), true);
+      }
+      if (first.kind === 'rejected') {
+        if (stoppedSeen || (sessionPaused() && session.lastStop)) {
+          return observed();
+        }
+        return rejected(first.error);
+      }
+
+      this.ctx.logger.info(
+        `[PauseCoordinator] DAP pause accepted for session ${session.id}; waiting for stopped event`
+      );
+      if (stoppedSeen || (sessionPaused() && session.lastStop)) {
+        return observed();
+      }
+      if (endedSeen) {
+        return rejected(new Error('Session ended before pause took effect'), true);
+      }
+
+      const afterAcceptance = await Promise.race([
+        event,
+        new Promise<'timeout'>((resolve) => {
+          timeout = setTimeout(() => resolve('timeout'), timeoutMs);
+        })
+      ]);
+      if (afterAcceptance === 'stopped') {
+        return observed();
+      }
+      if (afterAcceptance === 'ended') {
+        return rejected(new Error('Session ended before pause took effect'), true);
+      }
+
+      // A delivered pause may stop later when the target next executes. Keep
+      // this exact generation's intent armed for core stop normalization.
+      return { status: 'pending' };
+    } finally {
+      cleanup();
+    }
+  }
+}

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -19,6 +19,7 @@ import {
   type FunctionBreakpointRemoval
 } from './breakpoints/breakpoint-controller.js';
 import { ExecutionController } from './execution/execution-controller.js';
+import { PauseCoordinator } from './execution/pause-coordinator.js';
 import {
   ExpressionEvaluator,
   type EvaluateResult
@@ -162,13 +163,19 @@ export abstract class SessionManagerOperations extends SessionManagerData {
    */
   protected readonly opsContext: OperationsContext = this.buildOperationsContext();
   protected readonly breakpoints = new BreakpointController(this.opsContext);
-  protected readonly execution = new ExecutionController(this.opsContext);
+  protected readonly pauseCoordinator = new PauseCoordinator(this.opsContext);
+  protected readonly execution = new ExecutionController(this.opsContext, this.pauseCoordinator);
   protected readonly evaluator = new ExpressionEvaluator(this.opsContext);
   protected readonly hotSwap = new RedefineClassesController(this.opsContext, this.breakpoints);
   protected readonly mirror = new MirrorController(this.opsContext);
   protected readonly proxyLauncher = new ProxyLauncher(this.opsContext);
   protected readonly launcher = new DebugLauncher(this.opsContext, this.proxyLauncher, this.breakpoints);
-  protected readonly attach = new AttachController(this.opsContext, this.proxyLauncher, this.breakpoints);
+  protected readonly attach = new AttachController(
+    this.opsContext,
+    this.proxyLauncher,
+    this.breakpoints,
+    this.pauseCoordinator
+  );
 
   /**
    * Start (or dry-run) a launch-mode debug session. Delegates to the launcher,

--- a/tests/core/unit/session/pause-coordinator.test.ts
+++ b/tests/core/unit/session/pause-coordinator.test.ts
@@ -1,0 +1,89 @@
+import { EventEmitter } from 'node:events';
+import { SessionState } from '@debugmcp/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IProxyManager } from '../../../../src/proxy/proxy-manager.js';
+import { PauseCoordinator } from '../../../../src/session/execution/pause-coordinator.js';
+import type { ManagedSession } from '../../../../src/session/session-store.js';
+
+function fixture() {
+  const proxy = new EventEmitter() as EventEmitter & {
+    sendDapRequest: ReturnType<typeof vi.fn>;
+  };
+  proxy.sendDapRequest = vi.fn();
+  const session = {
+    id: 'session-1',
+    state: SessionState.RUNNING,
+    proxyGeneration: 7
+  } as ManagedSession;
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  };
+  return {
+    proxy,
+    session,
+    coordinator: new PauseCoordinator({ logger })
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('PauseCoordinator', () => {
+  it('arms intent and listeners before dispatch and observes a synchronous stop', async () => {
+    const { proxy, session, coordinator } = fixture();
+    proxy.sendDapRequest.mockImplementation(() => {
+      expect(session.pauseIntent).toMatchObject({ generation: 7, source: 'user' });
+      expect(proxy.listenerCount('stopped')).toBe(1);
+      proxy.emit('stopped', { reason: 'pause', threadId: 1 });
+      return Promise.resolve({ success: true });
+    });
+
+    await expect(coordinator.requestPause({
+      session,
+      proxyManager: proxy as unknown as IProxyManager,
+      threadId: 1,
+      timeoutMs: 50,
+      source: 'user'
+    })).resolves.toEqual({ status: 'observed' });
+    expect(session.pauseIntent).toBeUndefined();
+    expect(proxy.listenerCount('stopped')).toBe(0);
+  });
+
+  it('keeps current-generation intent armed when an accepted pause is pending', async () => {
+    vi.useFakeTimers();
+    const { proxy, session, coordinator } = fixture();
+    proxy.sendDapRequest.mockResolvedValue({ success: true });
+
+    const result = coordinator.requestPause({
+      session,
+      proxyManager: proxy as unknown as IProxyManager,
+      threadId: 4,
+      timeoutMs: 25,
+      source: 'attach'
+    });
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(result).resolves.toEqual({ status: 'pending' });
+    expect(session.pauseIntent).toMatchObject({ generation: 7, source: 'attach' });
+    expect(proxy.listenerCount('stopped')).toBe(0);
+  });
+
+  it('clears intent and returns a rejected outcome when dispatch fails', async () => {
+    const { proxy, session, coordinator } = fixture();
+    const error = new Error('pause rejected');
+    proxy.sendDapRequest.mockRejectedValue(error);
+
+    await expect(coordinator.requestPause({
+      session,
+      proxyManager: proxy as unknown as IProxyManager,
+      threadId: 2,
+      timeoutMs: 50,
+      source: 'user'
+    })).resolves.toEqual({ status: 'rejected', error });
+    expect(session.pauseIntent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #593. Introduces the shared PauseCoordinator with listener-before-request ordering and observed, pending, or rejected outcomes. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.