### PR TITLE
refactor: unify inspection frame anchoring (#594)

### DIFF
--- a/changelog.d/594.changed.md
+++ b/changelog.d/594.changed.md
@@ -1,0 +1,3 @@
+Stack traces, local-variable discovery, and default expression evaluation now
+share one injected `FrameAnchorResolver`; an explicit evaluation `frameId`
+remains authoritative.

--- a/src/session/inspection/expression-evaluator.ts
+++ b/src/session/inspection/expression-evaluator.ts
@@ -22,6 +22,7 @@ import {
   withTimeoutHint
 } from '../dap-request-helpers.js';
 import type { EvaluateContext } from '../operations-context.js';
+import type { FrameAnchorResolver } from './frame-anchor-resolver.js';
 
 /**
  * Result type for evaluate expression operations
@@ -55,7 +56,10 @@ export function expressionNameForRedaction(expression: string): string {
 }
 
 export class ExpressionEvaluator {
-  constructor(private readonly ctx: EvaluateContext) {}
+  constructor(
+    private readonly ctx: EvaluateContext,
+    private readonly frameAnchorResolver: FrameAnchorResolver
+  ) {}
 
   /**
    * Evaluate an expression in the context of the current debug session.
@@ -118,42 +122,28 @@ export class ExpressionEvaluator {
       };
     }
 
-    // Handle frameId - get current frame from stack trace if not provided
+    // Resolve the same default anchor stack and locals use. An explicit
+    // frameId is authoritative and deliberately bypasses the resolver.
     if (frameId === undefined) {
       try {
-        const threadId = session.proxyManager.getCurrentThreadId();
-        if (typeof threadId !== 'number') {
-          this.ctx.logger.warn(
-            `[SM evaluateExpression ${sessionId}] No current thread ID to get stack trace`
-          );
-          return {
-            success: false,
-            error: 'Unable to find thread for evaluation. Ensure the debugger is paused at a breakpoint.',
-          };
-        }
-
         this.ctx.logger.info(
-          `[SM evaluateExpression ${sessionId}] No frameId provided, getting current frame from stack trace`
+          `[SM evaluateExpression ${sessionId}] No frameId provided; resolving the shared inspection anchor`
         );
-        const stackResponse = await session.proxyManager.sendDapRequest<DebugProtocol.StackTraceResponse>(
-          'stackTrace',
-          {
-            threadId,
-            startFrame: 0,
-            levels: 1, // We only need the first frame
-          }
-        );
-
-        if (stackResponse?.body?.stackFrames && stackResponse.body.stackFrames.length > 0) {
-          frameId = stackResponse.body.stackFrames[0].id;
+        const anchor = await this.frameAnchorResolver.resolve(sessionId);
+        if (anchor.frames.length > 0) {
+          frameId = anchor.frames[0].id;
           this.ctx.logger.info(
-            `[SM evaluateExpression ${sessionId}] Using current frame ID: ${frameId} from stack trace`
+            `[SM evaluateExpression ${sessionId}] Using shared anchor frame ID: ${frameId}`
           );
         } else {
-          this.ctx.logger.warn(`[SM evaluateExpression ${sessionId}] No stack frames available`);
+          this.ctx.logger.warn(
+            `[SM evaluateExpression ${sessionId}] No stack frame available: ${anchor.note ?? 'no detail'}`
+          );
           return {
             success: false,
-            error: 'No active stack frame. Ensure the debugger is paused at a breakpoint.',
+            error: anchor.note?.includes('No stopped thread')
+              ? 'Unable to find thread for evaluation. Ensure the debugger is paused at a breakpoint.'
+              : 'No active stack frame. Ensure the debugger is paused at a breakpoint.',
           };
         }
       } catch (error) {

--- a/src/session/inspection/frame-anchor-resolver.ts
+++ b/src/session/inspection/frame-anchor-resolver.ts
@@ -1,0 +1,273 @@
+/**
+ * Resolve the inspection anchor shared by stack, locals, and evaluation.
+ *
+ * The resolver owns thread selection, bounded stack readiness, adoption, and
+ * language-policy filtering. Callers consume the same `StackTraceResult`
+ * instead of independently asking the adapter for whichever frame happens to
+ * be current at that instant.
+ */
+import {
+  SessionState,
+  type AdapterPolicy,
+  type DebugLanguage,
+  type ILogger,
+  type StackFrame
+} from '@debugmcp/shared';
+import type { DebugProtocol } from '@vscode/debugprotocol';
+import type { IProxyManager } from '../../proxy/proxy-manager.js';
+import type { ManagedSession } from '../session-store.js';
+
+export interface StackTraceResult {
+  frames: StackFrame[];
+  /** Thread whose stack is represented by `frames` (or was queried when empty). */
+  threadId?: number;
+  totalFrameCount: number;
+  hiddenFrameCount: number;
+  allFramesInternal: boolean;
+  /** Explanation for an empty result or an adopted sibling thread. */
+  note?: string;
+}
+
+export interface FrameAnchorTunables {
+  readonly pausedStackReadyTimeoutMs: number;
+  readonly pausedStackReadyIntervalMs: number;
+}
+
+export interface FrameAnchorContext {
+  readonly logger: ILogger;
+  readonly tunables: FrameAnchorTunables;
+  getSession(sessionId: string): ManagedSession;
+  selectPolicy(language: string | DebugLanguage): AdapterPolicy;
+}
+
+export interface ResolveFrameAnchorOptions {
+  ensureStackReady?: boolean;
+}
+
+function emptyResult(note?: string, threadId?: number): StackTraceResult {
+  return {
+    frames: [],
+    totalFrameCount: 0,
+    hiddenFrameCount: 0,
+    allFramesInternal: false,
+    ...(typeof threadId === 'number' ? { threadId } : {}),
+    ...(note ? { note } : {})
+  };
+}
+
+export class FrameAnchorResolver {
+  constructor(private readonly ctx: FrameAnchorContext) {}
+
+  async resolve(
+    sessionId: string,
+    threadId?: number,
+    includeInternals = false,
+    opts?: ResolveFrameAnchorOptions
+  ): Promise<StackTraceResult> {
+    const session = this.ctx.getSession(sessionId);
+    const currentThreadId = session.proxyManager?.getCurrentThreadId();
+    this.ctx.logger.info(
+      `[FrameAnchor ${sessionId}] Requested threadId=${threadId}, currentThreadId=${currentThreadId}, state=${session.state}, includeInternals=${includeInternals}`
+    );
+
+    if (!session.proxyManager || !session.proxyManager.isRunning()) {
+      this.ctx.logger.warn(`[FrameAnchor ${sessionId}] No active proxy.`);
+      return emptyResult('No active debug process for this session.', threadId);
+    }
+    if (session.state !== SessionState.PAUSED) {
+      this.ctx.logger.warn(`[FrameAnchor ${sessionId}] Session not paused: ${session.state}.`);
+      return emptyResult(
+        `Session is not paused (state: ${session.state}); stack traces are only available while paused.`,
+        threadId
+      );
+    }
+
+    const effectiveThreadId = threadId ?? currentThreadId;
+    if (typeof effectiveThreadId !== 'number') {
+      this.ctx.logger.warn(`[FrameAnchor ${sessionId}] No effective thread ID.`);
+      return emptyResult('No stopped thread is known for this session.');
+    }
+
+    const proxyManager = session.proxyManager;
+    try {
+      let rawFrames = await this.requestRawStackFrames(sessionId, proxyManager, effectiveThreadId);
+      let note: string | undefined;
+      let resultThreadId = effectiveThreadId;
+
+      if (rawFrames.length === 0 && opts?.ensureStackReady) {
+        const ready = await this.waitForReadyStack(
+          sessionId,
+          session,
+          proxyManager,
+          effectiveThreadId
+        );
+        rawFrames = ready.frames;
+        note = ready.note;
+        resultThreadId = ready.threadId;
+      } else if (rawFrames.length === 0 && typeof threadId === 'number') {
+        note = await this.describeFramelessThread(sessionId, proxyManager, threadId);
+      }
+
+      let frames: StackFrame[] = rawFrames.map((frame) => ({
+        id: frame.id,
+        name: frame.name,
+        file: frame.source?.path || frame.source?.name || '<unknown_source>',
+        line: frame.line,
+        column: frame.column
+      }));
+      const totalFrameCount = frames.length;
+      let allFramesInternal = false;
+      const policy = this.ctx.selectPolicy(session.language);
+      if (policy.filterStackFrames) {
+        const filtered = policy.filterStackFrames(frames, includeInternals);
+        if (filtered.length === 0 && frames.length > 0) {
+          allFramesInternal = true;
+          frames = [frames[0]];
+        } else {
+          frames = filtered;
+        }
+      }
+
+      this.ctx.logger.info(
+        `[FrameAnchor ${sessionId}] Resolved ${frames.length}/${totalFrameCount} frame(s) on thread ${resultThreadId}`
+      );
+      return {
+        frames,
+        threadId: resultThreadId,
+        totalFrameCount,
+        hiddenFrameCount: totalFrameCount - frames.length,
+        allFramesInternal,
+        ...(note ? { note } : {})
+      };
+    } catch (error) {
+      this.ctx.logger.error(`[FrameAnchor ${sessionId}] Error resolving stack:`, error);
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+  }
+
+  private async requestRawStackFrames(
+    sessionId: string,
+    proxyManager: IProxyManager,
+    threadId: number
+  ): Promise<DebugProtocol.StackFrame[]> {
+    this.ctx.logger.info(`[FrameAnchor ${sessionId}] Sending DAP stackTrace for thread ${threadId}.`);
+    const response = await proxyManager.sendDapRequest<DebugProtocol.StackTraceResponse>(
+      'stackTrace',
+      { threadId }
+    );
+    if (response?.success === false) {
+      throw new Error(response.message || `DAP 'stackTrace' request failed`);
+    }
+    if (!response?.body?.stackFrames) {
+      throw new Error(`DAP 'stackTrace' response did not include stack frames`);
+    }
+    return response.body.stackFrames;
+  }
+
+  private async waitForReadyStack(
+    sessionId: string,
+    session: Pick<ManagedSession, 'state'>,
+    proxyManager: IProxyManager,
+    threadId: number
+  ): Promise<{ frames: DebugProtocol.StackFrame[]; threadId: number; note?: string }> {
+    const { pausedStackReadyTimeoutMs, pausedStackReadyIntervalMs } = this.ctx.tunables;
+    const deadline = Date.now() + pausedStackReadyTimeoutMs;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, pausedStackReadyIntervalMs));
+      if (session.state !== SessionState.PAUSED) {
+        return {
+          frames: [],
+          threadId,
+          note: 'The session left the paused state while waiting for the stack; it is no longer paused.'
+        };
+      }
+      const frames = await this.requestRawStackFrames(sessionId, proxyManager, threadId);
+      if (frames.length > 0) {
+        return { frames, threadId };
+      }
+      const scanned = await this.scanThreadsForFrames(sessionId, proxyManager, threadId);
+      if (scanned) {
+        proxyManager.setCurrentThreadId(scanned.threadId);
+        this.ctx.logger.info(
+          `[FrameAnchor ${sessionId}] Thread ${threadId} stayed frameless; adopted thread ${scanned.threadId}.`
+        );
+        return {
+          frames: scanned.frames,
+          threadId: scanned.threadId,
+          note: `The stopped thread ${threadId} reported no stack frames; switched to thread ${scanned.threadId}, which has one.`
+        };
+      }
+    }
+    this.ctx.logger.warn(
+      `[FrameAnchor ${sessionId}] Stack stayed empty for ${pausedStackReadyTimeoutMs}ms on thread ${threadId}.`
+    );
+    return {
+      frames: [],
+      threadId,
+      note: `The stopped thread reported no stack frames within ${pausedStackReadyTimeoutMs}ms; the target may be paused in native code. Try get_stack_trace with a threadId from list_threads, or continue_execution followed by pause_execution to re-anchor the session on a reportable thread.`
+    };
+  }
+
+  private async describeFramelessThread(
+    sessionId: string,
+    proxyManager: IProxyManager,
+    threadId: number
+  ): Promise<string> {
+    const threads = await this.listThreadsForScan(sessionId, proxyManager) ?? [];
+    const label = (id: number, name?: string): string => name ? `${id} (${name})` : String(id);
+    const requested = label(threadId, threads.find((thread) => thread?.id === threadId)?.name);
+    const alternative = await this.scanThreadsForFrames(sessionId, proxyManager, threadId, threads);
+    if (alternative) {
+      return (
+        `Thread ${requested} reported no stack frames; thread ${label(alternative.threadId, alternative.threadName)} has frames. ` +
+        `Try get_stack_trace with threadId ${alternative.threadId}.`
+      );
+    }
+    return (
+      `Thread ${requested} reported no stack frames (it may be a native/runtime thread, or its stack may not have materialized yet). ` +
+      'Retry, or try get_stack_trace with another threadId from list_threads.'
+    );
+  }
+
+  private async listThreadsForScan(
+    sessionId: string,
+    proxyManager: IProxyManager
+  ): Promise<DebugProtocol.Thread[] | null> {
+    try {
+      const response = await proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {});
+      const threads = response?.body?.threads;
+      return Array.isArray(threads) ? threads : null;
+    } catch (error) {
+      this.ctx.logger.warn(
+        `[FrameAnchor ${sessionId}] Could not list threads: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return null;
+    }
+  }
+
+  private async scanThreadsForFrames(
+    sessionId: string,
+    proxyManager: IProxyManager,
+    excludeThreadId: number,
+    threads?: DebugProtocol.Thread[]
+  ): Promise<{
+    threadId: number;
+    threadName?: string;
+    frames: DebugProtocol.StackFrame[];
+  } | null> {
+    const candidates = threads ?? await this.listThreadsForScan(sessionId, proxyManager);
+    if (!candidates) return null;
+    for (const thread of candidates) {
+      if (!thread || typeof thread.id !== 'number' || thread.id === excludeThreadId) continue;
+      try {
+        const frames = await this.requestRawStackFrames(sessionId, proxyManager, thread.id);
+        if (frames.length > 0) {
+          return { threadId: thread.id, threadName: thread.name, frames };
+        }
+      } catch {
+        // Runtime threads may reject stackTrace; keep probing siblings.
+      }
+    }
+    return null;
+  }
+}

--- a/src/session/session-manager-data.ts
+++ b/src/session/session-manager-data.ts
@@ -15,7 +15,6 @@ import {
   extractionFromScope
 } from '@debugmcp/shared';
 import { SessionManagerCore } from './session-manager-core.js';
-import { IProxyManager } from '../proxy/proxy-manager.js';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import {
   applyVariableCaps,
@@ -23,39 +22,18 @@ import {
   maxVariablesPerCall,
   VariableTruncationSummary
 } from './variable-caps.js';
+import {
+  FrameAnchorResolver,
+  type StackTraceResult
+} from './inspection/frame-anchor-resolver.js';
+
+export type { StackTraceResult } from './inspection/frame-anchor-resolver.js';
 
 /**
  * Stack trace frames plus filtering metadata (issue #346): how many frames the
  * adapter reported, how many the language policy hid, and whether the
  * kept-first-frame fallback fired because every frame was internal.
  */
-export interface StackTraceResult {
-  frames: StackFrame[];
-  /** Thread whose stack is represented by `frames` (or was queried when empty). */
-  threadId?: number;
-  totalFrameCount: number;
-  hiddenFrameCount: number;
-  allFramesInternal: boolean;
-  /**
-   * Present when the result needs explaining: the session was not paused, no
-   * stopped thread was known, the stack came from a different thread than the
-   * tracked one, or every thread stayed frameless. Surfaced to the agent in
-   * the get_stack_trace tool payload.
-   */
-  note?: string;
-}
-
-function emptyStackTraceResult(note?: string, threadId?: number): StackTraceResult {
-  return {
-    frames: [],
-    totalFrameCount: 0,
-    hiddenFrameCount: 0,
-    allFramesInternal: false,
-    ...(typeof threadId === 'number' ? { threadId } : {}),
-    ...(note ? { note } : {})
-  };
-}
-
 /**
  * Data retrieval functionality for session management
  */
@@ -72,6 +50,20 @@ export abstract class SessionManagerData extends SessionManagerCore {
    */
   protected pausedStackReadyTimeoutMs = 3000;
   protected pausedStackReadyIntervalMs = 250;
+
+  /** One anchor contract shared by stack, locals, and expression evaluation. */
+  protected readonly frameAnchorResolver = (() => {
+    const facade = () => this;
+    return new FrameAnchorResolver({
+      get logger() { return facade().logger; },
+      tunables: {
+        get pausedStackReadyTimeoutMs() { return facade().pausedStackReadyTimeoutMs; },
+        get pausedStackReadyIntervalMs() { return facade().pausedStackReadyIntervalMs; }
+      },
+      getSession: (sessionId) => this._getSessionById(sessionId),
+      selectPolicy: (language) => this.selectPolicy(language)
+    });
+  })();
 
   /**
    * Selects the appropriate adapter policy based on language
@@ -187,7 +179,7 @@ export abstract class SessionManagerData extends SessionManagerCore {
   }
 
   async getStackTrace(sessionId: string, threadId?: number, includeInternals: boolean = false): Promise<StackFrame[]> {
-    return (await this.getStackTraceDetailed(sessionId, threadId, includeInternals)).frames;
+    return (await this.frameAnchorResolver.resolve(sessionId, threadId, includeInternals)).frames;
   }
 
   /**
@@ -210,231 +202,7 @@ export abstract class SessionManagerData extends SessionManagerCore {
     includeInternals: boolean = false,
     opts?: { ensureStackReady?: boolean }
   ): Promise<StackTraceResult> {
-    const session = this._getSessionById(sessionId);
-    const currentThreadId = session.proxyManager?.getCurrentThreadId();
-    this.logger.info(`[SM getStackTrace ${sessionId}] Entered. Requested threadId: ${threadId}, Current state: ${session.state}, Actual currentThreadId: ${currentThreadId}, includeInternals: ${includeInternals}`);
-
-    if (!session.proxyManager || !session.proxyManager.isRunning()) {
-      this.logger.warn(`[SM getStackTrace ${sessionId}] No active proxy.`);
-      return emptyStackTraceResult('No active debug process for this session.', threadId);
-    }
-    if (session.state !== SessionState.PAUSED) {
-      this.logger.warn(`[SM getStackTrace ${sessionId}] Session not paused. State: ${session.state}.`);
-      return emptyStackTraceResult(`Session is not paused (state: ${session.state}); stack traces are only available while paused.`, threadId);
-    }
-
-    const currentThreadForRequest = threadId ?? currentThreadId;
-    if (typeof currentThreadForRequest !== 'number') {
-      this.logger.warn(`[SM getStackTrace ${sessionId}] No effective thread ID to use.`);
-      return emptyStackTraceResult('No stopped thread is known for this session.');
-    }
-
-    const proxyManager = session.proxyManager;
-    try {
-      let rawFrames = await this.requestRawStackFrames(sessionId, proxyManager, currentThreadForRequest);
-      let note: string | undefined;
-      let resultThreadId = currentThreadForRequest;
-
-      // A PAUSED session answering with zero frames is nearly always a
-      // transient adapter race (netcoredbg materializes the managed stack a
-      // beat after the stop event) or a frameless runtime thread being
-      // tracked as current. On the agent-facing path, chase the real stack
-      // instead of handing back a confusing empty success.
-      if (rawFrames.length === 0 && opts?.ensureStackReady) {
-        const ready = await this.waitForReadyStack(sessionId, session, proxyManager, currentThreadForRequest);
-        rawFrames = ready.frames;
-        note = ready.note;
-        resultThreadId = ready.threadId;
-      } else if (rawFrames.length === 0 && typeof threadId === 'number') {
-        // An explicit thread request must remain anchored to that thread, but
-        // a silent empty success is not actionable. Inspect other threads only
-        // to offer a concrete alternative; never adopt it here (issue #553).
-        note = await this.describeFramelessThread(sessionId, proxyManager, threadId);
-      }
-
-      let frames: StackFrame[] = rawFrames.map((sf: DebugProtocol.StackFrame) => ({
-          id: sf.id, name: sf.name,
-          file: sf.source?.path || sf.source?.name || "<unknown_source>",
-          line: sf.line, column: sf.column
-      }));
-
-      // Apply filtering using the language's policy
-      const totalFrameCount = frames.length;
-      let allFramesInternal = false;
-      const policy = this.selectPolicy(session.language);
-      if (policy.filterStackFrames) {
-        this.logger.info(`[SM getStackTrace ${sessionId}] Applying stack frame filtering for ${session.language}. Original count: ${frames.length}`);
-        const filtered = policy.filterStackFrames(frames, includeInternals);
-        // Central guarantee (issue #346): a policy filter must never leave the
-        // agent with zero frames when the adapter reported some — keep the top
-        // unfiltered frame so scopes/evaluate still have an anchor.
-        if (filtered.length === 0 && frames.length > 0) {
-          allFramesInternal = true;
-          frames = [frames[0]];
-        } else {
-          frames = filtered;
-        }
-        this.logger.info(`[SM getStackTrace ${sessionId}] After filtering: ${frames.length} frames (hidden: ${totalFrameCount - frames.length}, allFramesInternal: ${allFramesInternal})`);
-      }
-
-      this.logger.info(`[SM getStackTrace ${sessionId}] Parsed stack frames (top 3):`, frames.slice(0,3).map(f => ({name:f.name, file:f.file, line:f.line})));
-      return {
-        frames,
-        threadId: resultThreadId,
-        totalFrameCount,
-        hiddenFrameCount: totalFrameCount - frames.length,
-        allFramesInternal,
-        ...(note ? { note } : {})
-      };
-    } catch (error) {
-      this.logger.error(`[SM getStackTrace ${sessionId}] Error getting stack trace:`, error);
-      throw error instanceof Error ? error : new Error(String(error));
-    }
-  }
-
-  /**
-   * Send one DAP stackTrace request and return the raw frames. A failed DAP
-   * response (e.g. "Child session not ready ...") must not be flattened into
-   * an empty-but-successful stack trace (issue #124): propagate the failure.
-   */
-  private async requestRawStackFrames(
-    sessionId: string,
-    proxyManager: IProxyManager,
-    threadId: number
-  ): Promise<DebugProtocol.StackFrame[]> {
-    this.logger.info(`[SM getStackTrace ${sessionId}] Sending DAP 'stackTrace' for threadId ${threadId}.`);
-    const response = await proxyManager.sendDapRequest<DebugProtocol.StackTraceResponse>('stackTrace', { threadId });
-    this.logger.info(`[SM getStackTrace ${sessionId}] DAP 'stackTrace' response received. Body:`, response?.body);
-
-    if (response?.success === false) {
-      throw new Error(response.message || `DAP 'stackTrace' request failed`);
-    }
-    if (!response || !response.body || !response.body.stackFrames) {
-      this.logger.warn(`[SM getStackTrace ${sessionId}] No stackFrames in response body. Response:`, response);
-      throw new Error(`DAP 'stackTrace' response did not include stack frames`);
-    }
-    return response.body.stackFrames;
-  }
-
-  /**
-   * Bounded readiness loop for a PAUSED session whose stackTrace succeeded
-   * with zero frames: re-poll the same thread (the stack may not be
-   * materialized yet), and each round also scan the other stopped threads —
-   * the tracked thread may be a frameless runtime thread (finalizer, JIT)
-   * while the real stack lives elsewhere. A frame-bearing thread found by the
-   * scan is adopted as current so scopes/evaluate anchor to it. If nothing
-   * reports frames within the window, return the honest empty answer with a
-   * note telling the agent what to try instead.
-   */
-  private async waitForReadyStack(
-    sessionId: string,
-    session: { state: SessionState },
-    proxyManager: IProxyManager,
-    threadId: number
-  ): Promise<{ frames: DebugProtocol.StackFrame[]; threadId: number; note?: string }> {
-    const deadline = Date.now() + this.pausedStackReadyTimeoutMs;
-    while (Date.now() < deadline) {
-      await new Promise(resolve => setTimeout(resolve, this.pausedStackReadyIntervalMs));
-      if (session.state !== SessionState.PAUSED) {
-        return { frames: [], threadId, note: 'The session left the paused state while waiting for the stack; it is no longer paused.' };
-      }
-      const frames = await this.requestRawStackFrames(sessionId, proxyManager, threadId);
-      if (frames.length > 0) {
-        return { frames, threadId };
-      }
-      const scanned = await this.scanThreadsForFrames(sessionId, proxyManager, threadId);
-      if (scanned) {
-        proxyManager.setCurrentThreadId(scanned.threadId);
-        this.logger.info(`[SM getStackTrace ${sessionId}] Thread ${threadId} stayed frameless; adopted thread ${scanned.threadId} which has a stack.`);
-        return {
-          frames: scanned.frames,
-          threadId: scanned.threadId,
-          note: `The stopped thread ${threadId} reported no stack frames; switched to thread ${scanned.threadId}, which has one.`
-        };
-      }
-    }
-    this.logger.warn(`[SM getStackTrace ${sessionId}] Stack stayed empty for ${this.pausedStackReadyTimeoutMs}ms while paused (threadId ${threadId}).`);
-    return {
-      frames: [],
-      threadId,
-      note: `The stopped thread reported no stack frames within ${this.pausedStackReadyTimeoutMs}ms; the target may be paused in native code. Try get_stack_trace with a threadId from list_threads, or continue_execution followed by pause_execution to re-anchor the session on a reportable thread.`
-    };
-  }
-
-  /**
-   * Explain an explicitly requested thread that reported no frames (issue
-   * #553): name it, and point at a frame-bearing sibling when one exists.
-   * Only describes — never adopts — so the caller's thread stays the anchor.
-   */
-  private async describeFramelessThread(
-    sessionId: string,
-    proxyManager: IProxyManager,
-    threadId: number
-  ): Promise<string> {
-    const threads = await this.listThreadsForScan(sessionId, proxyManager) ?? [];
-    const label = (id: number, name?: string): string => (name ? `${id} (${name})` : String(id));
-    const requestedLabel = label(threadId, threads.find(thread => thread?.id === threadId)?.name);
-
-    const alternative = await this.scanThreadsForFrames(sessionId, proxyManager, threadId, threads);
-    if (alternative) {
-      return (
-        `Thread ${requestedLabel} reported no stack frames; thread ${label(alternative.threadId, alternative.threadName)} has frames. ` +
-        `Try get_stack_trace with threadId ${alternative.threadId}.`
-      );
-    }
-    // Don't assert a cause: a native/runtime thread and the transient
-    // stack-not-materialized race right after a stop give the same answer.
-    return (
-      `Thread ${requestedLabel} reported no stack frames (it may be a native/runtime thread, or its stack may not have materialized yet). ` +
-      'Retry, or try get_stack_trace with another threadId from list_threads.'
-    );
-  }
-
-  /** One DAP `threads` request; null when the adapter rejects it. */
-  private async listThreadsForScan(
-    sessionId: string,
-    proxyManager: IProxyManager
-  ): Promise<DebugProtocol.Thread[] | null> {
-    try {
-      const response = await proxyManager.sendDapRequest<DebugProtocol.ThreadsResponse>('threads', {});
-      const threads = response?.body?.threads;
-      return Array.isArray(threads) ? threads : null;
-    } catch (err) {
-      this.logger.warn(`[SM getStackTrace ${sessionId}] Thread scan could not list threads: ${err instanceof Error ? err.message : String(err)}`);
-      return null;
-    }
-  }
-
-  /**
-   * Probe the other stopped threads for one that reports stack frames.
-   * Probe failures on individual threads are not fatal — runtime threads may
-   * reject stackTrace outright. Pass `threads` to reuse an already-fetched
-   * thread list instead of issuing a second `threads` request.
-   */
-  private async scanThreadsForFrames(
-    sessionId: string,
-    proxyManager: IProxyManager,
-    excludeThreadId: number,
-    threads?: DebugProtocol.Thread[]
-  ): Promise<{ threadId: number; threadName?: string; frames: DebugProtocol.StackFrame[] } | null> {
-    const candidates = threads ?? await this.listThreadsForScan(sessionId, proxyManager);
-    if (!candidates) {
-      return null;
-    }
-    for (const thread of candidates) {
-      if (!thread || typeof thread.id !== 'number' || thread.id === excludeThreadId) {
-        continue;
-      }
-      try {
-        const frames = await this.requestRawStackFrames(sessionId, proxyManager, thread.id);
-        if (frames.length > 0) {
-          return { threadId: thread.id, threadName: thread.name, frames };
-        }
-      } catch {
-        // This thread rejected stackTrace — keep scanning.
-      }
-    }
-    return null;
+    return this.frameAnchorResolver.resolve(sessionId, threadId, includeInternals, opts);
   }
 
   async getScopes(sessionId: string, frameId: number): Promise<DebugProtocol.Scope[]> {

--- a/src/session/session-manager-operations.ts
+++ b/src/session/session-manager-operations.ts
@@ -165,7 +165,7 @@ export abstract class SessionManagerOperations extends SessionManagerData {
   protected readonly breakpoints = new BreakpointController(this.opsContext);
   protected readonly pauseCoordinator = new PauseCoordinator(this.opsContext);
   protected readonly execution = new ExecutionController(this.opsContext, this.pauseCoordinator);
-  protected readonly evaluator = new ExpressionEvaluator(this.opsContext);
+  protected readonly evaluator = new ExpressionEvaluator(this.opsContext, this.frameAnchorResolver);
   protected readonly hotSwap = new RedefineClassesController(this.opsContext, this.breakpoints);
   protected readonly mirror = new MirrorController(this.opsContext);
   protected readonly proxyLauncher = new ProxyLauncher(this.opsContext);

--- a/tests/core/unit/session/session-manager-edge-cases.test.ts
+++ b/tests/core/unit/session/session-manager-edge-cases.test.ts
@@ -154,7 +154,7 @@ describe('SessionManager - Edge Cases and Error Scenarios', () => {
       // stack trace (issue #124).
       await expect(sessionManager.getStackTrace(session.id)).rejects.toThrow('Timeout');
       expect(dependencies.mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Error getting stack trace'),
+        expect.stringContaining('Error resolving stack'),
         expect.any(Error)
       );
     });
@@ -197,9 +197,9 @@ describe('SessionManager - Edge Cases and Error Scenarios', () => {
       dependencies.mockProxyManager.sendDapRequest = vi.fn().mockResolvedValue({ body: null });
 
       await expect(sessionManager.getStackTrace(session.id)).rejects.toThrow('did not include stack frames');
-      expect(dependencies.mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('No stackFrames in response body'),
-        expect.any(Object)
+      expect(dependencies.mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error resolving stack'),
+        expect.any(Error)
       );
     });
 
@@ -241,7 +241,7 @@ describe('SessionManager - Edge Cases and Error Scenarios', () => {
       const stackFrames = await sessionManager.getStackTrace(session.id);
       expect(stackFrames).toEqual([]);
       expect(dependencies.mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('No effective thread ID to use')
+        expect.stringContaining('No effective thread ID')
       );
     });
 

--- a/tests/core/unit/session/session-manager-evaluate.test.ts
+++ b/tests/core/unit/session/session-manager-evaluate.test.ts
@@ -89,6 +89,25 @@ describe('SessionManager.evaluateExpression default-frame resolution', () => {
     expect(evaluateArgs[0]).toMatchObject({ frameId: 99 });
   });
 
+  it('treats an explicit frameId as authoritative without resolving a stack', async () => {
+    const { sessionManager, dependencies } = makeManager();
+    const session = await createRunningSession(sessionManager, dependencies);
+    const commands: string[] = [];
+    dependencies.mockProxyManager.setDapRequestHandler(async (command: string, args?: unknown) => {
+      commands.push(command);
+      if (command === 'evaluate') {
+        expect(args).toMatchObject({ expression: 'value', frameId: 314 });
+        return { body: { result: 'ok', type: 'string', variablesReference: 0 } };
+      }
+      return { success: true, body: {} };
+    });
+
+    const result = await sessionManager.evaluateExpression(session.id, 'value', 314);
+
+    expect(result.success).toBe(true);
+    expect(commands).toEqual(['evaluate']);
+  });
+
   it('fails cleanly when the paused thread reports no stack frames', async () => {
     const { sessionManager, dependencies } = makeManager();
     const session = await createRunningSession(sessionManager, dependencies);


### PR DESCRIPTION
Closes #594. Extracts and injects one frame-anchor resolver across stack, locals, and expression evaluation. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.