### PR TITLE
ci(canary): widen the CodeLLDB VSIX download retry window (#669)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -134,7 +134,10 @@ jobs:
           MANIFEST=packages/codelldb-common/vendor-manifest.json
           VERSION="$(node -p "require('./$MANIFEST').codelldb.version")"
           EXPECTED_SHA="$(node -p "require('./$MANIFEST').codelldb.assets['codelldb-$CANARY_PLAT.vsix']")"
-          curl -fsSL --retry 3 -o "$RUNNER_TEMP/codelldb.vsix" \
+          # A short GitHub release-CDN blip (HTTP 500 x4 in ~7s filed #669)
+          # must not fail the leg: curl already treats 5xx as transient, the
+          # 1s/2s/4s default backoff was the problem. ~60s window.
+          curl -fsSL --retry 6 --retry-delay 10 -o "$RUNNER_TEMP/codelldb.vsix" \
             "https://github.com/vadimcn/codelldb/releases/download/v${VERSION}/codelldb-${CANARY_PLAT}.vsix"
           ACTUAL_SHA="$(node -e "const{createHash}=require('crypto');const{readFileSync}=require('fs');console.log(createHash('sha256').update(readFileSync(process.argv[1])).digest('hex'))" "$RUNNER_TEMP/codelldb.vsix")"
           if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then


### PR DESCRIPTION
Follow-up to #669 (closed as transient). The `npm omit-optional (windows-latest)` leg died in *Provision CODELLDB_PATH fallback* because GitHub's release-asset download answered HTTP 500 on all four attempts of `curl --retry 3` — a ~7-second window with the default 1s/2s/4s backoff. The rerun passed and every other leg was green.

curl already treats 500/502/503/504 as transient; the window was the problem. This makes it six attempts ten seconds apart (~60 s). No product code changes; CI-internal, so no changelog fragment.

Verify: `gh workflow run canary.yml` after merge (or wait for Tuesday's schedule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTzA7RiaM7fS18WU8a8Pgj