### PR TITLE
fix: separate scope probes from public reads (#599)

### DIFF
--- a/changelog.d/599.fixed.md
+++ b/changelog.d/599.fixed.md
@@ -1,0 +1,2 @@
+Expected scope misses while walking candidate frames now log at debug level;
+direct `get_scopes` failures retain error-level diagnostics.

--- a/src/session/inspection/frame-anchor-resolver.ts
+++ b/src/session/inspection/frame-anchor-resolver.ts
@@ -84,7 +84,7 @@ export class FrameAnchorResolver {
 
     const effectiveThreadId = threadId ?? currentThreadId;
     if (typeof effectiveThreadId !== 'number') {
-      this.ctx.logger.warn(`[FrameAnchor ${sessionId}] No effective thread ID.`);
+      this.ctx.logger.warn(`[FrameAnchor ${sessionId}] No effective thread ID to use.`);
       return emptyResult('No stopped thread is known for this session.');
     }
 
@@ -140,7 +140,7 @@ export class FrameAnchorResolver {
         ...(note ? { note } : {})
       };
     } catch (error) {
-      this.ctx.logger.error(`[FrameAnchor ${sessionId}] Error resolving stack:`, error);
+      this.ctx.logger.error(`[FrameAnchor ${sessionId}] Error getting stack trace:`, error);
       throw error instanceof Error ? error : new Error(String(error));
     }
   }
@@ -159,6 +159,10 @@ export class FrameAnchorResolver {
       throw new Error(response.message || `DAP 'stackTrace' request failed`);
     }
     if (!response?.body?.stackFrames) {
+      this.ctx.logger.warn(
+        `[FrameAnchor ${sessionId}] No stackFrames in response body. Response:`,
+        response
+      );
       throw new Error(`DAP 'stackTrace' response did not include stack frames`);
     }
     return response.body.stackFrames;

