### PR TITLE
fix(ci): gate the root manifest, and judge every manifest by what it ships (#630)

### DIFF
--- a/changelog.d/629.fixed.md
+++ b/changelog.d/629.fixed.md
@@ -5,8 +5,8 @@ user-visible and failed `Lint Code`. #625 (`@types/node`, `eslint`, `typescript-
 11 manifests) had to be merged under a hand-applied `no-changelog` label, and the same would
 have happened on every weekly batch — training everyone to reach for the label reflexively,
 which is what makes a gate stop meaning anything. The gate now reads each changed
-`package.json` on both sides of the diff and exempts it only when nothing outside
-`devDependencies` moved; a `dependencies`, `peerDependencies`, `bin`, `exports` or `version`
-change still requires an entry, and the failure message names the keys that moved so the
-verdict is checkable. Every uncertain case — an added or deleted manifest, unparseable JSON,
+`package.json` on both sides of the diff and exempts it unless a key describing what ships
+moved; a `dependencies`, `optionalDependencies`, `peerDependencies`, `bin`, `exports` or
+`engines` change still requires an entry, and the failure message names the keys that moved so
+the verdict is checkable. Every uncertain case — an added or deleted manifest, unparseable JSON,
 or revisions the gate cannot resolve — still requires a fragment (#629)

--- a/changelog.d/630.changed.md
+++ b/changelog.d/630.changed.md
@@ -1,0 +1,15 @@
+**The changelog gate now covers the root `package.json`, and judges every manifest by what it
+ships** — the gate picked its candidates by path prefix (`src/`, `packages/`, `tools/`), and the
+root manifest starts with none of them, so it was never examined at all. Its `dependencies` and
+`optionalDependencies` are exactly what `dist/index.js` and the Docker image run: registering the
+C/C++ adapter in `optionalDependencies` shipped a whole language and the gate said nothing. The
+root manifest is now a gated path, and every manifest — root and package alike — is judged
+against one list of shipping-surface keys (`dependencies`, `optionalDependencies`,
+`peerDependencies`, `bin`, `main`, `exports`, `files`, `engines`, `type`) rather than the
+"anything but `devDependencies`" rule of #629. That rule could not be reused as-is: the root
+manifest carries 104 npm scripts, and over 130 root-manifest commits it would have demanded a
+fragment for 115 of them versus 40 under the allowlist. `version` and `scripts` no longer gate
+anywhere — a release PR bumps `version` across every manifest, and the changelog entry for a
+release is the collated section itself, so requiring a fragment for the bump that cuts the
+release was circular. `pnpm-lock.yaml` is deliberately still not gated: every dependency PR
+touches it, devDependency-only ones included, so gating on it would undo #629 (#630)

--- a/scripts/changelog-fragments.mjs
+++ b/scripts/changelog-fragments.mjs
@@ -55,6 +55,37 @@ export const SKIP_LABEL = 'no-changelog';
 const USER_VISIBLE_ROOTS = ['src/', 'packages/', 'tools/'];
 
 /**
+ * Root-level files that are user-visible despite not sitting under one of those roots.
+ *
+ * The root manifest is `private: true`, but its `dependencies` and `optionalDependencies` are
+ * exactly what `dist/index.js` and the Docker image run — registering the C/C++ adapter in
+ * `optionalDependencies` (78912fc8) shipped a whole language and the gate said nothing (#630).
+ *
+ * `pnpm-lock.yaml` is deliberately NOT here, and it is not an oversight: every dependency PR
+ * touches the lockfile, devDependency-only ones included, so gating on it would undo #629 the
+ * day after it landed. It also has no top-level keys to classify. The accepted cost is that a
+ * purely transitive change — a `pnpm.overrides` pin — goes ungated.
+ */
+const USER_VISIBLE_FILES = ['package.json'];
+
+/**
+ * Manifest keys that describe what a consumer receives. Everything else in a `package.json` is
+ * plumbing: `scripts`, `devDependencies`, `packageManager`, `workspaces`, `pnpm`.
+ *
+ * An allowlist rather than "everything but devDependencies" (#629's rule) because the root
+ * manifest carries 104 npm scripts: measured over 130 root-manifest commits, the deny-rule
+ * demands a fragment for 115 of them and this allowlist for 40 (#630).
+ *
+ * `version` is absent on purpose. A release PR bumps it across every manifest, and the
+ * changelog entry for a release is the collated section itself — requiring a *fragment* for
+ * the bump that cuts the release would be circular.
+ */
+export const SHIPPING_SURFACE_KEYS = [
+  'dependencies', 'optionalDependencies', 'peerDependencies',
+  'bin', 'main', 'exports', 'files', 'engines', 'type'
+];
+
+/**
  * Tests live inside `packages/`, so a package's test-only change would
  * otherwise trip the gate. Test churn is not user-visible.
  */
@@ -63,41 +94,27 @@ function isTestPath(file) {
 }
 
 /**
- * Which top-level manifest keys moved between two `package.json` texts, ignoring
- * `devDependencies`?
+ * Which shipping-surface keys moved between two `package.json` texts?
+ *
+ * This is the whole judgement the gate makes about a manifest: it asks what actually moved
+ * rather than trusting the file's path, so toolchain churn (a linter, a types package, a test
+ * runner) stays silent while a change to what ships does not.
  *
  * Compared with `isDeepStrictEqual` rather than by string, so a manifest whose keys a tool
  * happened to reorder does not read as a change.
  *
  * @param {string} baseText `package.json` before the change
  * @param {string} headText `package.json` after the change
- * @returns {string[]} names of the changed keys, `devDependencies` excluded; empty if none
+ * @returns {string[]} the {@link SHIPPING_SURFACE_KEYS} that differ; empty if none
  * @throws {SyntaxError} when either side is not valid JSON
  */
-export function changedManifestKeys(baseText, headText) {
+export function changedShippingKeys(baseText, headText) {
   const base = JSON.parse(baseText);
   const head = JSON.parse(headText);
-  const keys = new Set([...Object.keys(base), ...Object.keys(head)]);
-  keys.delete('devDependencies');
 
-  return [...keys].filter(key => !isDeepStrictEqual(base[key], head[key])).sort();
-}
-
-/**
- * Did this manifest change move nothing but `devDependencies`?
- *
- * Such a change is toolchain churn — a linter, a types package, a test runner — and is not
- * something a consumer of the published package can observe. Everything else in the file
- * (`dependencies`, `peerDependencies`, `bin`, `exports`, `engines`, `version`) still counts,
- * which is why this asks what actually moved rather than trusting the file's path (#629).
- *
- * @param {string} baseText `package.json` before the change
- * @param {string} headText `package.json` after the change
- * @returns {boolean}
- * @throws {SyntaxError} when either side is not valid JSON
- */
-export function isDevDependencyOnlyChange(baseText, headText) {
-  return changedManifestKeys(baseText, headText).length === 0;
+  return SHIPPING_SURFACE_KEYS
+    .filter(key => !isDeepStrictEqual(base[key], head[key]))
+    .sort();
 }
 
 /**
@@ -124,9 +141,9 @@ function manifestVerdict(file, resolveManifest) {
   if (!pair) return null;
 
   try {
-    return changedManifestKeys(pair.base, pair.head);
+    return changedShippingKeys(pair.base, pair.head);
   } catch {
-    return null;  // unparseable JSON — cannot prove this was only devDependencies
+    return null;  // unparseable JSON — cannot prove nothing shipped changed
   }
 }
 
@@ -141,8 +158,9 @@ function describeOffender(file, movedKeys) {
  *
  * `resolveManifest` is injected rather than read from git in here so the classification stays
  * pure and testable, the way `isSameEntry` in ./lib/is-main.mjs takes its path resolver.
- * Omit it and the gate behaves exactly as it did before #629: every non-test path under a
- * user-visible root is an offender.
+ * Omit it and the gate falls back to path-only classification: every non-test path under a
+ * user-visible root, plus the root manifest, is an offender. That is the strict direction, so
+ * the fallback can only ever over-report.
  *
  * @param {string[]} changedFiles repo-relative paths changed by the PR
  * @param {string[]} labels PR label names
@@ -152,11 +170,13 @@ function describeOffender(file, movedKeys) {
  */
 export function requiresFragment(changedFiles, labels = [], resolveManifest = null) {
   const candidates = changedFiles.filter(
-    file => USER_VISIBLE_ROOTS.some(root => file.startsWith(root)) && !isTestPath(file)
+    file =>
+      (USER_VISIBLE_ROOTS.some(root => file.startsWith(root)) || USER_VISIBLE_FILES.includes(file))
+      && !isTestPath(file)
   );
 
-  // A manifest whose diff moved only devDependencies is toolchain churn, not a user-visible
-  // change (#629). Remember what did move, so the failure message can say why one was kept.
+  // A manifest that moved no shipping-surface key is toolchain churn, not a user-visible
+  // change (#629, #630). Remember what did move, so the message can say why one was kept.
   const movedKeys = new Map();
   const offenders = candidates.filter(file => {
     const changed = manifestVerdict(file, resolveManifest);
@@ -170,8 +190,8 @@ export function requiresFragment(changedFiles, labels = [], resolveManifest = nu
     return {
       required: false,
       reason: candidates.length === 0
-        ? 'No changes under src/, packages/, or tools/.'
-        : 'Only devDependencies moved in the changed manifests.',
+        ? 'No changes under src/, packages/, or tools/, or to the root manifest.'
+        : 'The changed manifests moved no shipping-surface key.',
       offenders
     };
   }

--- a/tests/unit/changelog/changelog-fragments.test.ts
+++ b/tests/unit/changelog/changelog-fragments.test.ts
@@ -2,9 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore -- plain-JS module without type declarations
 import {
-  changedManifestKeys,
+  changedShippingKeys,
   collateIntoChangelog,
-  isDevDependencyOnlyChange,
   parseFragmentFilename,
   readFragments,
   requiresFragment
@@ -202,39 +201,44 @@ function resolverOver(
 const RUBY_MANIFEST = 'packages/adapter-ruby/package.json';
 const GO_MANIFEST = 'packages/adapter-go/package.json';
 
-describe('changedManifestKeys / isDevDependencyOnlyChange (issue #629)', () => {
-  it('reports nothing changed when only devDependencies moved', () => {
-    const before = manifest();
+describe('changedShippingKeys (issues #629, #630)', () => {
+  it('reports nothing when only devDependencies moved', () => {
     const after = manifest({ devDependencies: { '@types/node': '^26.4.0', eslint: '^10.9.1' } });
-
-    expect(changedManifestKeys(before, after)).toEqual([]);
-    expect(isDevDependencyOnlyChange(before, after)).toBe(true);
+    expect(changedShippingKeys(manifest(), after)).toEqual([]);
   });
 
   it('names a runtime dependency bump, which a consumer of the package can observe', () => {
     const after = manifest({ dependencies: { '@debugmcp/shared': 'workspace:*', which: '^6.0.0' } });
-
-    expect(changedManifestKeys(manifest(), after)).toEqual(['dependencies']);
-    expect(isDevDependencyOnlyChange(manifest(), after)).toBe(false);
+    expect(changedShippingKeys(manifest(), after)).toEqual(['dependencies']);
   });
 
-  it('catches a version bump, so a release bump cannot slip through as toolchain churn', () => {
-    expect(changedManifestKeys(manifest(), manifest({ version: '0.25.0' }))).toEqual(['version']);
+  it('names an optionalDependencies change, which is how an adapter gets shipped (#630)', () => {
+    const after = manifest({ optionalDependencies: { '@debugmcp/adapter-cpp': 'workspace:*' } });
+    expect(changedShippingKeys(manifest(), after)).toEqual(['optionalDependencies']);
+  });
+
+  it('ignores a version bump: the release IS the changelog entry, so a fragment would be circular', () => {
+    expect(changedShippingKeys(manifest(), manifest({ version: '0.25.0' }))).toEqual([]);
+  });
+
+  it('ignores npm scripts, which no consumer of the package observes', () => {
+    const after = manifest({ scripts: { build: 'tsc -b', 'test:new': 'vitest run' } });
+    expect(changedShippingKeys(manifest(), after)).toEqual([]);
   });
 
   it('catches a key that only one side has, such as a newly published bin', () => {
-    expect(changedManifestKeys(manifest(), manifest({ bin: { rdbg: './cli.js' } }))).toEqual(['bin']);
+    expect(changedShippingKeys(manifest(), manifest({ bin: { rdbg: './cli.js' } }))).toEqual(['bin']);
   });
 
   it('ignores key reordering, comparing values rather than serialized text', () => {
     const before = JSON.stringify({ name: 'x', version: '1.0.0', dependencies: { a: '^1' } });
     const after = JSON.stringify({ dependencies: { a: '^1' }, version: '1.0.0', name: 'x' });
 
-    expect(isDevDependencyOnlyChange(before, after)).toBe(true);
+    expect(changedShippingKeys(before, after)).toEqual([]);
   });
 
   it('throws on unparseable JSON rather than reporting a silent no-change', () => {
-    expect(() => changedManifestKeys('{not json', manifest())).toThrow();
+    expect(() => changedShippingKeys('{not json', manifest())).toThrow();
   });
 });
 
@@ -265,13 +269,24 @@ describe('requiresFragment manifest carve-out (issue #629)', () => {
   });
 
   it('names the keys that kept a manifest on the list, so the failure is actionable', () => {
+    const bumped = manifest({ dependencies: { '@debugmcp/shared': 'workspace:*', which: '^6.0.0' } });
+    const result = requiresFragment(
+      [GO_MANIFEST],
+      [],
+      resolverOver({ [GO_MANIFEST]: [manifest(), bumped] })
+    );
+
+    expect(result.reason).toContain('changed: dependencies');
+  });
+
+  it('lets a release version bump through, since the release section is its own entry', () => {
     const result = requiresFragment(
       [GO_MANIFEST],
       [],
       resolverOver({ [GO_MANIFEST]: [manifest(), manifest({ version: '0.25.0' })] })
     );
 
-    expect(result.reason).toContain('changed: version');
+    expect(result.required).toBe(false);
   });
 
   it('keeps a manifest the resolver cannot place, since added or deleted is user-visible', () => {
@@ -318,6 +333,61 @@ describe('requiresFragment manifest carve-out (issue #629)', () => {
     );
 
     expect(result.required).toBe(true);
+  });
+});
+
+describe('the root manifest is gated too (issue #630)', () => {
+  const ROOT = 'package.json';
+
+  it('demands a fragment when a root runtime dependency moves', () => {
+    const after = manifest({ dependencies: { express: '^5.2.0' } });
+    const result = requiresFragment([ROOT], [], resolverOver({ [ROOT]: [manifest(), after] }));
+
+    expect(result.required).toBe(true);
+    expect(result.offenders).toEqual([ROOT]);
+    expect(result.reason).toContain('changed: dependencies');
+  });
+
+  it('demands one when an adapter is registered in optionalDependencies, the case that motivated #630', () => {
+    const after = manifest({ optionalDependencies: { '@debugmcp/adapter-cpp': 'workspace:*' } });
+    const result = requiresFragment([ROOT], [], resolverOver({ [ROOT]: [manifest(), after] }));
+
+    expect(result.required).toBe(true);
+    expect(result.reason).toContain('changed: optionalDependencies');
+  });
+
+  it('stays silent for npm-script churn, which dominates root-manifest history', () => {
+    const after = manifest({ scripts: { 'test:new': 'vitest run' } });
+    const result = requiresFragment([ROOT], [], resolverOver({ [ROOT]: [manifest(), after] }));
+
+    expect(result.required).toBe(false);
+  });
+
+  it('stays silent for a packageManager pin', () => {
+    const after = manifest({ packageManager: 'pnpm@10.34.0' });
+    const result = requiresFragment([ROOT], [], resolverOver({ [ROOT]: [manifest(), after] }));
+
+    expect(result.required).toBe(false);
+  });
+
+  it('never gates on pnpm-lock.yaml, or #629 would break again on every dependency PR', () => {
+    const devOnly = manifest({ devDependencies: { eslint: '^10.9.1' } });
+    const result = requiresFragment(
+      ['pnpm-lock.yaml', ROOT, RUBY_MANIFEST],
+      [],
+      resolverOver({ [ROOT]: [manifest(), devOnly], [RUBY_MANIFEST]: [manifest(), devOnly] })
+    );
+
+    expect(result.required).toBe(false);
+    expect(result.offenders).toEqual([]);
+  });
+
+  it('does not gate on a sibling root file such as pnpm-workspace.yaml', () => {
+    expect(requiresFragment(['pnpm-workspace.yaml', 'README.md'], []).required).toBe(false);
+  });
+
+  it('keeps the root manifest an offender under the path-only fallback', () => {
+    expect(requiresFragment([ROOT], []).required).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #630. Follow-on to #631 (#629), which fixed the opposite failure mode in the same function.

## The problem

`requiresFragment()` picked its candidates by path prefix:

```js
const USER_VISIBLE_ROOTS = ['src/', 'packages/', 'tools/'];
```

The root `package.json` starts with none of them, so it was never examined. It is
`private: true`, but its `dependencies` (12) and `optionalDependencies` (9 adapters) are exactly
what `dist/index.js` and the Docker image run.

Concretely: **`78912fc8` — "feat: add C/C++ debug adapter using CodeLLDB (#325)"** registered a
whole new language in root `optionalDependencies`, and the gate had nothing to say about it.

## Why the #629 rule could not simply be reused

Applying "anything but `devDependencies`" to the root would gate **115 of 130** root-manifest
commits, because the root carries **104 npm scripts** and `scripts` moved in 56 of them. That is
the #629 failure mode relocated, not fixed.

Measuring also showed #629's rule was itself over-strict on packages, so both sides now converge
on one question — **does this change what ships?**

```js
export const SHIPPING_SURFACE_KEYS = [
  'dependencies', 'optionalDependencies', 'peerDependencies',
  'bin', 'main', 'exports', 'files', 'engines', 'type'
];
```

| manifest | commits | #629 deny-rule | this PR |
|---|---|---|---|
| root `package.json` | 130 | 115 | **40** |
| `packages/shared/package.json` | 44 | 29 | **6** |
| `packages/adapter-ruby/package.json` | 15 | 6 | **4** |

`changedManifestKeys` / `isDevDependencyOnlyChange` become `changedShippingKeys`; the JSON-parse
and `isDeepStrictEqual` value comparison from #629 are unchanged, only the key set is. **Every
#629 fail-safe is untouched** — no resolver, an added or deleted manifest, unparseable JSON, or
unresolvable revisions all still keep a file an offender.

## Two deliberate calls, both commented in the source

**`version` and `scripts` stop gating anywhere.** A release PR bumps `version` across every
manifest, and the changelog entry for a release is the collated section itself — demanding a
*fragment* for the bump that cuts the release is circular. `scripts` is developer plumbing.

**`pnpm-lock.yaml` stays ungated.** It looks like an oversight, so there is a comment saying it
is not: every dependency PR touches the lockfile, devDependency-only ones included, so gating on
it would undo #629 the day after it landed. The accepted cost is that a purely transitive change
(a `pnpm.overrides` pin) goes ungated.

I also corrected the still-pending `changelog.d/629.fixed.md`, which promised that a `version`
change "still requires an entry" — this PR makes that false, and it has not been collated yet.

## Verification

The measurement was re-derived after the change rather than trusted from the plan; the table
above reproduces exactly. The CLI was then driven over four named controls:

| commit | expected | result |
|---|---|---|
| `78912fc8` add C/C++ adapter | gate | ✅ `package.json (changed: optionalDependencies)` |
| `32cf0dad` remove `eventsource` | gate | ✅ `package.json (changed: dependencies)` |
| `5cf97e03` #625 devDeps-only batch | pass | ✅ the #629 fix stays fixed |
| `d8e1dcc9` pin `packageManager` | pass | ✅ |

49 tests green (was 39). Mutation-checked in three directions, since a classification rule that
silently passes everything is the failure mode that matters: making `changedShippingKeys` always
return empty kills 7 tests, dropping the root manifest from the candidate set kills 3, and adding
`version` back to the allowlist kills 2.

`npm run lint` clean; `npm run typecheck:all` clean with the ratchet unchanged at `727 across 90`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWtBNHjsdqawm1STgti7Qj
