### PR TITLE
docs(http): a remote client needs --bind as well as --allowed-host (#680)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,9 +139,10 @@ mcp-debugger http -p 3001
 claude mcp add-json mcp-debugger '{"type":"http","url":"http://127.0.0.1:3001/mcp"}'
 ```
 
-The endpoint accepts only loopback `Host` headers by default, so a client on another machine goes
-through a port-forward or SSH tunnel. To accept a service name directly, start the server with
-`--allowed-host <name>` or `MCP_HTTP_ALLOWED_HOSTS=<name>` — see
+The server listens on `127.0.0.1` and accepts only loopback `Host` headers by default, so a client on
+another machine goes through a port-forward or SSH tunnel. To serve it directly, start the server with
+`--bind 0.0.0.0` (or `MCP_HTTP_BIND=0.0.0.0`) and `--allowed-host <name>` (or
+`MCP_HTTP_ALLOWED_HOSTS=<name>`) for the name that client dials — see
 [Over the network (Streamable HTTP)](../README.md#over-the-network-streamable-http) in the README.
 
 Restart the client after changing its configuration, then confirm the connection — `/mcp` inside

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -78,7 +78,7 @@ Restart the client after changing its configuration.
 
 ```bash
 mcp-debugger stdio                  # default subcommand; for clients that spawn the server
-mcp-debugger http -p 3001           # Streamable HTTP, recommended for remote; endpoint /mcp
+mcp-debugger http -p 3001           # Streamable HTTP on 127.0.0.1, endpoint /mcp; other machines need --bind + --allowed-host
 mcp-debugger sse -p 3001            # DEPRECATED — use http
 ```
 


### PR DESCRIPTION
## Summary

Docs follow-up to #688 (issue #680). Since the merge the `http` transport binds `127.0.0.1` by default, so a client on another machine needs `--bind` as well as `--allowed-host`. Two pages still gave `--allowed-host` alone as the remedy:

| File | Before | After |
|---|---|---|
| `docs/getting-started.md` (Step 3, HTTP) | "The endpoint accepts only loopback `Host` headers by default … To accept a service name directly, start the server with `--allowed-host <name>` …" | "The server listens on `127.0.0.1` and accepts only loopback `Host` headers by default … To serve it directly, start the server with `--bind 0.0.0.0` (or `MCP_HTTP_BIND=0.0.0.0`) and `--allowed-host <name>` … for the name that client dials" |
| `docs/quickstart.md` (Transports) | `# Streamable HTTP, recommended for remote; endpoint /mcp` | `# Streamable HTTP on 127.0.0.1, endpoint /mcp; other machines need --bind + --allowed-host` |

Both link on to the README's "Over the network" section, which #688 already updated. `docs/multiple-mcp-servers.md` makes no interface claim and is unchanged. No code, no changelog fragment (docs only; the behaviour change is recorded in `changelog.d/680-loopback-default.changed.md`).

`npm run check:docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTzA7RiaM7fS18WU8a8Pgj