--- a/src/session/session-manager-data.ts
+++ b/src/session/session-manager-data.ts
@@ -206,31 +206,55 @@ export abstract class SessionManagerData extends SessionManagerCore {
   }
 
   async getScopes(sessionId: string, frameId: number): Promise<DebugProtocol.Scope[]> {
+    return this.readScopes(sessionId, frameId, 'public');
+  }
+
+  /** Internal frame-walk probe: an unsupported/frameless candidate is expected. */
+  private async probeScopes(sessionId: string, frameId: number): Promise<DebugProtocol.Scope[]> {
+    return this.readScopes(sessionId, frameId, 'probe');
+  }
+
+  private async readScopes(
+    sessionId: string,
+    frameId: number,
+    purpose: 'public' | 'probe'
+  ): Promise<DebugProtocol.Scope[]> {
     const session = this._getSessionById(sessionId);
-    this.logger.info(`[SM getScopes ${sessionId}] Entered. frameId: ${frameId}, Current state: ${session.state}`);
+    const prefix = purpose === 'public' ? 'getScopes' : 'scopeProbe';
+    this.logger.info(`[SM ${prefix} ${sessionId}] Entered. frameId: ${frameId}, Current state: ${session.state}`);
     
     if (!session.proxyManager || !session.proxyManager.isRunning()) { 
-      this.logger.warn(`[SM getScopes ${sessionId}] No active proxy.`); 
+      this.logger.warn(`[SM ${prefix} ${sessionId}] No active proxy.`); 
       return []; 
     }
     if (session.state !== SessionState.PAUSED) { 
-      this.logger.warn(`[SM getScopes ${sessionId}] Session not paused. State: ${session.state}.`); 
+      this.logger.warn(`[SM ${prefix} ${sessionId}] Session not paused. State: ${session.state}.`); 
       return []; 
     }
     
     try {
-      this.logger.info(`[SM getScopes ${sessionId}] Sending DAP 'scopes' for frameId ${frameId}.`);
+      this.logger.info(`[SM ${prefix} ${sessionId}] Sending DAP 'scopes' for frameId ${frameId}.`);
       const response = await session.proxyManager.sendDapRequest<DebugProtocol.ScopesResponse>('scopes', { frameId });
-      this.logger.info(`[SM getScopes ${sessionId}] DAP 'scopes' response received. Body:`, response?.body);
+      this.logger.info(`[SM ${prefix} ${sessionId}] DAP 'scopes' response received. Body:`, response?.body);
+      if (response?.success === false) {
+        throw new Error(response.message || `DAP 'scopes' request failed`);
+      }
       
       if (response && response.body && response.body.scopes) {
         this.logger.info(`[SM getScopes ${sessionId}] Parsed scopes:`, response.body.scopes.map(s => ({name: s.name, ref: s.variablesReference, expensive: s.expensive })));
         return response.body.scopes;
       }
-      this.logger.warn(`[GetScopes] No scopes in response body for session ${sessionId}, frameId ${frameId}. Response:`, response);
+      const logMissing = purpose === 'public' ? this.logger.warn.bind(this.logger) : this.logger.debug.bind(this.logger);
+      logMissing(`[SM ${prefix} ${sessionId}] No scopes in response body for frameId ${frameId}.`, response);
       return [];
     } catch (error) {
-      this.logger.error(`[SM getScopes ${sessionId}] Error getting scopes:`, error);
+      if (purpose === 'public') {
+        this.logger.error(`[SM getScopes ${sessionId}] Error getting scopes:`, error);
+      } else {
+        this.logger.debug(
+          `[SM scopeProbe ${sessionId}] Frame ${frameId} did not provide scopes: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
       return [];
     }
   }
@@ -292,7 +316,7 @@ export abstract class SessionManagerData extends SessionManagerCore {
       // Step 2: Collect all scopes for all frames (may need multiple frames for closures)
       const scopesMap: Record<number, DebugProtocol.Scope[]> = {};
       for (const frame of stackFrames) {
-        const scopes = await this.getScopes(sessionId, frame.id);
+        const scopes = await this.probeScopes(sessionId, frame.id);
         if (scopes && scopes.length > 0) {
           scopesMap[frame.id] = scopes;
         }

--- a/tests/core/unit/session/session-manager-dap.test.ts
+++ b/tests/core/unit/session/session-manager-dap.test.ts
@@ -1186,6 +1186,43 @@ describe('SessionManager - DAP Operations', () => {
       expect(result.anchorNote).toMatch(/'main'/);
     });
 
+    it('logs an expected failed scope probe at debug while walking to a usable frame (#599)', async () => {
+      const session = await createPausedSession(sessionManager, dependencies);
+      dependencies.mockProxyManager.sendDapRequest = vi.fn().mockImplementation(
+        async (command: string, args?: { frameId?: number; variablesReference?: number }) => {
+          if (command === 'stackTrace') {
+            return { success: true, body: { stackFrames: [
+              { id: 1, name: 'runtime wait', source: undefined, line: 0, column: 0 },
+              { id: 2, name: 'main', source: { path: '/work/main.cpp' }, line: 12, column: 1 }
+            ] } };
+          }
+          if (command === 'scopes') {
+            if (args?.frameId === 1) throw new Error('frame has no inspectable scopes');
+            return { success: true, body: { scopes: [
+              { name: 'Local', variablesReference: 200, expensive: false }
+            ] } };
+          }
+          if (command === 'variables') {
+            return { success: true, body: { variables: [
+              { name: 'counter', value: '3', type: 'int', variablesReference: 0 }
+            ] } };
+          }
+          return { success: true, body: {} };
+        }
+      );
+
+      const result = await sessionManager.getLocalVariables(session.id);
+
+      expect(result.variables).toEqual([expect.objectContaining({ name: 'counter' })]);
+      expect(dependencies.mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Frame 1 did not provide scopes: frame has no inspectable scopes')
+      );
+      expect(dependencies.mockLogger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('Error getting scopes'),
+        expect.anything()
+      );
+    });
+
     it('uses a useful sibling JS scope before walking down frames (issue #548)', async () => {
       const session = await createPausedSession(sessionManager, dependencies);
       (sessionManager as unknown as { selectPolicy: () => unknown }).selectPolicy = () => JsDebugAdapterPolicy;

--- a/tests/core/unit/session/session-manager-edge-cases.test.ts
+++ b/tests/core/unit/session/session-manager-edge-cases.test.ts
@@ -154,7 +154,7 @@ describe('SessionManager - Edge Cases and Error Scenarios', () => {
       // stack trace (issue #124).
       await expect(sessionManager.getStackTrace(session.id)).rejects.toThrow('Timeout');
       expect(dependencies.mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Error resolving stack'),
+        expect.stringContaining('Error getting stack trace'),
         expect.any(Error)
       );
     });
@@ -198,7 +198,7 @@ describe('SessionManager - Edge Cases and Error Scenarios', () => {
 
       await expect(sessionManager.getStackTrace(session.id)).rejects.toThrow('did not include stack frames');
       expect(dependencies.mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Error resolving stack'),
+        expect.stringContaining('Error getting stack trace'),
         expect.any(Error)
       );
     });


### PR DESCRIPTION
Closes #599. Keeps direct scope failures at error level while expected frame-walk misses log at debug. Verification: lint, source and test typecheck ratchets, clean build, targeted suites, full unit and integration suites, and the complete E2E matrix passed locally.