### PR TITLE
fix: normalize requested attach pause reasons (#597)

### DIFF
--- a/changelog.d/597.fixed.md
+++ b/changelog.d/597.fixed.md
@@ -1,0 +1,2 @@
+Normalize generation-scoped attach pauses consistently: js-debug `step` and
+CodeLLDB `exception` stops now become `pause` while preserving `rawStopReason`.

--- a/packages/shared/src/interfaces/adapter-policy.ts
+++ b/packages/shared/src/interfaces/adapter-policy.ts
@@ -47,8 +47,10 @@ export interface AdapterSpecificState {
  * See that method's doc comment for the completeness rules.
  */
 export interface StopReasonContext {
-  /** True while a user-initiated pause request is in flight. */
+  /** True while a current-generation pause request is in flight. */
   pausePending: boolean;
+  /** Which operation requested the pause, when pausePending is true. */
+  pauseSource?: 'user' | 'attach';
   /**
    * Adapter-assigned ids of ALL user breakpoints (line + function).
    * Present only when both bookkeepings are complete.
@@ -312,8 +314,9 @@ export interface AdapterPolicy {
    *
    * @param reason The raw DAP stop reason from the adapter
    * @param body The full stopped-event body, if available
-   * @param context context.pausePending is true while a user-initiated
-   *   pause request is in flight for this session. context.userBreakpointIds
+   * @param context context.pausePending is true while a current-generation
+   *   pause request is in flight for this session; pauseSource distinguishes
+   *   a public pause from post-attach suspension. context.userBreakpointIds
    *   holds the adapter-assigned ids of every user-set breakpoint (line and
    *   function breakpoints combined), and is only present when that
    *   bookkeeping is complete (every breakpoint of both kinds has a known

--- a/packages/shared/src/interfaces/lldb-policy-shared.ts
+++ b/packages/shared/src/interfaces/lldb-policy-shared.ts
@@ -27,10 +27,10 @@ export const LLDB_LOCAL_SCOPE_NAMES = ['Local', 'Locals'] as const;
  * 1. A user-initiated pause is reported as reason 'exception': POSIX
  *    delivers it via SIGSTOP; Windows via DebugBreakProcess, whose
  *    injected break-in thread raises EXCEPTION_BREAKPOINT 0x80000003
- *    (issue #275). Map both back to 'pause' — the Windows form only
- *    while a pause request is actually in flight. Real exceptions
- *    (SIGSEGV, panics) carry other descriptions and are left untouched,
- *    even while a pause request is in flight.
+ *    (issue #275). Map both back to 'pause'. A post-attach pause may carry
+ *    any platform-specific exception detail, so its generation-scoped
+ *    intent is authoritative; public pauses retain the narrower Windows
+ *    detail checks so coincident real exceptions are not mislabeled.
  *
  * 2. An exception-filter hit (rust_panic, cpp_throw) is reported as reason
  *    'breakpoint' because CodeLLDB implements filters as internal
@@ -77,6 +77,9 @@ export function normalizeLldbStopReason(
   }
   const detail = `${body?.description ?? ''} ${body?.text ?? ''}`;
   if (/SIGSTOP/i.test(detail)) {
+    return 'pause';
+  }
+  if (context.pauseSource === 'attach') {
     return 'pause';
   }
   // Windows delivers a user-initiated pause via DebugBreakProcess: the

--- a/src/session/execution/pause-intent.ts
+++ b/src/session/execution/pause-intent.ts
@@ -38,6 +38,11 @@ export function hasCurrentPauseIntent(session: PauseIntentSession): boolean {
     session.pauseIntent.generation === (session.proxyGeneration ?? 0);
 }
 
+/** Return the current generation's intent, excluding any stale worker intent. */
+export function getCurrentPauseIntent(session: PauseIntentSession): PauseIntent | undefined {
+  return hasCurrentPauseIntent(session) ? session.pauseIntent : undefined;
+}
+
 /** Clear one current intent, optionally only if it is the expected object. */
 export function clearPauseIntent(
   session: PauseIntentSession,

--- a/src/session/session-manager-core.ts
+++ b/src/session/session-manager-core.ts
@@ -16,7 +16,7 @@ import { OutputRingBuffer } from './output-buffer.js';
 import {
   beginProxyGeneration,
   clearPauseIntent,
-  hasCurrentPauseIntent
+  getCurrentPauseIntent
 } from './execution/pause-intent.js';
 import { DebugProtocol } from '@vscode/debugprotocol'; 
 import path from 'path';
@@ -479,8 +479,10 @@ export abstract class SessionManagerCore extends EventEmitter {
         }
         const userBreakpointIds: ReadonlySet<number> | undefined =
           lineComplete && fnComplete ? new Set([...lineIds, ...fnIds]) : undefined;
+        const pauseIntent = getCurrentPauseIntent(session);
         const normalized = policy.normalizeStopReason?.(rawReason, body, {
-          pausePending: hasCurrentPauseIntent(session),
+          pausePending: pauseIntent !== undefined,
+          ...(pauseIntent ? { pauseSource: pauseIntent.source } : {}),
           userBreakpointIds,
           functionBreakpointIds: fnComplete ? fnIds : undefined,
           lineBreakpointCount: session.breakpoints.size,

--- a/tests/core/unit/session/pause-intent.test.ts
+++ b/tests/core/unit/session/pause-intent.test.ts
@@ -3,6 +3,7 @@ import {
   armPauseIntent,
   beginProxyGeneration,
   clearPauseIntent,
+  getCurrentPauseIntent,
   hasCurrentPauseIntent
 } from '../../../../src/session/execution/pause-intent.js';
 
@@ -34,6 +35,8 @@ describe('generation-scoped pause intent', () => {
     } = { proxyGeneration: 4 };
     const older = armPauseIntent(session, 'user');
     const newer = armPauseIntent(session, 'attach');
+
+    expect(getCurrentPauseIntent(session)).toBe(newer);
 
     clearPauseIntent(session, older);
     expect(session.pauseIntent).toBe(newer);

--- a/tests/core/unit/session/session-manager-dap.test.ts
+++ b/tests/core/unit/session/session-manager-dap.test.ts
@@ -2602,6 +2602,26 @@ describe('SessionManager - DAP Operations', () => {
       expect(managed.pauseIntent).toBeUndefined();
     });
 
+    it('normalizes any CodeLLDB exception raised by a requested attach pause (#597)', async () => {
+      const session = await createPausedRustSession();
+      const managed = sessionManager.getSession(session.id)!;
+      managed.pauseIntent = {
+        generation: managed.proxyGeneration ?? 0,
+        source: 'attach',
+        armedAt: Date.now()
+      };
+
+      dependencies.mockProxyManager.simulateStopped(1, 'exception', {
+        reason: 'exception',
+        threadId: 1,
+        description: 'platform-specific debugger interrupt'
+      });
+
+      expect(managed.lastStop?.reason).toBe('pause');
+      expect(managed.lastStop?.rawReason).toBe('exception');
+      expect(managed.pauseIntent).toBeUndefined();
+    });
+
     it('leaves a real rust exception stop unnormalized (no rawReason)', async () => {
       const session = await createPausedRustSession();
 

--- a/tests/unit/shared/adapter-policy-js.test.ts
+++ b/tests/unit/shared/adapter-policy-js.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { JsDebugAdapterPolicy } from '../../../packages/shared/src/interfaces/adapter-policy-js.js';
+import type { StopReasonContext } from '../../../packages/shared/src/interfaces/adapter-policy.js';
 
 describe('JsDebugAdapterPolicy', () => {
+  it('normalizes a requested attach pause while preserving real unrequested steps (#597)', () => {
+    const normalize = JsDebugAdapterPolicy.normalizeStopReason!;
+    const context = (pausePending: boolean, pauseSource?: 'user' | 'attach'): StopReasonContext => ({
+      pausePending,
+      ...(pauseSource ? { pauseSource } : {}),
+      lineBreakpointCount: 0,
+      functionBreakpointCount: 0
+    });
+
+    expect(normalize('step', { reason: 'step' }, context(true, 'attach'))).toBe('pause');
+    expect(normalize('step', { reason: 'step' }, context(false))).toBeUndefined();
+  });
+
   it('declares late-binding function breakpoints (issue #308)', () => {
     // CDP re-resolve at pauses for late-loaded modules: unverified at
     // launch is by design, so the launch-time unbound warning must skip js.


### PR DESCRIPTION
Closes #597. Normalizes js-debug step and CodeLLDB exception stops only when they fulfill requested attach pauses, retaining rawStopReason. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.